### PR TITLE
Fix playtest issues with stage access, setup

### DIFF
--- a/frontend/src/components/progress/progress_stage_waiting.scss
+++ b/frontend/src/components/progress/progress_stage_waiting.scss
@@ -48,11 +48,11 @@ h2 {
 }
 
 .participant {
+  @include typescale.body-small;
   @include common.flex-column-align-center;
   flex-wrap: wrap;
   gap: common.$spacing-medium;
   max-width: 100px;
   overflow-wrap: anywhere;
   text-align: center;
-  font-size: var(--md-sys-typescale-body-small-font-size);
 }

--- a/frontend/src/components/progress/progress_stage_waiting.scss
+++ b/frontend/src/components/progress/progress_stage_waiting.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -51,7 +51,8 @@ h2 {
   @include common.flex-column-align-center;
   flex-wrap: wrap;
   gap: common.$spacing-medium;
-  max-width: 80px;
+  max-width: 100px;
   overflow-wrap: anywhere;
   text-align: center;
+  font-size: var(--md-sys-typescale-body-small-font-size);
 }

--- a/frontend/src/components/progress/progress_stage_waiting.ts
+++ b/frontend/src/components/progress/progress_stage_waiting.ts
@@ -10,13 +10,11 @@ import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
 import {RouterService} from '../../services/router.service';
 
-import {
-  ParticipantProfile,
-} from '@deliberation-lab/utils';
+import {ParticipantProfile} from '@deliberation-lab/utils';
 import {
   getParticipantName,
   getParticipantPronouns,
-  isActiveParticipant
+  isActiveParticipant,
 } from '../../shared/participant.utils';
 
 import {styles} from './progress_stage_waiting.scss';
@@ -45,7 +43,13 @@ export class Progress extends MobxLitElement {
       <div class="status">
         <h2 class="secondary">
           <div class="chip secondary">Waiting on</div>
-          <div>${Math.max(locked.length, stage.progress.minParticipants - unlocked.length)} participants</div>
+          <div>
+            ${Math.max(
+              locked.length,
+              stage.progress.minParticipants - unlocked.length
+            )}
+            participants
+          </div>
         </h2>
         ${this.showWaitingAvatars ? this.renderParticipants(locked) : nothing}
       </div>
@@ -63,20 +67,29 @@ export class Progress extends MobxLitElement {
   private renderParticipant(participant: ParticipantProfile) {
     const isDisabled = !isActiveParticipant(participant);
 
-    const tooltipText = !isDisabled ? nothing :
-      'This participant is no longer in the experiment';
+    const participantName = getParticipantName(participant);
+    const isTruncated = participantName.length > 14;
+    const displayName = isTruncated
+      ? participantName.substring(0, 11) + '...'
+      : participantName;
+
+    let tooltipText = '';
+    if (isTruncated && isDisabled) {
+      tooltipText = `${participantName} is no longer in the experiment`;
+    } else if (isTruncated) {
+      tooltipText = participantName;
+    } else if (isDisabled) {
+      tooltipText = 'This participant is no longer in the experiment';
+    }
 
     return html`
-      <pr-tooltip text=${tooltipText}>
+      <pr-tooltip text=${tooltipText} position="BOTTOM_END">
         <div class="participant">
           <profile-avatar
             .emoji=${participant.avatar}
             .disabled=${isDisabled}
           ></profile-avatar>
-          <div>
-            ${getParticipantName(participant)}
-            ${getParticipantPronouns(participant)}
-          </div>
+          <div>${displayName} ${getParticipantPronouns(participant)}</div>
         </div>
       </pr-tooltip>
     `;

--- a/frontend/src/components/stages/base_stage_editor.scss
+++ b/frontend/src/components/stages/base_stage_editor.scss
@@ -25,3 +25,9 @@ pr-textarea {
   @include common.number-input;
   width: max-content;
 }
+
+.warning{
+  font-style: italic;
+  color: var(--md-sys-color-secondary);
+  max-width: common.$info-content-max-width;
+}

--- a/frontend/src/components/stages/base_stage_editor.ts
+++ b/frontend/src/components/stages/base_stage_editor.ts
@@ -10,6 +10,9 @@ import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
 
 import {
+  ElectionStrategy,
+  RevealAudience,
+  RankingType,
   StageConfig,
   StageKind,
   StageProgressConfig,
@@ -24,7 +27,7 @@ export class BaseStageEditorComponent extends MobxLitElement {
 
   private readonly experimentEditor = core.getService(ExperimentEditor);
 
-  @property() stage: StageConfig|undefined = undefined;
+  @property() stage: StageConfig | undefined = undefined;
 
   override render() {
     if (this.stage === undefined) {
@@ -32,21 +35,18 @@ export class BaseStageEditorComponent extends MobxLitElement {
     }
 
     return html`
-      ${this.renderName()}
-      ${this.renderPrimaryText()}
-      ${this.renderInfoText()}
-      ${this.renderHelpText()}
-      ${this.renderMinParticipants()}
+      ${this.renderName()} ${this.renderPrimaryText()} ${this.renderInfoText()}
+      ${this.renderHelpText()} ${this.renderMinParticipants()}
       ${this.renderWaitForAllParticipants()}
       ${this.renderShowParticipantProgress()}
     `;
   }
 
   private renderName() {
-    const updateName= (e: InputEvent) => {
+    const updateName = (e: InputEvent) => {
       const name = (e.target as HTMLTextAreaElement).value;
       if (this.stage) {
-        this.experimentEditor.updateStage({ ...this.stage, name });
+        this.experimentEditor.updateStage({...this.stage, name});
       }
     };
 
@@ -67,8 +67,8 @@ export class BaseStageEditorComponent extends MobxLitElement {
     const update = (e: InputEvent) => {
       const primaryText = (e.target as HTMLTextAreaElement).value;
       if (this.stage) {
-        const descriptions = { ...this.stage.descriptions, primaryText };
-        this.experimentEditor.updateStage({ ...this.stage, descriptions });
+        const descriptions = {...this.stage.descriptions, primaryText};
+        this.experimentEditor.updateStage({...this.stage, descriptions});
       }
     };
 
@@ -89,8 +89,8 @@ export class BaseStageEditorComponent extends MobxLitElement {
     const update = (e: InputEvent) => {
       const infoText = (e.target as HTMLTextAreaElement).value;
       if (this.stage) {
-        const descriptions = { ...this.stage.descriptions, infoText };
-        this.experimentEditor.updateStage({ ...this.stage, descriptions });
+        const descriptions = {...this.stage.descriptions, infoText};
+        this.experimentEditor.updateStage({...this.stage, descriptions});
       }
     };
 
@@ -111,8 +111,8 @@ export class BaseStageEditorComponent extends MobxLitElement {
     const update = (e: InputEvent) => {
       const helpText = (e.target as HTMLTextAreaElement).value;
       if (this.stage) {
-        const descriptions = { ...this.stage.descriptions, helpText };
-        this.experimentEditor.updateStage({ ...this.stage, descriptions });
+        const descriptions = {...this.stage.descriptions, helpText};
+        this.experimentEditor.updateStage({...this.stage, descriptions});
       }
     };
 
@@ -129,15 +129,89 @@ export class BaseStageEditorComponent extends MobxLitElement {
     `;
   }
 
+  private shouldDisableWaitForAllParticipants(): boolean {
+    if (!this.stage || this.stage.kind !== StageKind.REVEAL) {
+      return false;
+    }
+
+    for (const item of this.stage.items) {
+      // There's a dependency on all participants if we want to reveal all results.
+      if (
+        'revealAudience' in item &&
+        item.revealAudience === RevealAudience.ALL_PARTICIPANTS
+      ) {
+        return true;
+      }
+      if (item.kind === StageKind.RANKING) {
+        const stageId = item.id;
+
+        const foundStage = this.experimentEditor.stages.find(
+          (stage) => stage.id === stageId
+        );
+        // There's a dependency on all participants if we're ranking all participants.
+        if (
+          foundStage &&
+          'rankingType' in foundStage &&
+          foundStage.rankingType === RankingType.PARTICIPANTS
+        ) {
+          return true;
+        }
+
+        // There's a dependency on all participants if there's an election
+        // (so all votes are counted).
+        if (
+          foundStage &&
+          'strategy' in foundStage &&
+          foundStage.strategy === ElectionStrategy.CONDORCET
+        ) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   private renderWaitForAllParticipants() {
     if (!this.stage) return nothing;
     const waitForAllParticipants = this.stage.progress.waitForAllParticipants;
 
     const updateCheck = () => {
       if (!this.stage) return;
-      const progress: StageProgressConfig = { ...this.stage.progress, waitForAllParticipants: !waitForAllParticipants };
-      this.experimentEditor.updateStage({ ...this.stage, progress });
+      const progress: StageProgressConfig = {
+        ...this.stage.progress,
+        waitForAllParticipants: !waitForAllParticipants,
+      };
+      this.experimentEditor.updateStage({...this.stage, progress});
     };
+
+    if (this.shouldDisableWaitForAllParticipants()) {
+      if (!waitForAllParticipants) {
+        const progress: StageProgressConfig = {
+          ...this.stage.progress,
+          waitForAllParticipants: true,
+        };
+        this.experimentEditor.updateStage({...this.stage, progress});
+      }
+
+      return html`
+        <div class="config-item">
+          <div class="checkbox-wrapper">
+            <md-checkbox
+              touch-target="wrapper"
+              ?checked="${true}"
+              ?disabled="${true}"
+            >
+            </md-checkbox>
+            <div>Wait for all participants before starting stage<br/</div>
+            <div class="warning">
+              Because this experiment has a dependency on all participants'
+              responses, this must be enabled.
+            </div>
+          </div>
+        </div>
+      `;
+    }
 
     return html`
       <div class="config-item">
@@ -149,9 +223,7 @@ export class BaseStageEditorComponent extends MobxLitElement {
             @click=${updateCheck}
           >
           </md-checkbox>
-          <div>
-            Wait for all participants before starting stage
-          </div>
+          <div>Wait for all participants before starting stage</div>
         </div>
       </div>
     `;
@@ -163,8 +235,11 @@ export class BaseStageEditorComponent extends MobxLitElement {
 
     const updateCheck = () => {
       if (!this.stage) return;
-      const progress: StageProgressConfig = { ...this.stage.progress, showParticipantProgress: !showParticipantProgress };
-      this.experimentEditor.updateStage({ ...this.stage, progress });
+      const progress: StageProgressConfig = {
+        ...this.stage.progress,
+        showParticipantProgress: !showParticipantProgress,
+      };
+      this.experimentEditor.updateStage({...this.stage, progress});
     };
 
     return html`
@@ -178,7 +253,8 @@ export class BaseStageEditorComponent extends MobxLitElement {
           >
           </md-checkbox>
           <div>
-            Show participant progress (number of participants who have completed stage)
+            Show participant progress (number of participants who have completed
+            stage)
           </div>
         </div>
       </div>
@@ -191,16 +267,17 @@ export class BaseStageEditorComponent extends MobxLitElement {
     const updateNum = (e: InputEvent) => {
       if (!this.stage) return;
       const minParticipants = Number((e.target as HTMLTextAreaElement).value);
-      const progress: StageProgressConfig = { ...this.stage.progress, minParticipants };
-      this.experimentEditor.updateStage({ ...this.stage, progress });
+      const progress: StageProgressConfig = {
+        ...this.stage.progress,
+        minParticipants,
+      };
+      this.experimentEditor.updateStage({...this.stage, progress});
     };
 
     return html`
       <div class="config-item">
         <div class="number-input">
-          <label for="minParticipants">
-            Minimum number of participants
-          </label>
+          <label for="minParticipants"> Minimum number of participants </label>
           <input
             type="number"
             id="minParticipants"

--- a/frontend/src/components/stages/reveal_editor.ts
+++ b/frontend/src/components/stages/reveal_editor.ts
@@ -1,12 +1,12 @@
-
-import "../../pair-components/icon_button";
-import "../../pair-components/menu";
+import '../../pair-components/icon_button';
+import '../../pair-components/menu';
+import '../../pair-components/tooltip';
 
 import '@material/web/checkbox/checkbox.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
 import {
   RevealAudience,
@@ -16,25 +16,23 @@ import {
   StageKind,
   SurveyRevealItem,
   createNewRevealItem,
-} from "@deliberation-lab/utils";
+} from '@deliberation-lab/utils';
 
-import { core } from "../../core/core";
-import { ExperimentEditor } from "../../services/experiment.editor";
+import {core} from '../../core/core';
+import {ExperimentEditor} from '../../services/experiment.editor';
 
-import {
-  getStagesWithReveal
-} from '../../shared/experiment.utils';
+import {getStagesWithReveal} from '../../shared/experiment.utils';
 
-import { styles } from "./reveal_editor.scss";
+import {styles} from './reveal_editor.scss';
 
 /** Reveal stage editor */
-@customElement("reveal-editor")
+@customElement('reveal-editor')
 export class RevealEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly experimentEditor = core.getService(ExperimentEditor);
 
-  @property() stage: RevealStageConfig|undefined = undefined;
+  @property() stage: RevealStageConfig | undefined = undefined;
 
   override render() {
     if (!this.stage) return nothing;
@@ -44,8 +42,8 @@ export class RevealEditor extends MobxLitElement {
         <div class="left">Stages to reveal</div>
         ${this.renderAddMenu()}
       </div>
-      ${this.stage.items.map(
-        (item, index) => this.renderRevealStageItem(item, index)
+      ${this.stage.items.map((item, index) =>
+        this.renderRevealStageItem(item, index)
       )}
     `;
   }
@@ -53,16 +51,49 @@ export class RevealEditor extends MobxLitElement {
   private renderAddMenu() {
     if (!this.stage) return nothing;
 
-    const stageOptions = getStagesWithReveal(this.experimentEditor.stages).filter(
-      stage => stage.id !== this.stage?.id
-    );
+    // Get all stages with a reveal stage.
+    // Get all stages with a reveal stage.
+    const getStageOptions = () => {
+      const revealStages = getStagesWithReveal(
+        this.experimentEditor.stages
+      ).filter((stage) => stage.id !== this.stage?.id);
+
+      // Get the current stage index.
+      const currentStageIndex = this.experimentEditor.stages.findIndex(
+        (stage) => stage.id === this.stage!.id
+      );
+
+      // Filter stages to only those before the current stage index.
+      const filteredStages = revealStages.filter((stage) => {
+        const stageIndex = this.experimentEditor.stages.findIndex(
+          (expStage) => expStage.id === stage.id
+        );
+        return stageIndex < currentStageIndex;
+      });
+
+      return filteredStages;
+    };
+
+    const stageOptions = getStageOptions();
+    if (stageOptions.length === 0) {
+      return html`
+        <pr-tooltip
+          position="TOP_END"
+          text="No stages available. Only survey and election stages that precede this stage can be revealed."
+        >
+          <pr-menu name="Add stage" ?disabled=${true}></pr-menu>
+        </pr-tooltip>
+      `;
+    }
 
     return html`
-      <pr-menu name="Add stage" ?disabled=${!this.experimentEditor.canEditStages}>
+      <pr-menu
+        name="Add stage"
+        ?disabled=${!this.experimentEditor.canEditStages}
+      >
         <div class="menu-wrapper">
           <div class="stages">
-            ${stageOptions.length === 0 ? html`<div class="empty-message">No stages available</div>` : nothing}
-            ${stageOptions.map(stage => this.renderAddRevealStage(stage))}
+            ${stageOptions.map((stage) => this.renderAddRevealStage(stage))}
           </div>
         </div>
       </pr-menu>
@@ -79,12 +110,12 @@ export class RevealEditor extends MobxLitElement {
       const items = [...this.stage.items, item];
       this.experimentEditor.updateStage({
         ...this.stage,
-        items
+        items,
       });
     };
 
     const stageIndex = this.experimentEditor.stages.findIndex(
-      s => s.id === stage.id
+      (s) => s.id === stage.id
     );
 
     return html`
@@ -122,7 +153,7 @@ export class RevealEditor extends MobxLitElement {
 
       this.experimentEditor.updateStage({
         ...this.stage,
-        items
+        items,
       });
     };
 
@@ -138,7 +169,7 @@ export class RevealEditor extends MobxLitElement {
 
       this.experimentEditor.updateStage({
         ...this.stage,
-        items
+        items,
       });
     };
 
@@ -147,18 +178,18 @@ export class RevealEditor extends MobxLitElement {
 
       const items = [
         ...this.stage.items.slice(0, index),
-        ...this.stage.items.slice(index + 1)
+        ...this.stage.items.slice(index + 1),
       ];
 
       this.experimentEditor.updateStage({
         ...this.stage,
-        items
+        items,
       });
     };
 
     const stage = this.experimentEditor.getStage(item.id);
     const stageIndex = this.experimentEditor.stages.findIndex(
-      stage => stage.id === item.id
+      (stage) => stage.id === item.id
     );
     if (!this.stage || !stage) return nothing;
 
@@ -176,9 +207,7 @@ export class RevealEditor extends MobxLitElement {
     return html`
       <div class="reveal-stage">
         <div class="header">
-          <div class="label">
-            ${stageIndex + 1}. ${stage.name}
-          </div>
+          <div class="label">${stageIndex + 1}. ${stage.name}</div>
           <div class="buttons">
             <pr-icon-button
               color="neutral"
@@ -196,7 +225,8 @@ export class RevealEditor extends MobxLitElement {
               padding="small"
               size="small"
               variant="default"
-              ?disabled=${index === this.stage.items.length - 1 || !this.experimentEditor.canEditStages}
+              ?disabled=${index === this.stage.items.length - 1 ||
+              !this.experimentEditor.canEditStages}
               @click=${handleMoveDown}
             >
             </pr-icon-button>
@@ -220,13 +250,10 @@ export class RevealEditor extends MobxLitElement {
             @click=${toggleRevealAllParticipants}
           >
           </md-checkbox>
-          <div>
-            Reveal selections by all participants within the
-            cohort
-          </div>
+          <div>Reveal selections by all participants within the cohort</div>
         </div>
-        ${item.kind === StageKind.SURVEY ?
-          this.renderSurveyRevealSettings(item, index)
+        ${item.kind === StageKind.SURVEY
+          ? this.renderSurveyRevealSettings(item, index)
           : nothing}
       </div>
     `;
@@ -238,7 +265,10 @@ export class RevealEditor extends MobxLitElement {
     const revealScorableOnly = item.revealScorableOnly;
 
     const toggleRevealScorableOnly = () => {
-      this.updateRevealItem({...item, revealScorableOnly: !revealScorableOnly}, index);
+      this.updateRevealItem(
+        {...item, revealScorableOnly: !revealScorableOnly},
+        index
+      );
     };
 
     return html`
@@ -260,6 +290,6 @@ export class RevealEditor extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "reveal-editor": RevealEditor;
+    'reveal-editor': RevealEditor;
   }
 }

--- a/frontend/src/components/stages/reveal_editor.ts
+++ b/frontend/src/components/stages/reveal_editor.ts
@@ -21,7 +21,9 @@ import {
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
 
-import {getStagesWithReveal} from '../../shared/experiment.utils';
+import {
+  getPrecedingRevealableStages,
+} from '../../shared/experiment.utils';
 
 import {styles} from './reveal_editor.scss';
 
@@ -51,52 +53,27 @@ export class RevealEditor extends MobxLitElement {
   private renderAddMenu() {
     if (!this.stage) return nothing;
 
-    // Get all stages with a reveal stage.
-    // Get all stages with a reveal stage.
-    const getStageOptions = () => {
-      const revealStages = getStagesWithReveal(
-        this.experimentEditor.stages
-      ).filter((stage) => stage.id !== this.stage?.id);
-
-      // Get the current stage index.
-      const currentStageIndex = this.experimentEditor.stages.findIndex(
-        (stage) => stage.id === this.stage!.id
-      );
-
-      // Filter stages to only those before the current stage index.
-      const filteredStages = revealStages.filter((stage) => {
-        const stageIndex = this.experimentEditor.stages.findIndex(
-          (expStage) => expStage.id === stage.id
-        );
-        return stageIndex < currentStageIndex;
-      });
-
-      return filteredStages;
-    };
-
-    const stageOptions = getStageOptions();
-    if (stageOptions.length === 0) {
-      return html`
-        <pr-tooltip
-          position="TOP_END"
-          text="No stages available. Only survey and election stages that precede this stage can be revealed."
-        >
-          <pr-menu name="Add stage" ?disabled=${true}></pr-menu>
-        </pr-tooltip>
-      `;
-    }
-
+    const stageOptions = getPrecedingRevealableStages(
+      this.stage?.id,
+      this.experimentEditor.stages
+    );
+    const noAvailableStages = stageOptions.length === 0;
+    const tooltipText = noAvailableStages
+      ? 'No stages available. Only survey and election stages that precede this stage can be revealed.'
+      : '';
     return html`
-      <pr-menu
-        name="Add stage"
-        ?disabled=${!this.experimentEditor.canEditStages}
-      >
-        <div class="menu-wrapper">
-          <div class="stages">
-            ${stageOptions.map((stage) => this.renderAddRevealStage(stage))}
+      <pr-tooltip position="TOP_END" text=${tooltipText}>
+        <pr-menu
+          name="Add stage"
+          ?disabled=${!this.experimentEditor.canEditStages || noAvailableStages}
+        >
+          <div class="menu-wrapper">
+            <div class="stages">
+              ${stageOptions.map((stage) => this.renderAddRevealStage(stage))}
+            </div>
           </div>
-        </div>
-      </pr-menu>
+        </pr-menu>
+      </pr-tooltip>
     `;
   }
 

--- a/frontend/src/components/stages/transfer_view.ts
+++ b/frontend/src/components/stages/transfer_view.ts
@@ -55,28 +55,16 @@ export class TransferView extends MobxLitElement {
     return html`
       <stage-description .stage=${this.stage}></stage-description>
 
-      ${this.renderCountdown()} ${this.renderOverlay()}
+      ${this.renderCountdown()}
     `;
-  }
-
-  private renderOverlay() {
-    if (
-      !this.stage?.enableTimeout ||
-      this.participantService.completedStage(this.stage.id ?? '') ||
-      this.authService.isExperimenter
-    )
-      return;
-
-    // Temporary solution: Prevent participant from clicking to other
-    // stages and resetting the transfer countdown
-    return html`<div class="overlay"></div>`;
   }
 
   private renderCountdown() {
     if (
       !this.stage?.enableTimeout ||
       this.participantService.completedStage(this.stage.id ?? '')
-    ) return;
+    )
+      return;
 
     const minutes = Math.floor(this.timeRemainingSeconds / 60);
     const seconds = this.timeRemainingSeconds % 60;
@@ -92,8 +80,8 @@ export class TransferView extends MobxLitElement {
       <div class="transfer-wrapper">
         If the transfer cannot be completed, the experiment will end in:
         <span style="font-weight: bold; color: ${timeColor};">
-          ${minutes}:${seconds.toString().padStart(2, '0')} (mm:ss)
-        </span>.
+          ${minutes}:${seconds.toString().padStart(2, '0')} (mm:ss) </span
+        >.
       </div>
     `;
   }

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -1,4 +1,4 @@
-  import {
+import {
   AttentionCheckConfig,
   CohortParticipantConfig,
   Experiment,
@@ -14,16 +14,15 @@
   createProlificConfig,
   generateId,
 } from '@deliberation-lab/utils';
-import { Timestamp } from 'firebase/firestore';
+import {Timestamp} from 'firebase/firestore';
 import {computed, makeObservable, observable} from 'mobx';
-import {
-  writeExperimentCallable,
-} from '../shared/callables';
+import {writeExperimentCallable} from '../shared/callables';
 
 import {AuthService} from './auth.service';
 import {ExperimentManager} from './experiment.manager';
 import {FirebaseService} from './firebase.service';
 import {Service} from './service';
+import {mustWaitForAllParticipants} from '../shared/experiment.utils';
 
 interface ServiceProvider {
   authService: AuthService;
@@ -64,8 +63,10 @@ export class ExperimentEditor extends Service {
   }
 
   @computed get isCreator() {
-    return this.sp.authService.userId === this.experiment.metadata.creator
-      || this.experiment.metadata.creator === '';
+    return (
+      this.sp.authService.userId === this.experiment.metadata.creator ||
+      this.experiment.metadata.creator === ''
+    );
   }
 
   isInitializedExperiment() {
@@ -77,31 +78,34 @@ export class ExperimentEditor extends Service {
   }
 
   updatePermissions(permissions: Partial<PermissionsConfig>) {
-    this.experiment.permissions = {...this.experiment.permissions, ...permissions};
+    this.experiment.permissions = {
+      ...this.experiment.permissions,
+      ...permissions,
+    };
   }
 
   updateCohortConfig(config: Partial<CohortParticipantConfig>) {
     this.experiment.defaultCohortConfig = {
       ...this.experiment.defaultCohortConfig,
-      ...config
+      ...config,
     };
   }
 
   updateAttentionCheckConfig(config: Partial<AttentionCheckConfig>) {
     this.experiment.attentionCheckConfig = {
       ...this.experiment.attentionCheckConfig,
-      ...config
+      ...config,
     };
   }
 
   updateProlificConfig(config: Partial<ProlificConfig>) {
     this.experiment.prolificConfig = {
       ...this.experiment.prolificConfig,
-      ...config
+      ...config,
     };
   }
 
-  setCurrentStageId(id: string|undefined) {
+  setCurrentStageId(id: string | undefined) {
     this.currentStageId = id;
   }
 
@@ -112,7 +116,7 @@ export class ExperimentEditor extends Service {
   }
 
   @computed get currentStage() {
-    return this.stages.find(stage => stage.id === this.currentStageId);
+    return this.stages.find((stage) => stage.id === this.currentStageId);
   }
 
   hasStageKind(kind: StageKind) {
@@ -120,22 +124,27 @@ export class ExperimentEditor extends Service {
   }
 
   updateStage(newStage: StageConfig) {
-    const index = this.stages.findIndex(stage => stage.id === newStage.id);
+    const index = this.stages.findIndex((stage) => stage.id === newStage.id);
     if (index >= 0) {
       this.stages[index] = newStage;
     }
   }
 
   setStages(stages: StageConfig[]) {
-    this.stages = stages;
+    for (let stage of stages) {
+      this.addStage(stage);
+    }
   }
 
   addStage(stage: StageConfig) {
     this.stages.push(stage);
+    if (mustWaitForAllParticipants(stage, this.stages)) {
+      stage.progress.waitForAllParticipants = true;
+    }
   }
 
   getStage(stageId: string) {
-    return this.stages.find(stage => stage.id === stageId);
+    return this.stages.find((stage) => stage.id === stageId);
   }
 
   deleteStage(index: number) {
@@ -191,11 +200,14 @@ export class ExperimentEditor extends Service {
     // Update date modified
     this.experiment.metadata.dateModified = Timestamp.now();
 
-    const response = await writeExperimentCallable(this.sp.firebaseService.functions, {
-      collectionName: 'experiments',
-      experimentConfig: this.experiment,
-      stageConfigs: this.stages,
-    });
+    const response = await writeExperimentCallable(
+      this.sp.firebaseService.functions,
+      {
+        collectionName: 'experiments',
+        experimentConfig: this.experiment,
+        stageConfigs: this.stages,
+      }
+    );
 
     this.isWritingExperiment = false;
     return response;

--- a/frontend/src/shared/experiment.utils.ts
+++ b/frontend/src/shared/experiment.utils.ts
@@ -134,3 +134,13 @@ export function mustWaitForAllParticipants(
   }
   return false;
 }
+
+/** If must wait for all participants, set waitForAllParticipants in stage. */
+export function setMustWaitForAllParticipants(
+  stage: StageConfig,
+  allStages: StageConfig[]
+) {
+  if (mustWaitForAllParticipants(stage, allStages)) {
+    stage.progress.waitForAllParticipants = true;
+  }
+}

--- a/frontend/src/shared/experiment.utils.ts
+++ b/frontend/src/shared/experiment.utils.ts
@@ -1,8 +1,11 @@
 import {
+  ElectionStrategy,
   Experiment,
+  RevealAudience,
+  RankingType,
   StageConfig,
   StageKind,
-  Visibility
+  Visibility,
 } from '@deliberation-lab/utils';
 import {convertUnifiedTimestampToDate} from './utils';
 import {GalleryItem} from './types';
@@ -24,13 +27,14 @@ export function convertExperimentToGalleryItem(
     isPublic: experiment.permissions.visibility === Visibility.PUBLIC,
     isStarred: false, // TODO: Find user isStarred value
     tags: experiment.metadata.tags,
-  }
+  };
 }
 
 /** Return stages that support reveal views. */
 export function getStagesWithReveal(stages: StageConfig[]) {
   return stages.filter(
-    stage => stage.kind === StageKind.SURVEY || stage.kind === StageKind.RANKING
+    (stage) =>
+      stage.kind === StageKind.SURVEY || stage.kind === StageKind.RANKING
   );
 }
 
@@ -50,4 +54,83 @@ export function getPublicExperimentName(
 ) {
   if (!experiment) return defaultValue;
   return experiment.metadata.publicName.length > 0 ? experiment.metadata.publicName : defaultValue;
+}
+
+/** Returns all survey or election stages preceding the stage with the current ID. */
+export function getPrecedingRevealableStages(
+  currentStageId: string,
+  currentStages: StageConfig[]
+): StageConfig[] {
+  const revealStages = getStagesWithReveal(currentStages).filter(
+    (stage) => stage.id !== currentStageId
+  );
+
+  // Get the current stage index.
+  const currentStageIndex = currentStages.findIndex(
+    (stage) => stage.id === currentStageId
+  );
+
+  // Filter stages to only those before the current stage index.
+  const filteredStages = revealStages.filter((stage) => {
+    const stageIndex = currentStages.findIndex(
+      (expStage) => expStage.id === stage.id
+    );
+    return stageIndex < currentStageIndex;
+  });
+
+  return filteredStages;
+}
+
+/** Get experiment name (or default value if field is empty). */
+export function getExperimentName(
+  experiment: Experiment,
+  defaultValue = 'Experiment'
+) {
+  return experiment.metadata.name.length > 0
+    ? experiment.metadata.name
+    : defaultValue;
+}
+
+/* Returns whether the current stage must wait for all participants due to previous dependencies. */
+export function mustWaitForAllParticipants(
+  stage: StageConfig,
+  allStages: StageConfig[]
+): boolean {
+  if (!stage || stage.kind !== StageKind.REVEAL) {
+    return false;
+  }
+
+  for (const item of stage.items) {
+    // There's a dependency on all participants if we want to reveal all results.
+    if (
+      'revealAudience' in item &&
+      item.revealAudience === RevealAudience.ALL_PARTICIPANTS
+    ) {
+      return true;
+    }
+    if (item.kind === StageKind.RANKING) {
+      const stageId = item.id;
+
+      const foundStage = allStages.find((stage) => stage.id === stageId);
+      // There's a dependency on all participants if we're ranking all participants.
+      if (
+        foundStage &&
+        'rankingType' in foundStage &&
+        foundStage.rankingType === RankingType.PARTICIPANTS
+      ) {
+        return true;
+      }
+
+      // There's a dependency on all participants if there's an election
+      // (so all votes are counted).
+      if (
+        foundStage &&
+        'strategy' in foundStage &&
+        foundStage.strategy === ElectionStrategy.CONDORCET
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Fixes #241 

* Disable editing "Wait for all participants" in reveal stage under specific conditions.
* Only allow revealing preceding stages (#241).
* Get rid of lock overlay on transfer stage.
* Font improvements.