### PR TITLE
Add features to participant preview

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,9 @@
       ]
     }
   ],
+  "storage": {
+    "rules": "firestore/storage.rules"
+  },
   "emulators": {
     "auth": {
       "port": 9099
@@ -28,6 +31,9 @@
     },
     "firestore": {
       "port": 8080
+    },
+    "storage": {
+      "port": 9199
     },
     "ui": {
       "enabled": true

--- a/firestore/storage.rules
+++ b/firestore/storage.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/frontend/src/components/participant_previewer/participant_header.scss
+++ b/frontend/src/components/participant_previewer/participant_header.scss
@@ -15,6 +15,8 @@
   gap: common.$spacing-small;
   justify-content: space-between;
   padding: 0 common.$main-content-padding;
+  position: sticky;
+  top: 0;
 }
 
 .left,

--- a/frontend/src/components/participant_previewer/participant_header.ts
+++ b/frontend/src/components/participant_previewer/participant_header.ts
@@ -1,6 +1,6 @@
 import '../../pair-components/button';
 import '../../pair-components/icon_button';
-import '../../pair-components/tooltip';
+import '../../pair-components/info_popup';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -40,9 +40,7 @@ export class Header extends MobxLitElement {
       return nothing;
     }
     return html`
-      <pr-tooltip text=${this.stage.descriptions.infoText} position="BOTTOM_END">
-        <pr-icon color="neutral" icon="info"></pr-icon>
-      </pr-tooltip>
+      <info-popup .popupText=${this.stage.descriptions.infoText}></info-popup>
     `;
   }
 
@@ -51,9 +49,7 @@ export class Header extends MobxLitElement {
       return nothing;
     }
     return html`
-      <pr-tooltip text=${this.stage.descriptions.helpText} position="BOTTOM_END">
-        <pr-icon color="neutral" icon="help"></pr-icon>
-      </pr-tooltip>
+      <info-popup .showHelpIcon=${true} .popupText=${this.stage.descriptions.helpText}></info-popup>
     `;
   }
 }

--- a/frontend/src/components/participant_previewer/participant_previewer.ts
+++ b/frontend/src/components/participant_previewer/participant_previewer.ts
@@ -198,7 +198,7 @@ export class ParticipantPreviewer extends MobxLitElement {
       case StageKind.INFO:
         return html`<info-view .stage=${stage}></info-view>`;
       case StageKind.PROFILE:
-        return html`<profile-editor></profile-editor>`;
+        return html`<profile-editor .stage=${stage}></profile-editor>`;
       case StageKind.CHAT:
         return html`
           <div class="content chat">

--- a/frontend/src/components/participant_previewer/participant_previewer.ts
+++ b/frontend/src/components/participant_previewer/participant_previewer.ts
@@ -190,30 +190,14 @@ export class ParticipantPreviewer extends MobxLitElement {
     const answer = this.participantService.getStageAnswer(stage.id);
     switch (stage.kind) {
       case StageKind.TOS:
-        return html`
-          <div class="content">
-            <tos-view .stage=${stage}></tos-view>
-          </div>
-        `;
+        return html`<tos-view .stage=${stage}></tos-view>`;
       case StageKind.INFO:
-        return html`
-          <div class="content">
-            <info-view .stage=${stage}></info-view>
-          </div>
-        `;
+        return html`<info-view .stage=${stage}></info-view>`;
       case StageKind.PROFILE:
-        return html`
-          <div class="content">
-            <profile-editor></profile-editor>
-          </div>
-        `;
+        return html`<profile-editor></profile-editor>`;
       case StageKind.CHAT:
         if (isWaiting) {
-          return html`
-            <div class="content">
-              <progress-stage-waiting></progress-stage-waiting>
-            </div>
-          `;
+          return html`<progress-stage-waiting></progress-stage-waiting>`;
         }
         return html`
           <div class="content chat">
@@ -223,48 +207,24 @@ export class ParticipantPreviewer extends MobxLitElement {
         `;
       case StageKind.ELECTION:
         if (isWaiting) {
-          return html`
-            <div class="content">
-              <progress-stage-waiting></progress-stage-waiting>
-            </div>
-          `;
+          return html`<progress-stage-waiting></progress-stage-waiting>`;
         }
         return html`
-          <div class="content">
-            <election-view .stage=${stage} .answer=${answer}></election-view>
-          </div>
+          <election-view .stage=${stage} .answer=${answer}></election-view>
         `;
       case StageKind.PAYOUT:
-        return html`
-          <div class="content">
-            <payout-view .stage=${stage}></payout-view>
-          </div>
-        `;
+        return html`<payout-view .stage=${stage}></payout-view>`;
       case StageKind.REVEAL:
         if (isWaiting) {
-          return html`
-            <div class="content">
-              <progress-stage-waiting></progress-stage-waiting>
-            </div>
-          `;
+          return html`<progress-stage-waiting></progress-stage-waiting>`;
         }
-        return html`
-          <div class="content">
-            <reveal-view .stage=${stage}></reveal-view>
-          </div>
-        `;
+        return html`<reveal-view .stage=${stage}></reveal-view>`;
       case StageKind.SURVEY:
         return html`
-          <div class="content">
-            <survey-view .stage=${stage} .answer=${answer}></survey-view>
-          </div>
+          <survey-view .stage=${stage} .answer=${answer}></survey-view>
         `;
       case StageKind.TRANSFER:
-        return html`
-          <div class="content">
-            <transfer-view .stage=${stage}></transfer-view>
-          </div>
-        `;
+        return html`<transfer-view .stage=${stage}></transfer-view>`;
       default:
         return html`<div class="content">Stage not found</div>`;
     }

--- a/frontend/src/components/participant_previewer/participant_previewer.ts
+++ b/frontend/src/components/participant_previewer/participant_previewer.ts
@@ -187,6 +187,10 @@ export class ParticipantPreviewer extends MobxLitElement {
     }
 
     const isWaiting = this.cohortService.isStageWaitingForParticipants(stage.id);
+    if (isWaiting) {
+      return html`<progress-stage-waiting></progress-stage-waiting>`;
+    }
+
     const answer = this.participantService.getStageAnswer(stage.id);
     switch (stage.kind) {
       case StageKind.TOS:
@@ -196,9 +200,6 @@ export class ParticipantPreviewer extends MobxLitElement {
       case StageKind.PROFILE:
         return html`<profile-editor></profile-editor>`;
       case StageKind.CHAT:
-        if (isWaiting) {
-          return html`<progress-stage-waiting></progress-stage-waiting>`;
-        }
         return html`
           <div class="content chat">
             <chat-panel .stage=${stage}></chat-panel>
@@ -206,18 +207,12 @@ export class ParticipantPreviewer extends MobxLitElement {
           </div>
         `;
       case StageKind.ELECTION:
-        if (isWaiting) {
-          return html`<progress-stage-waiting></progress-stage-waiting>`;
-        }
         return html`
           <election-view .stage=${stage} .answer=${answer}></election-view>
         `;
       case StageKind.PAYOUT:
         return html`<payout-view .stage=${stage}></payout-view>`;
       case StageKind.REVEAL:
-        if (isWaiting) {
-          return html`<progress-stage-waiting></progress-stage-waiting>`;
-        }
         return html`<reveal-view .stage=${stage}></reveal-view>`;
       case StageKind.SURVEY:
         return html`

--- a/frontend/src/components/participant_previewer/participant_previewer.ts
+++ b/frontend/src/components/participant_previewer/participant_previewer.ts
@@ -187,7 +187,7 @@ export class ParticipantPreviewer extends MobxLitElement {
     }
 
     const isWaiting = this.cohortService.isStageWaitingForParticipants(stage.id);
-    if (isWaiting) {
+    if (isWaiting && !this.authService.isExperimenter) {
       return html`<progress-stage-waiting></progress-stage-waiting>`;
     }
 

--- a/frontend/src/components/participant_profile/profile_avatar.ts
+++ b/frontend/src/components/participant_profile/profile_avatar.ts
@@ -17,6 +17,7 @@ export class ProfileAvatar extends MobxLitElement {
   @property() square = false;
   @property() small = false;
   @property() disabled = false;
+  @property() tooltip = '';
 
   override render() {
     const classes = classMap({
@@ -29,16 +30,18 @@ export class ProfileAvatar extends MobxLitElement {
       person: ['🧑🏻', '🧑🏼', '🧑🏽', '🧑🏾', '🧑🏿'].indexOf(this.emoji) > -1,
     });
 
-    const emojiHtml = html` <div class=${classes} text="test">
-      ${this.emoji}
-    </div>`;
-    if (this.disabled) {
-      return html`<pr-tooltip text="This participant is no longer active.">
-        ${emojiHtml}
-      </pr-tooltip>`;
-    } else {
-      return emojiHtml;
+    const emojiHtml = html`
+      <div class=${classes}>
+        ${this.emoji}
+      </div>
+    `;
+
+    if (this.tooltip.length > 0) {
+      return html`
+        <pr-tooltip text=${this.tooltip}>${emojiHtml}</pr-tooltip>
+      `;
     }
+    return emojiHtml;
   }
 }
 

--- a/frontend/src/components/participant_profile/profile_editor.scss
+++ b/frontend/src/components/participant_profile/profile_editor.scss
@@ -5,12 +5,14 @@
   @include common.flex-column;
   gap: common.$spacing-xxl;
   height: 100%;
+  overflow: auto;
 }
 
 .profile-wrapper {
   @include common.flex-column;
   flex-grow: 1;
   gap: common.$spacing-xxl;
+  padding: common.$main-content-padding;
 }
 
 .title {

--- a/frontend/src/components/participant_profile/profile_editor.ts
+++ b/frontend/src/components/participant_profile/profile_editor.ts
@@ -1,5 +1,6 @@
 import '../../pair-components/textarea';
 
+import '../progress/progress_stage_completed';
 import '../stages/stage_description';
 import '../stages/stage_footer';
 import './profile_avatar';
@@ -48,6 +49,9 @@ export class ProfileEditor extends MobxLitElement {
         ${this.renderName()} ${this.renderPronouns()} ${this.renderAvatars()}
       </div>
       <stage-footer .disabled=${!filled} .onNextClick=${saveProfileTextProperties}>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
       </stage-footer>
     `;
   }

--- a/frontend/src/components/participant_profile/profile_editor.ts
+++ b/frontend/src/components/participant_profile/profile_editor.ts
@@ -1,18 +1,20 @@
 import '../../pair-components/textarea';
 
+import '../stages/stage_description';
 import '../stages/stage_footer';
 import './profile_avatar';
 
 import '@material/web/radio/radio.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
-import {CSSResultGroup, html} from 'lit';
+import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
 import {ParticipantService} from '../../services/participant.service';
 
 import {PROFILE_AVATARS} from '../../shared/constants';
+import {ProfileStageConfig} from '@deliberation-lab/utils';
 
 import {styles} from './profile_editor.scss';
 
@@ -22,11 +24,15 @@ export class ProfileEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
+
+  @property() stage: ProfileStageConfig | null = null;
   @property() name = '';
 
   @property() customPronouns = '';
 
   override render() {
+    if (!this.stage) return nothing;
+
     const filled =
       this.name &&
       this.participantService.profile?.pronouns &&
@@ -37,6 +43,7 @@ export class ProfileEditor extends MobxLitElement {
     }
 
     return html`
+      <stage-description .stage=${this.stage}></stage-description>
       <div class="profile-wrapper">
         ${this.renderName()} ${this.renderPronouns()} ${this.renderAvatars()}
       </div>

--- a/frontend/src/components/progress/progress_chat_discussion_completed.ts
+++ b/frontend/src/components/progress/progress_chat_discussion_completed.ts
@@ -1,0 +1,78 @@
+import '../../pair-components/tooltip';
+import '../participant_profile/profile_avatar';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {CohortService} from '../../services/cohort.service';
+import {RouterService} from '../../services/router.service';
+
+import {
+  ParticipantProfile,
+} from '@deliberation-lab/utils';
+import {
+  getParticipantName,
+  getParticipantPronouns
+} from '../../shared/participant.utils';
+
+import {styles} from './progress_stage_completed.scss';
+
+/** Progress component: Shows how many participants are ready to end
+  * the chat discussion.
+  */
+@customElement('progress-chat-discussion-completed')
+export class Progress extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly cohortService = core.getService(CohortService);
+  private readonly routerService = core.getService(RouterService);
+
+  @property() discussionId: string|null = null;
+
+  override render() {
+    if (!this.discussionId) return nothing;
+
+    const stageId = this.routerService.activeRoute.params['stage'];
+    const { completed, notCompleted } =
+      this.cohortService.getParticipantsByChatDiscussionCompletion(
+        stageId, this.discussionId
+      );
+
+    return html`
+      ${this.renderParticipants(completed)}
+      <div class="status">
+        ${completed.length} of
+        ${completed.length + notCompleted.length}
+        participants are ready to move on
+      </div>
+    `;
+  }
+
+  private renderParticipant(participant: ParticipantProfile) {
+    return html`
+      <profile-avatar
+        class="participant"
+        .small=${true}
+        .emoji=${participant.avatar}
+        .tooltip=${getParticipantName(participant)}
+      >
+      </profile-avatar>
+    `;
+  }
+
+  private renderParticipants(participants: ParticipantProfile[]) {
+    return html`
+      <div class="participants-wrapper">
+        ${participants.map((p) => this.renderParticipant(p))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'progress-chat-discussion-completed': Progress;
+  }
+}

--- a/frontend/src/components/progress/progress_stage_completed.scss
+++ b/frontend/src/components/progress/progress_stage_completed.scss
@@ -1,0 +1,22 @@
+@use "../../sass/common";
+@use "../../sass/typescale";
+
+:host {
+  @include typescale.label-small;
+  @include common.flex-row-align-center;
+  gap: common.$spacing-medium;
+  user-select: none;
+}
+
+.participants-wrapper {
+  @include common.flex-row-align-center;
+  max-width: 200px;
+}
+
+.participant {
+  width: common.$spacing-large;
+
+  &:last-of-type {
+    width: max-content;
+  }
+}

--- a/frontend/src/components/progress/progress_stage_completed.ts
+++ b/frontend/src/components/progress/progress_stage_completed.ts
@@ -1,0 +1,69 @@
+import '../../pair-components/tooltip';
+import '../participant_profile/profile_avatar';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {CohortService} from '../../services/cohort.service';
+import {RouterService} from '../../services/router.service';
+
+import {
+  ParticipantProfile,
+} from '@deliberation-lab/utils';
+import {
+  getParticipantName,
+  getParticipantPronouns
+} from '../../shared/participant.utils';
+
+import {styles} from './progress_stage_completed.scss';
+
+/** Progress component: Shows how many participants have completed the stage */
+@customElement('progress-stage-completed')
+export class Progress extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly cohortService = core.getService(CohortService);
+  private readonly routerService = core.getService(RouterService);
+
+  override render() {
+    const stageId = this.routerService.activeRoute.params['stage'];
+    const { completed, notCompleted } = this.cohortService.getParticipantsByCompletion(stageId);
+
+    return html`
+      ${this.renderParticipants(completed)}
+      <div class="status">
+        ${completed.length} of
+        ${completed.length + notCompleted.length}
+        participants completed this stage
+      </div>
+    `;
+  }
+
+  private renderParticipant(participant: ParticipantProfile) {
+    return html`
+      <profile-avatar
+        class="participant"
+        .small=${true}
+        .emoji=${participant.avatar}
+        .tooltip=${getParticipantName(participant)}
+      >
+      </profile-avatar>
+    `;
+  }
+
+  private renderParticipants(participants: ParticipantProfile[]) {
+    return html`
+      <div class="participants-wrapper">
+        ${participants.map((p) => this.renderParticipant(p))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'progress-stage-completed': Progress;
+  }
+}

--- a/frontend/src/components/progress/progress_stage_waiting.scss
+++ b/frontend/src/components/progress/progress_stage_waiting.scss
@@ -3,8 +3,6 @@
 
 :host {
   @include common.flex-column;
-  border: 1px solid var(--md-sys-color-outline);
-  border-radius: common.$spacing-medium;
   gap: common.$spacing-xl;
   padding: common.$spacing-xxl;
 }

--- a/frontend/src/components/progress/progress_stage_waiting.ts
+++ b/frontend/src/components/progress/progress_stage_waiting.ts
@@ -63,16 +63,17 @@ export class Progress extends MobxLitElement {
 
     return html`
       <pr-tooltip text=${tooltipText}>
-      <div class="participant">
-        <profile-avatar
-          .emoji=${participant.avatar}
-          .disabled=${isDisabled}
-        ></profile-avatar>
-        <div>
-          ${getParticipantName(participant)}
-          ${getParticipantPronouns(participant)}
+        <div class="participant">
+          <profile-avatar
+            .emoji=${participant.avatar}
+            .disabled=${isDisabled}
+          ></profile-avatar>
+          <div>
+            ${getParticipantName(participant)}
+            ${getParticipantPronouns(participant)}
+          </div>
         </div>
-      </div>
+      </pr-tooltip>
     `;
   }
 

--- a/frontend/src/components/progress/progress_stage_waiting.ts
+++ b/frontend/src/components/progress/progress_stage_waiting.ts
@@ -7,6 +7,7 @@ import {customElement, property} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
 import {CohortService} from '../../services/cohort.service';
+import {ExperimentService} from '../../services/experiment.service';
 import {RouterService} from '../../services/router.service';
 
 import {
@@ -26,6 +27,7 @@ export class Progress extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly cohortService = core.getService(CohortService);
+  private readonly experimentService = core.getService(ExperimentService);
   private readonly routerService = core.getService(RouterService);
 
   @property() showReadyAvatars = true;
@@ -33,6 +35,9 @@ export class Progress extends MobxLitElement {
 
   override render() {
     const stageId = this.routerService.activeRoute.params['stage'];
+    const stage = this.experimentService.getStage(stageId);
+    if (!stage) return nothing;
+
     const locked = this.cohortService.getLockedStageParticipants(stageId);
     const unlocked = this.cohortService.getUnlockedStageParticipants(stageId);
 
@@ -40,7 +45,7 @@ export class Progress extends MobxLitElement {
       <div class="status">
         <h2 class="secondary">
           <div class="chip secondary">Waiting on</div>
-          <div>${locked.length} participants</div>
+          <div>${Math.max(locked.length, stage.progress.minParticipants - unlocked.length)} participants</div>
         </h2>
         ${this.showWaitingAvatars ? this.renderParticipants(locked) : nothing}
       </div>

--- a/frontend/src/components/stages/base_stage_editor.scss
+++ b/frontend/src/components/stages/base_stage_editor.scss
@@ -10,3 +10,18 @@
 pr-textarea {
   width: 100%;
 }
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}

--- a/frontend/src/components/stages/base_stage_editor.ts
+++ b/frontend/src/components/stages/base_stage_editor.ts
@@ -4,12 +4,15 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
+import '@material/web/checkbox/checkbox.js';
+
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
 
 import {
   StageConfig,
   StageKind,
+  StageProgressConfig,
 } from '@deliberation-lab/utils';
 
 import {styles} from './base_stage_editor.scss';
@@ -33,6 +36,9 @@ export class BaseStageEditorComponent extends MobxLitElement {
       ${this.renderPrimaryText()}
       ${this.renderInfoText()}
       ${this.renderHelpText()}
+      ${this.renderMinParticipants()}
+      ${this.renderWaitForAllParticipants()}
+      ${this.renderShowParticipantProgress()}
     `;
   }
 
@@ -120,6 +126,91 @@ export class BaseStageEditorComponent extends MobxLitElement {
         @input=${update}
       >
       </pr-textarea>
+    `;
+  }
+
+  private renderWaitForAllParticipants() {
+    if (!this.stage) return nothing;
+    const waitForAllParticipants = this.stage.progress.waitForAllParticipants;
+
+    const updateCheck = () => {
+      if (!this.stage) return;
+      const progress: StageProgressConfig = { ...this.stage.progress, waitForAllParticipants: !waitForAllParticipants };
+      this.experimentEditor.updateStage({ ...this.stage, progress });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${waitForAllParticipants}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateCheck}
+          >
+          </md-checkbox>
+          <div>
+            Wait for all participants before starting stage
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderShowParticipantProgress() {
+    if (!this.stage) return nothing;
+    const showParticipantProgress = this.stage.progress.showParticipantProgress;
+
+    const updateCheck = () => {
+      if (!this.stage) return;
+      const progress: StageProgressConfig = { ...this.stage.progress, showParticipantProgress: !showParticipantProgress };
+      this.experimentEditor.updateStage({ ...this.stage, progress });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${showParticipantProgress}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateCheck}
+          >
+          </md-checkbox>
+          <div>
+            Show participant progress (number of participants who have completed stage)
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderMinParticipants() {
+    const minParticipants = this.stage?.progress.minParticipants ?? 0;
+
+    const updateNum = (e: InputEvent) => {
+      if (!this.stage) return;
+      const minParticipants = Number((e.target as HTMLTextAreaElement).value);
+      const progress: StageProgressConfig = { ...this.stage.progress, minParticipants };
+      this.experimentEditor.updateStage({ ...this.stage, progress });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="number-input">
+          <label for="minParticipants">
+            Minimum number of participants
+          </label>
+          <input
+            type="number"
+            id="minParticipants"
+            name="minParticipants"
+            min="0"
+            .value=${minParticipants ?? 0}
+            @input=${updateNum}
+          />
+        </div>
+      </div>
     `;
   }
 }

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -12,6 +12,7 @@ import {customElement, property} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
+import {FirebaseService} from '../../services/firebase.service';
 import {ParticipantService} from '../../services/participant.service';
 
 import {
@@ -26,7 +27,7 @@ import {
 } from '@deliberation-lab/utils';
 import {
   LAS_ITEMS,
-  getLASItemImageURL
+  getLASItemImageId
 } from '../../shared/games/lost_at_sea';
 import {styles} from './chat_interface.scss';
 
@@ -36,6 +37,7 @@ export class ChatInterface extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly cohortService = core.getService(CohortService);
+  private readonly firebaseService = core.getService(FirebaseService);
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
@@ -123,10 +125,13 @@ export class ChatInterface extends MobxLitElement {
     };
 
     const renderDiscussionItem = (item: DiscussionItem) => {
+      const image = document.createElement('img');
+      this.firebaseService.setImage(image, getLASItemImageId(item.id));
+
       return html`
         <div class="discussion-item">
           ${LAS_ITEMS[item.id] ?
-            html`<div class="img-wrapper"><img src=${getLASItemImageURL(item.id)} /></div>`
+            html`<div class="img-wrapper">${image}</div>`
             : nothing}
           ${item.name}
         </div>

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -3,6 +3,8 @@ import '../../pair-components/icon_button';
 import '../../pair-components/textarea';
 import '../../pair-components/tooltip';
 
+import '../progress/progress_chat_discussion_completed';
+import '../progress/progress_stage_completed';
 import './chat_message';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -237,6 +239,16 @@ export class ChatInterface extends MobxLitElement {
       this.stage.id
     );
 
+    const renderProgress = () => {
+      if (currentDiscussionId) {
+        return html`
+          <progress-chat-discussion-completed .discussionId=${currentDiscussionId}>
+          </progress-chat-discussion-completed>
+        `;
+      }
+      return html`<progress-stage-completed></progress-stage-completed>`;
+    };
+
     return html`
       <div class="chat-content">
         ${this.cohortService.isChatLoading ?
@@ -246,6 +258,7 @@ export class ChatInterface extends MobxLitElement {
         <div class="input-row">${this.renderInput()}</div>
       </div>
       <stage-footer .showNextButton=${currentDiscussionId === null}>
+        ${renderProgress()}
         ${this.renderEndDiscussionButton(currentDiscussionId)}
       </stage-footer>
     `;

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -25,10 +25,6 @@ import {
   StageConfig,
   StageKind,
 } from '@deliberation-lab/utils';
-import {
-  LAS_ITEMS,
-  getLASItemImageId
-} from '../../shared/games/lost_at_sea';
 import {styles} from './chat_interface.scss';
 
 /** Chat interface component */
@@ -125,14 +121,18 @@ export class ChatInterface extends MobxLitElement {
     };
 
     const renderDiscussionItem = (item: DiscussionItem) => {
-      const image = document.createElement('img');
-      this.firebaseService.setImage(image, getLASItemImageId(item.id));
+      const renderImage = () => {
+        if (item.imageId.length === 0) return nothing;
+
+        const image = document.createElement('img');
+        this.firebaseService.setImage(image, item.imageId);
+
+        return html`<div class="img-wrapper">${image}</div>`;
+      };
 
       return html`
         <div class="discussion-item">
-          ${LAS_ITEMS[item.id] ?
-            html`<div class="img-wrapper">${image}</div>`
-            : nothing}
+          ${renderImage()}
           ${item.name}
         </div>
       `;

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -14,6 +14,7 @@ import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
 import {FirebaseService} from '../../services/firebase.service';
 import {ParticipantService} from '../../services/participant.service';
+import {RouterService} from '../../services/router.service';
 
 import {
   ChatDiscussion,
@@ -36,6 +37,7 @@ export class ChatInterface extends MobxLitElement {
   private readonly firebaseService = core.getService(FirebaseService);
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
+  private readonly routerService = core.getService(RouterService);
 
   @property() stage: ChatStageConfig|undefined = undefined;
   @property() value = '';
@@ -60,7 +62,7 @@ export class ChatInterface extends MobxLitElement {
   }
 
   private renderChatHistory(currentDiscussionId: string|null) {
-    const stageId = this.participantService.profile?.currentStageId ?? '';
+    const stageId = this.routerService.activeRoute.params['stage'];
     const stage = this.experimentService.getStage(stageId);
     if (!stage || stage.kind !== StageKind.CHAT) return nothing;
 

--- a/frontend/src/components/stages/election_editor.scss
+++ b/frontend/src/components/stages/election_editor.scss
@@ -32,6 +32,10 @@
   padding: common.$spacing-medium;
   background-color: var(--md-sys-color-surface);
   border-radius: common.$spacing-medium;
+
+  pr-textarea {
+    flex-grow: 1;
+  }
 }
 
 pr-icon-button {

--- a/frontend/src/components/stages/election_editor.ts
+++ b/frontend/src/components/stages/election_editor.ts
@@ -12,7 +12,7 @@ import {ExperimentEditor} from '../../services/experiment.editor';
 import {
   ElectionStageConfig,
   ElectionItem,
-  generateId,
+  createElectionItem,
 } from '@deliberation-lab/utils';
 
 import {styles} from './election_editor.scss';
@@ -72,7 +72,7 @@ export class ElectionEditorComponent extends MobxLitElement {
 
     const addItem = () => {
       if (!this.stage) return;
-      const newItems: ElectionItem[] = [...electionItems, { id: generateId(), text: '' }];
+      const newItems: ElectionItem[] = [...electionItems, createElectionItem()];
       this.experimentEditor.updateStage({ ...this.stage, electionItems: newItems });
     };
 

--- a/frontend/src/components/stages/election_view.scss
+++ b/frontend/src/components/stages/election_view.scss
@@ -91,3 +91,17 @@
   @include common.flex-row-align-center;
   gap: common.$spacing-small;
 }
+
+.img-wrapper {
+  @include common.flex-row-align-center;
+  aspect-ratio: 1 / 1;
+  background: var(--md-sys-color-surface);
+  border-radius: 100%;
+  overflow: hidden;
+  width: 30px;
+
+  img {
+    height: auto;
+    width: 100%;
+  }
+}

--- a/frontend/src/components/stages/election_view.scss
+++ b/frontend/src/components/stages/election_view.scss
@@ -5,6 +5,7 @@
   @include common.flex-column;
   gap: common.$spacing-xl;
   height: 100%;
+  overflow: auto;
 }
 
 .election-wrapper {
@@ -12,6 +13,7 @@
   flex-grow: 1;
   grid-template-columns: repeat(2, 1fr);
   gap: common.$spacing-xxl;
+  padding: common.$main-content-padding;
   width: 100%;
 }
 

--- a/frontend/src/components/stages/election_view.ts
+++ b/frontend/src/components/stages/election_view.ts
@@ -11,6 +11,7 @@ import {customElement, property} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
+import {FirebaseService} from '../../services/firebase.service';
 import {ParticipantService} from '../../services/participant.service';
 import {RouterService} from '../../services/router.service';
 
@@ -32,6 +33,7 @@ export class ElectionView extends MobxLitElement {
 
   private readonly cohortService = core.getService(CohortService);
   private readonly experimentService = core.getService(ExperimentService);
+  private readonly firebaseService = core.getService(FirebaseService);
   private readonly participantService = core.getService(ParticipantService);
   private readonly routerService = core.getService(RouterService);
 
@@ -122,9 +124,18 @@ export class ElectionView extends MobxLitElement {
   }
 
   private renderElectionItem(item: ElectionItem) {
-    // TODO: Allow item photos?
+    const renderImage = () => {
+      if (item.imageId.length === 0) return nothing;
+
+      const image = document.createElement('img');
+      this.firebaseService.setImage(image, item.imageId);
+
+      return html`<div class="img-wrapper">${image}</div>`;
+    };
+
     return html`
       <div class="item">
+        ${renderImage()}
         <div class="right">
           <div class="title">${item.text}</div>
         </div>
@@ -133,7 +144,6 @@ export class ElectionView extends MobxLitElement {
   }
 
   private renderDraggableParticipant(item: ParticipantProfile | ElectionItem) {
-
     const onDragStart = (event: DragEvent) => {
       let target = event.target as HTMLElement;
       target.style.opacity = '.25';
@@ -253,7 +263,6 @@ export class ElectionView extends MobxLitElement {
   }
 
   private renderRankedItem(item: ParticipantProfile | ElectionItem, index: number) {
-
     const rankings = this.answer?.rankingList ?? [];
     const onCancel = () => {
       if (index === -1 || !this.stage) {
@@ -376,6 +385,6 @@ export class ElectionView extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'election-view': ElectionView;
+      'election-view': ElectionView;
   }
 }

--- a/frontend/src/components/stages/election_view.ts
+++ b/frontend/src/components/stages/election_view.ts
@@ -45,8 +45,8 @@ export class ElectionView extends MobxLitElement {
     if (this.stage?.isParticipantElection) {
       // TODO: Enable voting for self.
       return this.cohortService
-  .getAllParticipants()
-  .filter(profile => profile.publicId !== this.participantService.profile?.publicId) ?? [];
+        .getAllParticipants()
+        .filter(profile => profile.publicId !== this.participantService.profile?.publicId) ?? [];
     } else {
       return this.stage?.electionItems ?? [];
     }

--- a/frontend/src/components/stages/election_view.ts
+++ b/frontend/src/components/stages/election_view.ts
@@ -3,6 +3,7 @@ import '../../pair-components/icon_button';
 import './stage_description';
 import './stage_footer';
 import '../participant_profile/profile_avatar';
+import '../progress/progress_stage_completed';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -77,6 +78,9 @@ export class ElectionView extends MobxLitElement {
         ${this.renderStartZone()} ${this.renderEndZone()}
       </div>
       <stage-footer .disabled=${disabled}>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
       </stage-footer>
     `;
   }

--- a/frontend/src/components/stages/election_view.ts
+++ b/frontend/src/components/stages/election_view.ts
@@ -23,7 +23,11 @@ import {
   ElectionItem,
 } from '@deliberation-lab/utils';
 import {convertMarkdownToHTML} from '../../shared/utils';
-import {isObsoleteParticipant} from '../../shared/participant.utils';
+import {
+  getParticipantName,
+  getParticipantPronouns,
+  isObsoleteParticipant
+} from '../../shared/participant.utils';
 
 import {styles} from './election_view.scss';
 
@@ -120,8 +124,8 @@ export class ElectionView extends MobxLitElement {
         >
         </profile-avatar>
         <div class="right">
-          <div class="title">${profile.name}</div>
-          <div class="subtitle">(${profile.pronouns})</div>
+          <div class="title">${getParticipantName(profile)}</div>
+          <div class="subtitle">${getParticipantPronouns(profile)}</div>
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/info_view.scss
+++ b/frontend/src/components/stages/info_view.scss
@@ -5,6 +5,7 @@
   @include common.flex-column;
   gap: common.$spacing-large;
   height: 100%;
+  overflow: auto;
   width: 100%;
 }
 
@@ -21,4 +22,5 @@
   flex-grow: 1;
   gap: common.$spacing-xl;
   margin-bottom: common.$spacing-xl;
+  padding: common.$main-content-padding;
 }

--- a/frontend/src/components/stages/info_view.ts
+++ b/frontend/src/components/stages/info_view.ts
@@ -1,3 +1,5 @@
+import '../progress/progress_stage_completed';
+
 import './stage_description';
 import './stage_footer';
 
@@ -29,6 +31,9 @@ export class InfoView extends MobxLitElement {
         ${this.stage?.infoLines.map((line) => this.renderInfoLine(line))}
       </div>
       <stage-footer>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
       </stage-footer>
     `;
   }

--- a/frontend/src/components/stages/payout_view.scss
+++ b/frontend/src/components/stages/payout_view.scss
@@ -5,6 +5,7 @@
   @include common.flex-column;
   gap: common.$spacing-xl;
   height: 100%;
+  overflow: auto;
 }
 
 h2 {
@@ -17,13 +18,6 @@ h3 {
   margin: 0;
 }
 
-.description {
-  @include typescale.title-small;
-  color: var(--md-sys-color-secondary);
-  padding-bottom: common.$spacing-medium;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-}
-
 .total {
   @include common.flex-row-align-center;
   @include typescale.body-large;
@@ -33,6 +27,7 @@ h3 {
 .stages-wrapper {
   @include common.flex-column;
   gap: common.$spacing-xl;
+  padding: common.$main-content-padding;
 }
 
 .scoring-bundle {

--- a/frontend/src/components/stages/payout_view.ts
+++ b/frontend/src/components/stages/payout_view.ts
@@ -64,7 +64,7 @@ export class PayoutView extends MobxLitElement {
     if (this.stage.game !== StageGame.LAS) {
       return html`
         <stage-description .stage=${this.stage}></stage-description>
-        <div>No payout view available at this time.</div>
+        <div class="stages-wrapper">No payout view available at this time.</div>
         <stage-footer></stage-footer>
       `;
     }

--- a/frontend/src/components/stages/payout_view.ts
+++ b/frontend/src/components/stages/payout_view.ts
@@ -1,3 +1,4 @@
+import '../progress/progress_stage_completed';
 import './stage_description';
 import './stage_footer';
 
@@ -65,7 +66,11 @@ export class PayoutView extends MobxLitElement {
       return html`
         <stage-description .stage=${this.stage}></stage-description>
         <div class="stages-wrapper">No payout view available at this time.</div>
-        <stage-footer></stage-footer>
+        <stage-footer>
+          ${this.stage.progress.showParticipantProgress ?
+            html`<progress-stage-completed></progress-stage-completed>`
+            : nothing}
+        </stage-footer>
       `;
     }
 
@@ -95,7 +100,11 @@ export class PayoutView extends MobxLitElement {
           ${this.renderScoringItem(item2)}
         </div>
       </div>
-      <stage-footer></stage-footer>
+      <stage-footer>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
+      </stage-footer>
     `;
   }
 

--- a/frontend/src/components/stages/payout_view.ts
+++ b/frontend/src/components/stages/payout_view.ts
@@ -176,6 +176,7 @@ export class PayoutView extends MobxLitElement {
 
   private renderAnswerItem(item: AnswerItem) {
     const getName = (id: string) => {
+      if (id.length === 0) return '';
       return LAS_ITEMS[id].name;
     };
 

--- a/frontend/src/components/stages/reveal_view.scss
+++ b/frontend/src/components/stages/reveal_view.scss
@@ -4,10 +4,12 @@
 :host {
   @include common.flex-column;
   height: 100%;
+  overflow: auto;
 }
 
 .reveal-wrapper {
   @include common.flex-column;
   flex-grow: 1;
   gap: common.$spacing-xl;
+  padding: common.$main-content-padding;
 }

--- a/frontend/src/components/stages/reveal_view.ts
+++ b/frontend/src/components/stages/reveal_view.ts
@@ -1,6 +1,7 @@
+import '../progress/progress_stage_completed';
+
 import './stage_description';
 import './stage_footer';
-
 import './election_reveal_view';
 import './survey_reveal_view';
 
@@ -42,7 +43,11 @@ export class RevealView extends MobxLitElement {
       <div class="reveal-wrapper">
         ${this.stage.stageIds.map(id => this.renderStage(id))}
       </div>
-      <stage-footer></stage-footer>
+      <stage-footer>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
+      </stage-footer>
     `;
   }
 

--- a/frontend/src/components/stages/stage_description.scss
+++ b/frontend/src/components/stages/stage_description.scss
@@ -3,14 +3,18 @@
 
 :host {
   @include common.flex-column;
+}
+
+.description-wrapper {
+  @include common.flex-column;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  padding: common.$main-content-padding;
 }
 
 .description {
   @include typescale.title-small;
   color: var(--md-sys-color-secondary);
   max-width: common.$info-content-max-width;
-  padding-bottom: common.$spacing-large;
 }
 
 .html-wrapper {

--- a/frontend/src/components/stages/stage_description.ts
+++ b/frontend/src/components/stages/stage_description.ts
@@ -21,8 +21,10 @@ export class StageDescription extends MobxLitElement {
     }
 
     return html`
-      <div class="description html-wrapper">
-        ${unsafeHTML(convertMarkdownToHTML(this.stage.descriptions.primaryText))}
+      <div class="description-wrapper">
+        <div class="description html-wrapper">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.descriptions.primaryText))}
+        </div>
       </div>
     `;
   }

--- a/frontend/src/components/stages/stage_footer.scss
+++ b/frontend/src/components/stages/stage_footer.scss
@@ -10,6 +10,7 @@
   gap: common.$spacing-medium;
   height: common.$footer-height;
   justify-content: space-between;
+  padding: 0 common.$main-content-padding;
   position: sticky;
 
   .left,

--- a/frontend/src/components/stages/survey_reveal_view.ts
+++ b/frontend/src/components/stages/survey_reveal_view.ts
@@ -147,7 +147,7 @@ export class SurveyReveal extends MobxLitElement {
           html`<div class="table-cell"></div>`
         )}
         <div class="table-cell">
-          ${this.renderIcon(question.correctAnswerId ?? '', participantAnswer?.choiceId ?? null)}
+          ${question.correctAnswerId ? this.renderIcon(question.correctAnswerId, participantAnswer?.choiceId ?? null) : nothing}
           <div>${answer?.text ?? ''}</div>
         </div>
         ${this.renderLeaderCell(question)}

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -38,13 +38,13 @@
   @include common.flex-column;
   gap: common.$spacing-medium;
 
-  &.las {
+  &.image {
     @include common.flex-row;
     flex-wrap: wrap;
   }
 }
 
-.las-question {
+.image-question {
   @include common.flex-column;
   border: 2px solid transparent;
   border-radius: common.$spacing-medium;

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -5,19 +5,14 @@
   @include common.flex-column;
   gap: common.$spacing-xl;
   height: 100%;
-}
-
-.description {
-  @include typescale.title-small;
-  color: var(--md-sys-color-secondary);
-  padding-bottom: common.$spacing-medium;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  overflow: auto;
 }
 
 .questions-wrapper {
   @include common.flex-column;
   flex-grow: 1;
   gap: calc(common.$spacing-xxl * 2);
+  padding: common.$main-content-padding;
 }
 
 .question {

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -23,11 +23,8 @@ import {
   SurveyStageConfig,
   SurveyStageParticipantAnswer,
   TextSurveyQuestion,
+  isMultipleChoiceImageQuestion
 } from '@deliberation-lab/utils';
-import {
-  LAS_ITEMS,
-  getLASItemImageId
-} from '../../shared/games/lost_at_sea';
 
 import {core} from '../../core/core';
 import {FirebaseService} from '../../services/firebase.service';
@@ -169,7 +166,7 @@ export class SurveyView extends MobxLitElement {
   private renderMultipleChoiceQuestion(question: MultipleChoiceSurveyQuestion) {
     const questionWrapperClasses = classMap({
       'radio-question-wrapper': true,
-      'las': question.id.slice(0, 3) === 'las',
+      'image': isMultipleChoiceImageQuestion(question),
     });
 
     return html`
@@ -209,15 +206,15 @@ export class SurveyView extends MobxLitElement {
       );
     };
 
-    if (LAS_ITEMS[choice.id]) {
+    if (choice.imageId.length > 0) {
       const classes = classMap({
-        'las-question': true,
+        'image-question': true,
         'selected': this.isMultipleChoiceMatch(questionId, choice.id),
         'disabled': this.participantService.disableStage,
       });
 
       const image = document.createElement('img');
-      this.firebaseService.setImage(image, getLASItemImageId(choice.id));
+      this.firebaseService.setImage(image, choice.imageId);
 
       return html`
         <div class=${classes} @click=${handleMultipleChoiceClick}>

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -1,7 +1,9 @@
 import '../../pair-components/textarea';
 
+import '../progress/progress_stage_completed';
 import './stage_description';
 import './stage_footer';
+
 import '@material/web/radio/radio.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -83,6 +85,9 @@ export class SurveyView extends MobxLitElement {
         .disabled=${!questionsComplete()}
         .onNextClick=${saveTextAnswers}
       >
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
       </stage-footer>
     `;
   }

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -26,10 +26,11 @@ import {
 } from '@deliberation-lab/utils';
 import {
   LAS_ITEMS,
-  getLASItemImageURL
+  getLASItemImageId
 } from '../../shared/games/lost_at_sea';
 
 import {core} from '../../core/core';
+import {FirebaseService} from '../../services/firebase.service';
 import {ParticipantService} from '../../services/participant.service';
 import {SurveyService} from '../../services/survey.service';
 
@@ -40,6 +41,7 @@ import {styles} from './survey_view.scss';
 export class SurveyView extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly firebaseService = core.getService(FirebaseService);
   private readonly participantService = core.getService(ParticipantService);
   private readonly surveyService = core.getService(SurveyService);
 
@@ -214,10 +216,13 @@ export class SurveyView extends MobxLitElement {
         'disabled': this.participantService.disableStage,
       });
 
+      const image = document.createElement('img');
+      this.firebaseService.setImage(image, getLASItemImageId(choice.id));
+
       return html`
         <div class=${classes} @click=${handleMultipleChoiceClick}>
           <div class="img-wrapper">
-            <img src=${getLASItemImageURL(choice.id)} />
+            ${image}
           </div>
           <div class="radio-button">
             <md-radio

--- a/frontend/src/components/stages/tos_view.scss
+++ b/frontend/src/components/stages/tos_view.scss
@@ -4,22 +4,14 @@
 :host {
   @include common.flex-column;
   @include common.html-preview;
-  gap: common.$spacing-xl;
   height: 100%;
+  overflow: auto;
 }
 
-.description {
-  @include typescale.title-small;
-  color: var(--md-sys-color-secondary);
-
-  padding-bottom: common.$spacing-medium;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-}
-
-.tos-wrapper {
+.html-wrapper {
   @include common.flex-column;
   gap: common.$spacing-xl;
-  overflow: auto;
+  padding: common.$main-content-padding;
 }
 
 .tos-block {
@@ -35,7 +27,6 @@
   flex-shrink: 0;
   margin-bottom: 0;
   margin-top: auto;
-  padding: common.$spacing-medium 0;
   position: sticky;
 }
 

--- a/frontend/src/components/stages/tos_view.scss
+++ b/frontend/src/components/stages/tos_view.scss
@@ -37,8 +37,12 @@
 }
 
 .timestamp-wrapper {
-  @include typescale.label-medium;
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
+.ack {
+  @include typescale.label-small;
   color: var(--md-sys-color-primary);
   font-style: italic;
-  margin-left: calc(common.$spacing-xxl * 2 + common.$spacing-medium);
 }

--- a/frontend/src/components/stages/tos_view.ts
+++ b/frontend/src/components/stages/tos_view.ts
@@ -1,3 +1,4 @@
+import '../progress/progress_stage_completed';
 import './stage_description';
 import './stage_footer';
 
@@ -69,6 +70,9 @@ export class TOSView extends MobxLitElement {
         </label>
       </div>
       <stage-footer .disabled=${!timestamp}>
+        ${this.stage.progress.showParticipantProgress ?
+          html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
       </stage-footer>
     `;
   }

--- a/frontend/src/components/stages/tos_view.ts
+++ b/frontend/src/components/stages/tos_view.ts
@@ -48,9 +48,7 @@ export class TOSView extends MobxLitElement {
     return html`
       <stage-description .stage=${this.stage}></stage-description>
       <div class="html-wrapper">
-        <div class="tos-block">
-          ${this.stage?.tosLines.map((line) => this.renderTOSLine(line))}
-        </div>
+        ${this.stage?.tosLines.map((line) => this.renderTOSLine(line))}
       </div>
       <div class="ack-wrapper">
         <label class="checkbox-wrapper">

--- a/frontend/src/components/stages/tos_view.ts
+++ b/frontend/src/components/stages/tos_view.ts
@@ -60,13 +60,13 @@ export class TOSView extends MobxLitElement {
             @click=${handleTOSClick}
           >
           </md-checkbox>
-          I accept the Terms of Service
+          <div class="timestamp-wrapper">
+            <div>I accept the Terms of Service</div>
+            ${timestamp
+              ? html`<div class="ack">Accepted at ${convertUnifiedTimestampToDate(timestamp)}</div>`
+              : nothing}
+          </div>
         </label>
-        <div class="timestamp-wrapper">
-          ${timestamp
-            ? `Accepted at ${convertUnifiedTimestampToDate(timestamp)}`
-            : nothing}
-        </div>
       </div>
       <stage-footer .disabled=${!timestamp}>
       </stage-footer>

--- a/frontend/src/components/stages/transfer_view.scss
+++ b/frontend/src/components/stages/transfer_view.scss
@@ -11,3 +11,7 @@
   @include common.overlay;
   opacity: 0;
 }
+
+.transfer-wrapper {
+  padding: common.$main-content-padding;
+}

--- a/frontend/src/components/stages/transfer_view.ts
+++ b/frontend/src/components/stages/transfer_view.ts
@@ -73,7 +73,10 @@ export class TransferView extends MobxLitElement {
   }
 
   private renderCountdown() {
-    if (!this.stage?.enableTimeout) return;
+    if (
+      !this.stage?.enableTimeout ||
+      this.participantService.completedStage(this.stage.id ?? '')
+    ) return;
 
     const minutes = Math.floor(this.timeRemainingSeconds / 60);
     const seconds = this.timeRemainingSeconds % 60;
@@ -84,12 +87,15 @@ export class TransferView extends MobxLitElement {
       this.timeRemainingSeconds,
       this.stage?.timeoutSeconds
     );
-    return html` <div>
-      If the transfer cannot be completed, the experiment will end in:
-      <span style="font-weight: bold; color: ${timeColor};">
-        ${minutes}:${seconds.toString().padStart(2, '0')} (mm:ss) </span
-      >.
-    </div>`;
+
+    return html`
+      <div class="transfer-wrapper">
+        If the transfer cannot be completed, the experiment will end in:
+        <span style="font-weight: bold; color: ${timeColor};">
+          ${minutes}:${seconds.toString().padStart(2, '0')} (mm:ss)
+        </span>.
+      </div>
+    `;
   }
 
   handleTimedOut() {

--- a/frontend/src/pair-components/info_popup.scss
+++ b/frontend/src/pair-components/info_popup.scss
@@ -4,15 +4,16 @@
 .modal {
   display: none; /* Hidden by default */
   position: fixed;
-  z-index: 2;
+  z-index: 99;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.7); /* Semi-transparent background */
+  background-color: rgba(0, 0, 0, 0.3); /* Semi-transparent background */
 }
 
 .modal-content {
+  font-size: var(--md-sys-typescale-body-medium-font-size);
   position: absolute;
   right: 10%;
   margin: auto;
@@ -25,21 +26,6 @@
   border: 1px solid var(--md-sys-color-outline);
   width: var(--pr-text-area-width, 60%);
   height: max-content;
-}
-
-
-.close {
-  color: var(--md-sys-color-outline);
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-  color: black;
-  text-decoration: none;
-  cursor: pointer;
 }
 
 a {

--- a/frontend/src/pair-components/info_popup.ts
+++ b/frontend/src/pair-components/info_popup.ts
@@ -20,15 +20,12 @@ export class InfoPopupComponent extends LitElement {
 
   @property({type: Object}) handleClose: () => void = () => {};
   @property() popupText: string = "";
+  @property() showHelpIcon: boolean = false;
   @state() private showModal: boolean = false;
 
   private handleButtonClick() {
     this.showModal = true;
   }
-
-  private handleCloseClick() {
-    this.showModal = false;
-}
 
   private handleOutsideClick(e: MouseEvent) {
     if ((e.target as HTMLElement).classList.contains('modal')) {
@@ -37,13 +34,12 @@ export class InfoPopupComponent extends LitElement {
   }
 
   override render() {
+    const icon = this.showHelpIcon ? "help" : "info";
     return html`
-    <pr-icon-button color="secondary" variant="default" icon="info" @click=${this.handleButtonClick}>info</pr-icon-button>
-
+    <pr-icon-button variant="default" color="secondary" icon="${icon}" @click=${this.handleButtonClick}>${icon}</pr-icon-button>
     <div class="modal" style=${this.showModal ? 'display: block;' : 'display: none;'} @click=${this.handleOutsideClick}>
       <div class="modal-content">
-        <pr-icon-button color="neutral" class="close" variant="default" icon="close" @click=${this.handleCloseClick}></pr-icon-button>
-        ${unsafeHTML(convertMarkdownToHTML(this.popupText))}
+        <p>${this.popupText}</p>
       </div>
     </div>
     `;

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -176,14 +176,15 @@ export class CohortService extends Service {
 
   // Returns chat discussion ID (or null if none or finished with all chats)
   getChatDiscussionId(stageId: string): string|null {
-    const stageData = this.stagePublicDataMap[stageId];
-    if (!stageData || stageData.kind !== StageKind.CHAT) {
-      return null;
-    }
-
     const stageConfig = this.sp.experimentService.getStage(stageId);
     if (!stageConfig || stageConfig.kind !== StageKind.CHAT || stageConfig.discussions.length === 0) {
       return null;
+    }
+
+    const stageData = this.stagePublicDataMap[stageId];
+    // If no public stage data yet, return first discussion
+    if (!stageData || stageData.kind !== StageKind.CHAT) {
+      return stageConfig.discussions[0].id;
     }
 
     // Find latest chat with messages, then check if everyone

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -120,6 +120,25 @@ export class CohortService extends Service {
     );
   }
 
+  // Get participants who have completed/not completed the stage
+  // (excluding obsolete participants)
+  getParticipantsByCompletion(stageId: string) {
+    const completed: ParticipantProfile[] = [];
+    const notCompleted: ParticipantProfile[] = [];
+
+    this.getAllParticipants().forEach(participant => {
+      if (!isObsoleteParticipant(participant)) {
+        if (participant.timestamps.completedStages[stageId]) {
+          completed.push(participant);
+        } else {
+          notCompleted.push(participant);
+        }
+      }
+    });
+
+    return { completed, notCompleted };
+  }
+
   // If stage is waiting for participants, i.e., is is locked to at least
   // one participant and no one has completed the stage yet
   isStageWaitingForParticipants(stageId: string) {

--- a/frontend/src/services/firebase.service.ts
+++ b/frontend/src/services/firebase.service.ts
@@ -16,12 +16,20 @@ import {
     connectFunctionsEmulator,
     getFunctions
 } from 'firebase/functions';
+import {
+  connectStorageEmulator,
+  FirebaseStorage,
+  getDownloadURL,
+  getStorage,
+  ref
+} from "firebase/storage";
 import { makeObservable } from "mobx";
 
 import {
     FIREBASE_LOCAL_HOST_PORT_AUTH,
     FIREBASE_LOCAL_HOST_PORT_FIRESTORE,
-    FIREBASE_LOCAL_HOST_PORT_FUNCTIONS
+    FIREBASE_LOCAL_HOST_PORT_FUNCTIONS,
+    FIREBASE_LOCAL_HOST_PORT_STORAGE,
 } from '../shared/constants';
 import { FIREBASE_CONFIG } from '../../firebase_config';
 
@@ -39,6 +47,7 @@ export class FirebaseService extends Service {
     this.firestore = getFirestore(this.app);
     this.auth = getAuth(this.app);
     this.functions = getFunctions(this.app);
+    this.storage = getStorage(this.app);
 
     // Only register emulators if in dev mode
     if (process.env.NODE_ENV === 'development'){
@@ -55,13 +64,29 @@ export class FirebaseService extends Service {
   auth: Auth;
   functions: Functions;
   provider: GoogleAuthProvider;
+  storage: FirebaseStorage;
   unsubscribe: Unsubscribe[] = [];
+
+  setImage(imageElement: HTMLImageElement, imageId: string) {
+    const imageRef = ref(this.storage, `images/${imageId}`);
+    getDownloadURL(imageRef).then((url) => {
+      imageElement.setAttribute('src', url);
+    })
+    .catch((error) => {
+      // Handle any errors
+    });
+  }
 
   registerEmulators() {
     connectFirestoreEmulator(
       this.firestore,
       'localhost',
       FIREBASE_LOCAL_HOST_PORT_FIRESTORE
+    );
+    connectStorageEmulator(
+      this.storage,
+      'localhost',
+      FIREBASE_LOCAL_HOST_PORT_STORAGE
     );
     connectAuthEmulator(
       this.auth,

--- a/frontend/src/shared/constants.ts
+++ b/frontend/src/shared/constants.ts
@@ -3,6 +3,7 @@ export const PROLIFIC_COMPLETION_URL_PREFIX = 'https://app.prolific.com/submissi
 
 /** Firebase constants. */
 export const FIREBASE_LOCAL_HOST_PORT_FIRESTORE = 8080;
+export const FIREBASE_LOCAL_HOST_PORT_STORAGE = 9199;
 export const FIREBASE_LOCAL_HOST_PORT_AUTH = 9099;
 export const FIREBASE_LOCAL_HOST_PORT_FUNCTIONS = 5001;
 

--- a/frontend/src/shared/games/gift_card_exchange.ts
+++ b/frontend/src/shared/games/gift_card_exchange.ts
@@ -1,136 +1,140 @@
 import {
-    Experiment,
-    MultipleChoiceSurveyQuestion,
-    StageConfig,
-    StageGame,
-    SurveyQuestion,
-    SurveyQuestionKind,
-    createChatStage,
-    createCompareChatDiscussion,
-    createElectionStage,
-    createExperimentConfig,
-    createInfoStage,
-    createPayoutStage,
-    createProfileStage,
-    createMetadataConfig,
-    createMultipleChoiceSurveyQuestion,
-    createRevealStage,
-    createScaleSurveyQuestion,
-    createStageTextConfig,
-    createSurveyStage,
-    createTOSStage,
-    createTransferStage,
-    ElectionItemData,
-  } from '@deliberation-lab/utils';
+  ElectionItemData,
+  Experiment,
+  MultipleChoiceSurveyQuestion,
+  StageConfig,
+  StageGame,
+  SurveyQuestion,
+  SurveyQuestionKind,
+  createChatStage,
+  createCompareChatDiscussion,
+  createElectionStage,
+  createExperimentConfig,
+  createInfoStage,
+  createPayoutStage,
+  createProfileStage,
+  createMetadataConfig,
+  createMultipleChoiceSurveyQuestion,
+  createRevealStage,
+  createScaleSurveyQuestion,
+  createStageTextConfig,
+  createSurveyStage,
+  createTOSStage,
+  createTransferStage,
+} from '@deliberation-lab/utils';
   
-  /** Constants and functions to create the Gift Card Exchange game. */
+/** Constants and functions to create the Gift Card Exchange game. */
  export const GIFT_CARDS = [
-    { id: "1", text: "💄 Sephora, 🛒 Whole Foods" }, // Lipstick for Sephora, Apple for Whole Foods
-    { id: "2", text: "🍏 Apple, 🎮 Steam" },  // Apple for Apple, Game Controller for Google Play
-    { id: "3", text: "👟 Nike, 📱 Google Play" },         // Sneaker for Nike, Joystick for Steam
+  { id: "1", imageId: "", text: "💄 Sephora, 🛒 Whole Foods" },  // Lipstick for Sephora, Apple for Whole Foods
+  { id: "2", imageId: "", text: "🍏 Apple, 🎮 Steam" },  // Apple for Apple, Game Controller for Google Play
+  { id: "3", imageId: "", text: "👟 Nike, 📱 Google Play" },  // Sneaker for Nike, Joystick for Steam
  ];
-  // ****************************************************************************
-  // Experiment config
-  // ****************************************************************************
-  export const GCE_METADATA = createMetadataConfig({
-    name: 'Gift Card Exchange Experiment',
-    publicName: 'Gift Card Exchange',
-    description: 'A trading scenario involving gift cards.'
-  });
-  
+
+export const GIFT_CARDS_LIST_DESCRIPTION = GIFT_CARDS.map(
+  item => `(${item.text})`
+);
+
+// ****************************************************************************
+// Experiment config
+// ****************************************************************************
+export const GCE_METADATA = createMetadataConfig({
+  name: 'Gift Card Exchange Experiment',
+  publicName: 'Gift Card Exchange',
+  description: 'A trading scenario involving gift cards.'
+});
 
 export function getGCEStageConfigs(): StageConfig[] {
-    const stages: StageConfig[] = [];
-    // Terms of service
-    stages.push(GCE_TOS_STAGE);
-    // Intro
-    stages.push(GCE_INTRO_STAGE);
-    // Profile
-    stages.push(GCE_PROFILE_STAGE);
-    // Part 1: Rank items
-    stages.push(GCE_PART_1_INSTRUCTIONS_STAGE);
-    stages.push(GCE_PART_1_RANKING_STAGE);
-    // Part 2: Chat
-    stages.push(GCE_PART_2_INSTRUCTIONS_STAGE);
-    stages.push(
-        createChatStage({
-            game: StageGame.GCE,
-            name: 'Group discussion',
-            descriptions: {
-                primaryText: '',
-                infoText: `As a reminder, the bundles are (💄 Sephora, 🛒 Whole Foods), (🍏 Apple, 🎮 Steam), and (👟 Nike,, 📱 Google Play).`, 
-                helpText: '',
-            }
-          })
-    );
-    // Part 3: Selection and reveal
-    stages.push(GCE_SELECTION_STAGE);
-    stages.push(GCE_REVEAL_STAGE);
+  const stages: StageConfig[] = [];
+  // Terms of service
+  stages.push(GCE_TOS_STAGE);
+  // Intro
+  stages.push(GCE_INTRO_STAGE);
+  // Profile
+  stages.push(GCE_PROFILE_STAGE);
+  // Part 1: Rank items
+  stages.push(GCE_PART_1_INSTRUCTIONS_STAGE);
+  stages.push(GCE_PART_1_RANKING_STAGE);
+  // Part 2: Chat
+  stages.push(GCE_PART_2_INSTRUCTIONS_STAGE);
+  stages.push(
+    createChatStage({
+      game: StageGame.GCE,
+      name: 'Group discussion',
+      descriptions: {
+        primaryText: '',
+        infoText: `As a reminder, the bundles are ${GIFT_CARDS_LIST_DESCRIPTION}.`,
+        helpText: '',
+      }
+    })
+  );
+  // Part 3: Selection and reveal
+  stages.push(GCE_SELECTION_STAGE);
+  stages.push(GCE_REVEAL_STAGE);
 
-    // Part 4: Trade and reveal
-    stages.push(GCE_TRADE_STAGE);
-    stages.push(GCE_REVEAL2_STAGE);
+  // Part 4: Trade and reveal
+  stages.push(GCE_TRADE_STAGE);
+  stages.push(GCE_REVEAL2_STAGE);
 
-    // Survey
-    stages.push(GCE_FINAL_SURVEY_STAGE);
-    return stages;
-  }
+  // Survey
+  stages.push(GCE_FINAL_SURVEY_STAGE);
+  return stages;
+}
   
-  // ****************************************************************************
+// ****************************************************************************
 // Terms of Service stage
 // ****************************************************************************
 const GCE_TOS_LINES = [
-    'Thank you for participating in this study.',
-  ];
+  'Thank you for participating in this study.',
+];
   
-  const GCE_TOS_STAGE = createTOSStage({
-    game: StageGame.GCE,
-    tosLines: GCE_TOS_LINES,
-  });
+const GCE_TOS_STAGE = createTOSStage({
+  game: StageGame.GCE,
+  tosLines: GCE_TOS_LINES,
+});
  
-  // ****************************************************************************
+// ****************************************************************************
 // Intro info stage
 // ****************************************************************************
 const GCE_INTRO_INFO_DESCRIPTION_PRIMARY =
 `This experiment is part of a research project that explores a trading scenario. You may interact with others during the experiment.`;
 
 const GCE_INTRO_INFO_LINES = [
-    'You will receive a fixed compensation of $4 for your participation, with an opportunity to receive a bonus in the form of gift cards.',
-    '💸 If you win a gift card, your gift card will be delivered digitally within 24-48 hours.',
-    '‼️ If you experience any technical difficulties during the study, **please message the experiment administrators on Prolific as soon as possible.**',
-    'Please click “Next stage” to proceed.',
-    ];
+  'You will receive a fixed compensation of $4 for your participation, with an opportunity to receive a bonus in the form of gift cards.',
+  '💸 If you win a gift card, your gift card will be delivered digitally within 24-48 hours.',
+  '‼️ If you experience any technical difficulties during the study, **please message the experiment administrators on Prolific as soon as possible.**',
+  'Please click “Next stage” to proceed.',
+];
 
 const GCE_INTRO_STAGE = createInfoStage({
-game: StageGame.GCE,
-name: 'Welcome to the experiment',
-descriptions: createStageTextConfig({ primaryText: GCE_INTRO_INFO_DESCRIPTION_PRIMARY }),
-infoLines: GCE_INTRO_INFO_LINES,
+  game: StageGame.GCE,
+  name: 'Welcome to the experiment',
+  descriptions: createStageTextConfig({ primaryText: GCE_INTRO_INFO_DESCRIPTION_PRIMARY }),
+  infoLines: GCE_INTRO_INFO_LINES,
 });
 
 // ****************************************************************************
 // Profile stage
 // ****************************************************************************
 const GCE_PROFILE_STAGE = createProfileStage({
-    game: StageGame.GCE,
-  });
+  game: StageGame.GCE,
+});
   
 // ****************************************************************************
 // Part 1 Instructions info stage
 // ****************************************************************************
 const GCE_PART_1_INSTRUCTIONS_INFO_LINES = [
-    'You will be presented with pairs of gift cards.',
-    'Please rank these pairs from the one you’d most prefer to the one you’d least prefer.',
-    'The gift card pairs are not separable, meaning you cannot choose individual cards from each pair. You will be selecting and ranking the pairs as combinations.',
-    'Think carefully about the combinations you would most like, as your preferences may impact the gift card pair you receive.',
-    'At the end of the experiment, you may be selected to receive one of the pairs based on your rankings and a lottery selection process.',
-    'Please make your selections carefully and click "Next" when you’re ready to proceed.',
-  ];
+  'You will be presented with pairs of gift cards.',
+  'Please rank these pairs from the one you’d most prefer to the one you’d least prefer.',
+  'The gift card pairs are not separable, meaning you cannot choose individual cards from each pair. You will be selecting and ranking the pairs as combinations.',
+  'Think carefully about the combinations you would most like, as your preferences may impact the gift card pair you receive.',
+  'At the end of the experiment, you may be selected to receive one of the pairs based on your rankings and a lottery selection process.',
+  'Please make your selections carefully and click "Next" when you’re ready to proceed.',
+];
 
 const GCE_PART_1_INSTRUCTIONS_STAGE = createInfoStage({
-game: StageGame.GCE,
-name: 'Ranking instructions',
-infoLines: GCE_PART_1_INSTRUCTIONS_INFO_LINES,
+  game: StageGame.GCE,
+  name: 'Ranking instructions',
+  infoLines: GCE_PART_1_INSTRUCTIONS_INFO_LINES,
 });
  
 // ****************************************************************************
@@ -146,7 +150,7 @@ const GCE_PART_1_RANKING_STAGE = createElectionStage({
   name: 'Initial item ranking',
   descriptions: createStageTextConfig({ infoText: RANKING_INSTRUCTIONS }),
   isParticipantElection: false,
-  electionItems:  GIFT_CARDS,
+  electionItems: GIFT_CARDS,
 });
 
 
@@ -155,19 +159,19 @@ const GCE_PART_1_RANKING_STAGE = createElectionStage({
 // ****************************************************************************
   
 export const GCE_CHAT_INSTRUCTIONS = [
-    'Now you’re going to chat with other participants about the gift card allocations.',
-    'Please select different pairs of gift cards to discuss; otherwise, you will receive a random pair.',
-    'In the next stage, you will be in a group chat with three other people. Together, you will need to unanimously decide who gets which pair of gift cards. Each participant must receive one pair of gift cards.',
-    'If you do not reach a unanimous agreement on the allocations within XX minutes, the gift cards will be allocated randomly.',
-    'Throughout the experiment, you will engage in multiple bargaining sessions (specifically, five different bargaining games) with different groups. One of the pairs of gift cards you negotiate for will be randomly given to you based on the outcomes of these discussions.',
-    'Please communicate effectively with your group to ensure everyone is satisfied with the final allocations. Click "Next" to proceed.',
-  ];
+  'Now you’re going to chat with other participants about the gift card allocations.',
+  'Please select different pairs of gift cards to discuss; otherwise, you will receive a random pair.',
+  'In the next stage, you will be in a group chat with three other people. Together, you will need to unanimously decide who gets which pair of gift cards. Each participant must receive one pair of gift cards.',
+  'If you do not reach a unanimous agreement on the allocations within XX minutes, the gift cards will be allocated randomly.',
+  'Throughout the experiment, you will engage in multiple bargaining sessions (specifically, five different bargaining games) with different groups. One of the pairs of gift cards you negotiate for will be randomly given to you based on the outcomes of these discussions.',
+  'Please communicate effectively with your group to ensure everyone is satisfied with the final allocations. Click "Next" to proceed.',
+];
   
 export  const GCE_PART_2_INSTRUCTIONS_STAGE = createInfoStage({
-    game: StageGame.GCE,
-    name: 'Chat instructions',
-    infoLines: GCE_CHAT_INSTRUCTIONS,
-    });
+  game: StageGame.GCE,
+  name: 'Chat instructions',
+  infoLines: GCE_CHAT_INSTRUCTIONS,
+});
 
 // ****************************************************************************
 // Part 3: Now rank the items 
@@ -175,24 +179,26 @@ export  const GCE_PART_2_INSTRUCTIONS_STAGE = createInfoStage({
 
 const SELECTION_ID = 'gift_card_selection';
 const GCE_SELECTION_STAGE = createSurveyStage({
-    id: SELECTION_ID,
-    game: StageGame.GCE,
-    name: 'Select your gift card',
-    descriptions: createStageTextConfig({ primaryText: 'Now, lock in the bundle of gift cards.'}),
-    questions: [
-      createMultipleChoiceSurveyQuestion({
-        questionTitle: 'Which bundle did the group decide that you should receive?',
-        options: GIFT_CARDS })
-      ]});
+  id: SELECTION_ID,
+  game: StageGame.GCE,
+  name: 'Select your gift card',
+  descriptions: createStageTextConfig({ primaryText: 'Now, lock in the bundle of gift cards.'}),
+  questions: [
+    createMultipleChoiceSurveyQuestion({
+      questionTitle: 'Which bundle did the group decide that you should receive?',
+      options: GIFT_CARDS
+    })
+  ],
+});
 
-    export const GCE_REVEAL_STAGE = createRevealStage({
-      game: StageGame.GCE,
-      name: 'Results reveal',
-      descriptions: createStageTextConfig({
-        primaryText: 'Here are the allocation results.'
-      }),
-      stageIds: [SELECTION_ID],
-    });
+export const GCE_REVEAL_STAGE = createRevealStage({
+  game: StageGame.GCE,
+  name: 'Results reveal',
+  descriptions: createStageTextConfig({
+    primaryText: 'Here are the allocation results.'
+  }),
+  stageIds: [SELECTION_ID],
+});
     
 // ****************************************************************************
 // Part 4: Opportunity to trade 
@@ -201,42 +207,42 @@ const GCE_SELECTION_STAGE = createSurveyStage({
 
 const TRADE_ID = 'gift_card_trade';
 const GCE_TRADE_STAGE = createSurveyStage({
-    id: TRADE_ID,
-    game: StageGame.GCE,
-    name: 'Opportunity to trade',
-    descriptions: createStageTextConfig({ primaryText: 'Would you like to trade for a different gift card? Select your own if not.'}),
-    questions: [
-      createMultipleChoiceSurveyQuestion({
-        questionTitle: 'Which would you prefer?',
-        options: GIFT_CARDS })
-      ]});
+  id: TRADE_ID,
+  game: StageGame.GCE,
+  name: 'Opportunity to trade',
+  descriptions: createStageTextConfig({ primaryText: 'Would you like to trade for a different gift card? Select your own if not.'}),
+  questions: [
+    createMultipleChoiceSurveyQuestion({
+      questionTitle: 'Which would you prefer?',
+      options: GIFT_CARDS
+    })
+  ]
+});
 
-    export const GCE_REVEAL2_STAGE = createRevealStage({
-      game: StageGame.GCE,
-      name: 'Trade reveal',
-      descriptions: createStageTextConfig({
-        primaryText: 'Here are the results after any trades may have occurred.'
-      }),
-      stageIds: [TRADE_ID],
-    });
+export const GCE_REVEAL2_STAGE = createRevealStage({
+  game: StageGame.GCE,
+  name: 'Trade reveal',
+  descriptions: createStageTextConfig({
+    primaryText: 'Here are the results after any trades may have occurred.'
+  }),
+  stageIds: [TRADE_ID],
+});
  
-    // ****************************************************************************
+// ****************************************************************************
 // Final survey stage
 // ****************************************************************************
 const GCE_FINAL_DESCRIPTION_PRIMARY =
 `Thanks for participating. Please complete this final survey.`;
 
-export const GCE_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
-{
+export const GCE_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [{
   id: '0',
   kind: SurveyQuestionKind.TEXT,
-  questionTitle: 'If someone were to negotiate for you in this exact game on your behalf, how would you describe your preferences over the pairs of gifcards in 25 words or less?'
-},
-];
+  questionTitle: 'If someone were to negotiate for you in this exact game on your behalf, how would you describe your preferences over the pairs of gift cards in 25 words or less?'
+}];
 
 const GCE_FINAL_SURVEY_STAGE = createSurveyStage({
-game: StageGame.GCE,
-name: 'Final survey',
-descriptions: createStageTextConfig({ primaryText: GCE_FINAL_DESCRIPTION_PRIMARY }),
-questions: GCE_FINAL_SURVEY_QUESTIONS,
+  game: StageGame.GCE,
+  name: 'Final survey',
+  descriptions: createStageTextConfig({ primaryText: GCE_FINAL_DESCRIPTION_PRIMARY }),
+  questions: GCE_FINAL_SURVEY_QUESTIONS,
 });

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -20,6 +20,8 @@ import {
   createSurveyStage,
   createTOSStage,
   createTransferStage,
+  LAS_WTL_STAGE_ID,
+  LAS_WTL_QUESTION_ID,
 } from '@deliberation-lab/utils';
 
 /** Constants and functions to create the Lost at Sea game. */
@@ -489,8 +491,6 @@ const LAS_PART_2_ELECTION_INFO_STAGE = createInfoStage({
 // ****************************************************************************
 // Part 2 updated willingness to lead - survey stage
 // ****************************************************************************
-export const LAS_PART_2_WTL_ID = 'wtl';
-
 export const LAS_PART_2_WTL_DESCRIPTION_PRIMARY =
   'Please indicate your willingness to become the group leader';
 
@@ -498,7 +498,7 @@ export const LAS_PART_2_WTL_DESCRIPTION_INFO =
   'Your group must elect a leader whose role is to answer on behalf of the group the same types of questions you have just seen. In this scenario, the leader is the only one who chooses the most useful items for survival from pairs, and their answers determine the payment for each member of the group.';
 
 const LAS_PART_2_WTL_SURVEY_STAGE = createSurveyStage({
-  id: LAS_PART_2_WTL_ID,
+  id: LAS_WTL_STAGE_ID,
   game: StageGame.LAS,
   name: 'Willingness to lead survey',
   descriptions: createStageTextConfig({
@@ -507,6 +507,7 @@ const LAS_PART_2_WTL_SURVEY_STAGE = createSurveyStage({
   }),
   questions: [
     createScaleSurveyQuestion({
+      id: LAS_WTL_QUESTION_ID,
       questionTitle: 'How much would you like to become the group leader in Part 3?',
       upperText: 'Very much',
       lowerText: 'Not at all',

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -172,8 +172,8 @@ export function createLASMultipleChoiceQuestion(
     kind: SurveyQuestionKind.MULTIPLE_CHOICE,
     questionTitle: LAS_ITEM_MULTIPLE_CHOICE_QUESTION_TITLE,
     options: [
-      { id: id1, text: LAS_ITEMS[id1]?.name ?? '' },
-      { id: id2, text: LAS_ITEMS[id2]?.name ?? '' },
+      { id: id1, imageId: getLASItemImageId(id1), text: LAS_ITEMS[id1]?.name ?? '' },
+      { id: id2, imageId: getLASItemImageId(id2), text: LAS_ITEMS[id2]?.name ?? '' },
     ],
     correctAnswerId: getCorrectLASAnswer(id1, id2),
   };
@@ -334,18 +334,22 @@ const LAS_PART_2_PERFORMANCE_ESTIMATION_SURVEY_STAGE = createSurveyStage({
       options: [
         {
           id: '1',
+          imageId: '',
           text: 'My score was the best',
         },
         {
           id: '2',
+          imageId: '',
           text: 'My score was the second best',
         },
         {
           id: '3',
+          imageId: '',
           text: 'My score was the third best',
         },
         {
           id: '4',
+          imageId: '',
           text: 'My score was the fourth best',
         },
       ],
@@ -431,18 +435,22 @@ const LAS_PART_2_UPDATED_PERFORMANCE_ESTIMATION_SURVEY_STAGE = createSurveyStage
       options: [
         {
           id: '1',
+          imageId: '',
           text: 'My score was the best',
         },
         {
           id: '2',
+          imageId: '',
           text: 'My score was the second best',
         },
         {
           id: '3',
+          imageId: '',
           text: 'My score was the third best',
         },
         {
           id: '4',
+          imageId: '',
           text: 'My score was the fourth best',
         },
       ],

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -395,6 +395,11 @@ const LAS_PART_2_CHAT_STAGE = createChatStage({
   game: StageGame.LAS,
   name: 'Group discussion',
   discussions: LAS_PART_2_CHAT_DISCUSSIONS,
+  progress: {
+    minParticipants: 4,
+    waitForAllParticipants: true,
+    showParticipantProgress: true,
+  }
 });
 
 // ****************************************************************************

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -385,8 +385,8 @@ const LAS_PART_2_GROUP_INSTRUCTIONS_STAGE = createInfoStage({
 const LAS_PART_2_CHAT_DISCUSSIONS = ITEMS_SET_1.map(itemSet =>
   createCompareChatDiscussion({
     items: [
-      { id: itemSet[0], name: LAS_ITEMS[itemSet[0]]?.name ?? '' },
-      { id: itemSet[1], name: LAS_ITEMS[itemSet[1]]?.name ?? '' },
+      { id: itemSet[0], imageId: getLASItemImageId(itemSet[0]), name: LAS_ITEMS[itemSet[0]]?.name ?? '' },
+      { id: itemSet[1], imageId: getLASItemImageId(itemSet[1]), name: LAS_ITEMS[itemSet[1]]?.name ?? '' },
     ]
   })
 );

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -77,8 +77,6 @@ export function getLASStageConfigs(): StageConfig[] {
 export const LAS_SCENARIO_REMINDER =
   'Here is a reminder of the scenario:\n\nYou and three friends are on a yacht trip across the Atlantic. A fire breaks out, and the skipper and crew are lost. The yacht is sinking, and your location is unclear.\nYou have saved 10 items, a life raft, and a box of matches.\n\nEvaluate the relative importance of items in each presented pair by selecting the one you believe is most useful. You can earn £2 per correct answer if that question is drawn to determine your payoff.';
 
-export const LAS_IMAGE_URL_PREFIX = (process.env.URL_PREFIX ?? '') + 'assets/lost_at_sea/';
-
 interface LASItem {
   name: string;
   ranking: number;
@@ -101,10 +99,8 @@ export const LAS_ITEMS: Record<string, LASItem> = {
   'netting': { name: 'Mosquito netting', ranking: 14 },
 };
 
-export function getLASItemImageURL(itemId: string) {
-  const item = LAS_ITEMS[itemId];
-  if (!item) return undefined;
-  return `${LAS_IMAGE_URL_PREFIX}${itemId}.jpg`;
+export function getLASItemImageId(itemId: string) {
+  return `las/${itemId}.jpg`;
 }
 
 export const LAS_ITEM_MULTIPLE_CHOICE_QUESTION_TITLE =

--- a/frontend/src/shared/participant.utils.ts
+++ b/frontend/src/shared/participant.utils.ts
@@ -24,7 +24,6 @@ export function getParticipantPronouns(
   return '';
 }
 
-
 /** Returns the start timestamp of the current stage. */
 export function getCurrentStageStartTime(
   participant: ParticipantProfile,

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -55,12 +55,6 @@ const config: webpack.Configuration = {
     ],
   },
   plugins: [
-    new CopyWebpackPlugin({
-      patterns: [
-        // Move assets from assets/ to dist/assets/
-        {from: 'assets', to: 'assets'},
-      ],
-    }),
     new HtmlWebpackPlugin({
       template: './index.html',
       filename: 'index.html',

--- a/utils/src/shared.ts
+++ b/utils/src/shared.ts
@@ -49,6 +49,20 @@ export enum Visibility {
 }
 
 // ************************************************************************* //
+// CONSTANTS                                                                 //
+// ************************************************************************* //
+
+/** Hardcoded willingness to lead stage ID for Lost at Sea game
+  * (needed for determining winner of participant rankings)
+  */
+export const LAS_WTL_STAGE_ID = 'wtl';
+
+/** Hardcoded willingness to lead question ID for Lost at Sea game
+  * (needed for determining winner of participant rankings)
+  */
+export const LAS_WTL_QUESTION_ID = 'wtl';
+
+// ************************************************************************* //
 // FUNCTIONS                                                                 //
 // ************************************************************************* //
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -171,7 +171,7 @@ export function createChatStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Group chat',
     descriptions: config.descriptions ?? createStageTextConfig(),
-    progress: config.progress ?? createStageProgressConfig({ waitForParticipants: true }),
+    progress: config.progress ?? createStageProgressConfig({ waitForAllParticipants: true }),
     discussions: config.discussions ?? [],
     mediators: config.mediators ?? [],
   };

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -57,6 +57,7 @@ export interface CompareChatDiscussion extends BaseChatDiscussion {
 /** Discussion item to compare. */
 export interface DiscussionItem {
   id: string;
+  imageId: string; // or empty if no image provided
   name: string;
 }
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -6,7 +6,8 @@ import {
   BaseStagePublicData,
   StageGame,
   StageKind,
-  createStageTextConfig
+  createStageTextConfig,
+  createStageProgressConfig,
 } from './stage';
 import {
   ParticipantProfileBase,
@@ -170,6 +171,7 @@ export function createChatStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Group chat',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig({ waitForParticipants: true }),
     discussions: config.discussions ?? [],
     mediators: config.mediators ?? [],
   };

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -1,7 +1,11 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { UnifiedTimestampSchema } from '../shared.validation';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageTextConfigSchema,
+  StageProgressConfigSchema
+} from './stage.validation';
 import { ChatMessageType } from './chat_stage';
 
 /** Shorthand for strict TypeBox object validation */
@@ -17,6 +21,7 @@ export const ChatStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String(),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     // discussions
     // mediators
   },

--- a/utils/src/stages/election_stage.ts
+++ b/utils/src/stages/election_stage.ts
@@ -73,7 +73,7 @@ export function createElectionStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Election',
     descriptions: config.descriptions ?? createStageTextConfig(),
-    progress: config.progress ?? createStageProgressConfig({ waitForParticipants: true }),
+    progress: config.progress ?? createStageProgressConfig({ waitForAllParticipants: true }),
     isParticipantElection: config.isParticipantElection ?? true,
     electionItems: config.electionItems ?? [],
   };

--- a/utils/src/stages/election_stage.ts
+++ b/utils/src/stages/election_stage.ts
@@ -27,6 +27,7 @@ export interface ElectionStageConfig extends BaseStageConfig {
 
 export interface ElectionItem {
   id: string;
+  imageId: string; // or empty if no image provided
   text: string;
 }
 

--- a/utils/src/stages/election_stage.ts
+++ b/utils/src/stages/election_stage.ts
@@ -79,6 +79,17 @@ export function createElectionStage(
   };
 }
 
+/** Create election item. */
+export function createElectionItem(
+  config: Partial<ElectionItem> = {}
+): ElectionItem {
+  return {
+    id: config.id ?? generateId(),
+    imageId: config.imageId ?? '',
+    text: config.text ?? '',
+  };
+}
+
 /** Create election stage public data. */
 export function createElectionStagePublicData(
   id: string, // stage ID

--- a/utils/src/stages/election_stage.ts
+++ b/utils/src/stages/election_stage.ts
@@ -5,6 +5,7 @@ import {
   BaseStagePublicData,
   StageGame,
   StageKind,
+  createStageProgressConfig,
   createStageTextConfig,
 } from './stage';
 
@@ -72,6 +73,7 @@ export function createElectionStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Election',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig({ waitForParticipants: true }),
     isParticipantElection: config.isParticipantElection ?? true,
     electionItems: config.electionItems ?? [],
   };

--- a/utils/src/stages/election_stage.validation.ts
+++ b/utils/src/stages/election_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 import { ElectionItem } from './election_stage';
 
 /** Shorthand for strict TypeBox object validation */
@@ -27,6 +31,7 @@ export const ElectionStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     isParticipantElection: Type.Boolean(),
     electionItems: Type.Array(ElectionItemData),
   },

--- a/utils/src/stages/election_stage.validation.ts
+++ b/utils/src/stages/election_stage.validation.ts
@@ -18,6 +18,7 @@ const strict = { additionalProperties: false } as const;
 export const ElectionItemData = Type.Object(
   {
     id: Type.String({ minLength: 1 }),
+    imageId: Type.String(),
     text: Type.String(),
   },
   strict,

--- a/utils/src/stages/info_stage.ts
+++ b/utils/src/stages/info_stage.ts
@@ -4,6 +4,7 @@ import {
   StageGame,
   StageKind,
   createStageTextConfig,
+  createStageProgressConfig,
 } from './stage';
 
 /** Info stage types and functions. */
@@ -31,6 +32,7 @@ export function createInfoStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Info',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
     infoLines: config.infoLines ?? [],
   };
 }

--- a/utils/src/stages/info_stage.validation.ts
+++ b/utils/src/stages/info_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const InfoStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     infoLines: Type.Array(Type.String()),
   },
   strict,

--- a/utils/src/stages/payout_stage.ts
+++ b/utils/src/stages/payout_stage.ts
@@ -3,7 +3,8 @@ import {
   BaseStageConfig,
   StageGame,
   StageKind,
-  createStageTextConfig
+  createStageTextConfig,
+  createStageProgressConfig,
 } from './stage';
 
 /** Payout stage types and functions. */
@@ -30,5 +31,6 @@ export function createPayoutStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Payout',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
   };
 }

--- a/utils/src/stages/payout_stage.validation.ts
+++ b/utils/src/stages/payout_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const PayoutStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
   },
   strict,
 );

--- a/utils/src/stages/profile_stage.ts
+++ b/utils/src/stages/profile_stage.ts
@@ -3,6 +3,7 @@ import {
   BaseStageConfig,
   StageGame,
   StageKind,
+  createStageProgressConfig,
   createStageTextConfig
 } from './stage';
 
@@ -30,5 +31,6 @@ export function createProfileStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Set profile',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
   };
 }

--- a/utils/src/stages/profile_stage.validation.ts
+++ b/utils/src/stages/profile_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const ProfileStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
   },
   strict,
 );

--- a/utils/src/stages/reveal_stage.ts
+++ b/utils/src/stages/reveal_stage.ts
@@ -5,6 +5,7 @@ import {
   BaseStagePublicData,
   StageGame,
   StageKind,
+  createStageProgressConfig,
   createStageTextConfig,
 } from './stage';
 
@@ -38,6 +39,7 @@ export function createRevealStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Reveal',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
     stageIds: config.stageIds ?? [],
   };
 }

--- a/utils/src/stages/reveal_stage.validation.ts
+++ b/utils/src/stages/reveal_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const RevealStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     stageIds: Type.Array(Type.String({ minLength: 1})),
   },
   strict,

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -62,12 +62,19 @@ export interface BaseStageConfig {
   game: StageGame;
   name: string;
   descriptions: StageTextConfig;
+  progress: StageProgressConfig;
 }
 
 export interface StageTextConfig {
   primaryText: string; // shown at top of screen under header
   infoText: string; // for info popup
   helpText: string; // for help popup
+}
+
+export interface StageProgressConfig {
+  minParticipants: number; // min participants required for stage
+  waitForAllParticipants: boolean; // wait for all participants to reach stage
+  showParticipantProgress: boolean; // show participants who completed stage
 }
 
 export type StageConfig =
@@ -128,6 +135,17 @@ export function createStageTextConfig(
     primaryText: config.primaryText ?? '',
     infoText: config.infoText ?? '',
     helpText: config.helpText ?? '',
+  };
+}
+
+/** Create stage progress config. */
+export function createStageProgressConfig(
+  config: Partial<StageProgressConfig> = {}
+): StageProgressConfig {
+  return {
+    minParticipants: config.minParticipants ?? 0,
+    waitForAllParticipants: config.waitForAllParticipants ?? false,
+    showParticipantProgress: config.showParticipantProgress ?? true,
   };
 }
 

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -40,3 +40,10 @@ export const StageTextConfigSchema = Type.Object({
   infoText: Type.String(),
   helpText: Type.String(),
 });
+
+/** StageProgressConfig input validation. */
+export const StageProgressConfigSchema = Type.Object({
+  minParticipants: Type.Number(),
+  waitForAllParticipants: Type.Boolean(),
+  showParticipantProgress: Type.Boolean(),
+});

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -5,6 +5,7 @@ import {
   BaseStagePublicData,
   StageGame,
   StageKind,
+  createStageProgressConfig,
   createStageTextConfig,
 } from './stage';
 
@@ -140,6 +141,7 @@ export function createSurveyStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Survey',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
     questions: config.questions ?? [],
   };
 }

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -54,6 +54,7 @@ export interface MultipleChoiceSurveyQuestion extends BaseSurveyQuestion {
 
 export interface MultipleChoiceItem {
   id: string;
+  imageId: string; // or empty if no image provided
   text: string;
 }
 
@@ -184,6 +185,7 @@ export function createMultipleChoiceItem(
 ): MultipleChoiceItem {
   return {
     id: config.id ?? generateId(),
+    imageId: config.imageId ?? '',
     text: config.text ?? '',
   }
 }
@@ -223,4 +225,16 @@ export function createSurveyStagePublicData(
     kind: StageKind.SURVEY,
     participantAnswerMap: {},
   };
+}
+
+/** Returns true if any multiple choice options contain an image. */
+export function isMultipleChoiceImageQuestion(
+  question: MultipleChoiceSurveyQuestion
+) {
+  for (const option of question.options) {
+    if (option.imageId.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/utils/src/stages/survey_stage.validation.ts
+++ b/utils/src/stages/survey_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 import { SurveyQuestionKind } from './survey_stage';
 
 /** Shorthand for strict TypeBox object validation */
@@ -82,6 +86,7 @@ export const SurveyStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     questions: Type.Array(SurveyQuestionData),
   },
   strict,

--- a/utils/src/stages/survey_stage.validation.ts
+++ b/utils/src/stages/survey_stage.validation.ts
@@ -34,6 +34,7 @@ export const CheckSurveyQuestionData = Type.Object(
 export const MultipleChoiceItemData = Type.Object(
   {
     id: Type.String({ minLength: 1 }),
+    imageId: Type.String(),
     text: Type.String(),
   },
   strict,

--- a/utils/src/stages/tos_stage.ts
+++ b/utils/src/stages/tos_stage.ts
@@ -3,7 +3,8 @@ import {
   BaseStageConfig,
   StageGame,
   StageKind,
-  createStageTextConfig
+  createStageTextConfig,
+  createStageProgressConfig,
 } from './stage';
 
 /** Terms of Service (TOS) stage types and functions. */
@@ -31,6 +32,7 @@ export function createTOSStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Terms of Service',
     descriptions: config.descriptions ?? createStageTextConfig(),
+    progress: config.progress ?? createStageProgressConfig(),
     tosLines: config.tosLines ?? [],
   };
 }

--- a/utils/src/stages/tos_stage.validation.ts
+++ b/utils/src/stages/tos_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageTextConfigSchema,
+  StageProgressConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const TOSStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     tosLines: Type.Array(Type.String()),
   },
   strict,

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -3,6 +3,7 @@ import {
   BaseStageConfig,
   StageGame,
   StageKind,
+  createStageProgressConfig,
   createStageTextConfig,
 } from './stage';
 
@@ -35,6 +36,7 @@ export function createTransferStage(
     game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Transfer',
     descriptions: config.descriptions ?? createStageTextConfig({primaryText : defaultText}),
+    progress: config.progress ?? createStageProgressConfig(),
     enableTimeout: config.enableTimeout ?? false,
     timeoutSeconds: config.timeoutSeconds ?? 600, // 10 minutes
   };

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -1,6 +1,10 @@
 import { Type, type Static } from '@sinclair/typebox';
 import { StageKind } from './stage';
-import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema
+} from './stage.validation';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = { additionalProperties: false } as const;
@@ -17,6 +21,7 @@ export const TransferStageConfigData = Type.Object(
     game: StageGameSchema,
     name: Type.String({ minLength: 1 }),
     descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
     enableTimeout: Type.Boolean(),
     timeoutSeconds: Type.Number(),
   },


### PR DESCRIPTION
- Fix layout bugs for stage views
- Add `imageId` fields to survey (multiple choice), chat (discussion thread), election stages and use Firebase storage to retrieve images
  - NOTE: This currently means manually loading `frontend/assets` images to the storage emulator. Filed [#254](https://github.com/PAIR-code/deliberate-lab/issues/254) to create a script to help populate and [#255](https://github.com/PAIR-code/deliberate-lab/issues/255) to create a frontend gallery so users can directly upload/select images
- Add fields to base stage (and use in rendering waiting, progress components):
  - `waitForAllParticipants: boolean` - wait until all non-obsolete participants have unlocked stage
  - `minParticipants: number` - wait until minParticipants (0 by default) have unlocked stage
  - `showParticipantsCompleted: boolean` - if true, render progress_stage_completed component in footer
- Hardcode WTL logic for election/ranking
- Add `ready to end chat discussion` progress view
- Update info/help icons to use custom modal