### PR TITLE
Add ability to configure JSON and show debugging for mediators

### DIFF
--- a/frontend/src/components/experimenter/experimenter_data_editor.ts
+++ b/frontend/src/components/experimenter/experimenter_data_editor.ts
@@ -32,6 +32,7 @@ export class ExperimenterDataEditor extends MobxLitElement {
       this.authService.writeExperimenterData({...data, apiKeys});
     };
 
+    // TODO: Make this more clear when this has been saved.
     return html`
       <div class="section">
         <div class="title">API keys</div>

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -8,12 +8,12 @@
 }
 
 .panel-wrapper {
-  @include common.flex-column;
+  @include common.flex-row;
   background: var(--md-sys-color-surface);
   border-left: 1px solid var(--md-sys-color-outline-variant-high);
   flex-shrink: 0;
   height: 100%;
-  width: common.$sidenav-width;
+  width: calc(common.$sidenav-width + common.$sidenav-closed-width);
 
   &.closed {
     width: common.$sidenav-closed-width;
@@ -31,7 +31,7 @@
   @include common.flex-column-align-center;
   border-right: 1px solid var(--md-sys-color-outline-variant);
   flex-shrink: 0;
-  gap: common.$spacing-small;
+  gap: common.$spacing-medium;
   padding: common.$sidenav-padding;
   width: common.$sidenav-closed-width;
 }
@@ -40,17 +40,13 @@
   @include common.flex-column;
   flex-grow: 1;
   gap: common.$spacing-large;
-  padding: common.$sidenav-padding;
 }
 
 .header {
   @include common.flex-row-align-center;
-}
-
-.title {
-  @include common.flex-row-align-center;
   @include typescale.label-large;
   flex-shrink: 0;
+  height: 40px;
 }
 
 .top {

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -51,7 +51,7 @@
 
 .top {
   @include common.flex-column;
-  gap: common.$spacing-small;
+  gap: common.$spacing-large;
   overflow: auto;
   padding: common.$sidenav-padding;
 }
@@ -62,4 +62,35 @@
   gap: common.$spacing-small;
   overflow: auto;
   padding: common.$sidenav-padding;
+}
+
+.mediator {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
+.debug {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  word-break: break-all;
+
+  &.error {
+    color: var(--md-sys-color-error);
+  }
+}
+
+.mediator-title {
+  @include typescale.title-small;
+}
+
+.prompt-box {
+  @include common.flex-column;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-medium;
+  padding: common.$spacing-large;
+}
+
+.action-bar {
+  @include common.flex-row;
+  justify-content: end;
 }

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -40,6 +40,7 @@ export class Panel extends MobxLitElement {
   private readonly routerService = core.getService(RouterService);
 
   @state() panelView: PanelView = PanelView.MANUAL_CHAT;
+  @state() isLoading = false;
 
   override render() {
     if (!this.authService.isExperimenter) {
@@ -203,7 +204,12 @@ export class Panel extends MobxLitElement {
               padding="small"
               size="small"
               variant="tonal"
-              disabled
+              ?loading=${this.isLoading}
+              @click=${async () => {
+                this.isLoading = true;
+                await this.mediatorEditor.saveChatMediators(stageId)
+                this.isLoading = false;
+              }}
             >
               Update prompt
             </pr-button>

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -187,6 +187,7 @@ export class Header extends MobxLitElement {
   private renderActions() {
     const activePage = this.routerService.activePage;
 
+    // TODO: Refactor pr-buttons into separate render stages
     switch (activePage) {
       case Pages.EXPERIMENT_CREATE:
         return html`
@@ -316,9 +317,34 @@ export class Header extends MobxLitElement {
             </pr-icon-button>
           </pr-tooltip>
         `;
+      case Pages.PARTICIPANT_STAGE:
+        return this.renderDebugModeButton();
       default:
         return nothing;
     }
+  }
+
+  private renderDebugModeButton() {
+    if (!this.authService.isExperimenter) return nothing;
+
+    const debugMode = this.authService.isDebugMode;
+    const tooltipText = `
+      Turn debug mode ${debugMode ? 'off' : 'on'}.
+      (When on, experimenters can debugging statements in participant preview.
+      Note that only some stages have debugging statements.)
+    `;
+
+    return html`
+      <pr-tooltip text=${tooltipText} position="BOTTOM_END">
+        <pr-icon-button
+          icon=${debugMode ? 'code_off' : 'code'}
+          color="neutral"
+          variant="default"
+          @click=${() => { this.authService.setDebugMode(!debugMode); }}
+        >
+        </pr-icon-button>
+      </pr-tooltip>
+    `;
   }
 }
 

--- a/frontend/src/components/stages/chat_editor.scss
+++ b/frontend/src/components/stages/chat_editor.scss
@@ -29,6 +29,13 @@
   font-style: italic;
 }
 
+.notification {
+  @include typescale.label-small;
+  background: var(--md-sys-color-surface-container);
+  border-radius: common.$spacing-medium;
+  color: var(--md-sys-color-on-surface-container);
+  padding: common.$spacing-small common.$spacing-medium;
+}
 .warning {
   @include typescale.label-small;
   background: var(--md-sys-color-error-container);

--- a/frontend/src/components/stages/chat_editor.scss
+++ b/frontend/src/components/stages/chat_editor.scss
@@ -36,6 +36,7 @@
   color: var(--md-sys-color-on-surface-container);
   padding: common.$spacing-small common.$spacing-medium;
 }
+
 .warning {
   @include typescale.label-small;
   background: var(--md-sys-color-error-container);
@@ -77,6 +78,16 @@
   flex-wrap: wrap;
   gap: common.$spacing-xl;
   max-width: 500px;
+}
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
 }
 
 pr-textarea {

--- a/frontend/src/components/stages/chat_editor.ts
+++ b/frontend/src/components/stages/chat_editor.ts
@@ -5,6 +5,8 @@ import {customElement, property} from 'lit/decorators.js';
 import '@material/web/checkbox/checkbox.js';
 
 import {core} from '../../core/core';
+import {AuthService} from '../../services/auth.service';
+
 import {ExperimentEditor} from '../../services/experiment.editor';
 
 import {
@@ -25,6 +27,8 @@ export class ChatEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly experimentEditor = core.getService(ExperimentEditor);
+  private readonly authService = core.getService(AuthService);
+
 
   @property() stage: ChatStageConfig|undefined = undefined;
 
@@ -33,7 +37,25 @@ export class ChatEditor extends MobxLitElement {
       return nothing;
     }
 
+    // Check if experimenter's API key exists
+    let apiCheck;
+    if (!this.authService.experimenterData?.apiKeys.geminiKey) {
+      apiCheck = html`
+        <div class="warning">
+          <b>Note:</b> In order for LLM calls to work,
+          you must add your Gemini API key under Settings.
+        </div>
+      `;
+    } else {
+      apiCheck = html`
+        <div class="notification">
+          <b>✅ A Gemini API key has been added. If it is valid, LLM calls will work.
+        </div>
+      `;
+    }
+
     return html`
+      ${apiCheck}
       ${this.stage.mediators.map(
         (mediator, index) => this.renderMediator(mediator, index)
       )}
@@ -189,14 +211,9 @@ export class ChatEditor extends MobxLitElement {
     const onDelete = () => {
       this.deleteMediator(index);
     };
-
     return html`
       <div class="question-wrapper">
         <div class="question-label">Mediator ${index + 1}</div>
-        <div class="warning">
-          <b>Note:</b> In order for LLM mediator calls to work,
-          you must add your Gemini API key under Settings.
-        </div>
         <div class="question">
           <div class="header">
             <div class="left">

--- a/frontend/src/components/stages/chat_editor.ts
+++ b/frontend/src/components/stages/chat_editor.ts
@@ -13,6 +13,7 @@ import {
   ChatStageConfig,
   StageKind,
   MediatorConfig,
+  MediatorResponseConfig,
   createMediatorConfig,
 } from '@deliberation-lab/utils';
 import {
@@ -230,8 +231,68 @@ export class ChatEditor extends MobxLitElement {
           </div>
           ${this.renderAvatars(mediator, index)}
           ${this.renderMediatorPrompt(mediator, index)}
+          ${this.renderMediatorResponseConfig(mediator, index)}
         </div>
       </div>
+    `;
+  }
+
+  private renderMediatorResponseConfig(
+    mediator: MediatorConfig,
+    index: number
+  ) {
+    const config = mediator.responseConfig;
+    const updateConfig = (responseConfig: MediatorResponseConfig) => {
+      this.updateMediator({ ...mediator, responseConfig }, index);
+    };
+    const updateJSON = () => {
+      updateConfig({ ...config, isJSON: !config.isJSON });
+    };
+    const updateMessageField = (e: InputEvent) => {
+      const messageField = (e.target as HTMLTextAreaElement).value;
+      updateConfig({ ...config, messageField })
+    };
+    const updateExplanationField = (e: InputEvent) => {
+      const explanationField = (e.target as HTMLTextAreaElement).value;
+      updateConfig({ ...config, explanationField })
+    };
+
+    return html`
+      <div class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${config.isJSON}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @click=${updateJSON}
+        >
+        </md-checkbox>
+        <div>
+          Parse mediator response as JSON (tip: include appropriate
+          instructions/examples in prompt so that valid JSON is returned)
+        </div>
+      </div>
+      ${!config.isJSON ? nothing : html`
+        <pr-textarea
+          label="JSON field to extract chat message from"
+          placeholder="JSON field to extract chat message from"
+          variant="outlined"
+          .value=${config.messageField}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @input=${updateMessageField}
+        >
+        </pr-textarea>
+      `}
+      ${!config.isJSON ? nothing : html`
+        <pr-textarea
+          label="JSON field to extract debugging explanation from"
+          placeholder="JSON field to extract debugging explanation from"
+          variant="outlined"
+          .value=${config.explanationField}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @input=${updateExplanationField}
+        >
+        </pr-textarea>
+      `}
     `;
   }
 }

--- a/frontend/src/components/stages/chat_message.scss
+++ b/frontend/src/components/stages/chat_message.scss
@@ -93,3 +93,8 @@ $bubble-radius-small: common.$spacing-small;
     width: 100%;
   }
 }
+
+.debug {
+  @include typescale.label-small;
+  color: var(--md-sys-color-tertiary);
+}

--- a/frontend/src/components/stages/chat_message.ts
+++ b/frontend/src/components/stages/chat_message.ts
@@ -10,6 +10,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { Timestamp } from "firebase/firestore";
 
 import { core } from "../../core/core";
+import { AuthService } from "../../services/auth.service";
 import { ExperimentService } from "../../services/experiment.service";
 import { ParticipantService } from "../../services/participant.service";
 
@@ -31,6 +32,7 @@ import { styles } from "./chat_message.scss";
 export class ChatMessageComponent extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly authService = core.getService(AuthService);
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
@@ -64,7 +66,7 @@ export class ChatMessageComponent extends MobxLitElement {
     return html`
       <div class=${classes}>
         <profile-avatar .emoji=${profile.avatar}></profile-avatar>
-          <div class="content">
+        <div class="content">
           <div class="label">
             ${profile.name ?? chatMessage.participantPublicId}
             ${profile.pronouns ? `(${profile.pronouns})` : ""}
@@ -81,7 +83,7 @@ export class ChatMessageComponent extends MobxLitElement {
     return html`
       <div class="chat-message">
         <profile-avatar .emoji=${profile.avatar}></profile-avatar>
-          <div class="content">
+        <div class="content">
           <div class="label">
             ${profile.name}
           </div>
@@ -97,12 +99,23 @@ export class ChatMessageComponent extends MobxLitElement {
     return html`
       <div class="chat-message">
         <profile-avatar .emoji=${profile.avatar}></profile-avatar>
-          <div class="content">
+        <div class="content">
           <div class="label">
             ${profile.name}
           </div>
           <div class="chat-bubble">${chatMessage.message}</div>
+          ${this.renderDebuggingExplanation(chatMessage)}
         </div>
+      </div>
+    `;
+  }
+
+  renderDebuggingExplanation(chatMessage: AgentMediatorChatMessage) {
+    if (!this.authService.isDebugMode) return nothing;
+
+    return html`
+      <div class="debug">
+        ${chatMessage.explanation}
       </div>
     `;
   }

--- a/frontend/src/components/stages/chat_panel.scss
+++ b/frontend/src/components/stages/chat_panel.scss
@@ -16,11 +16,10 @@
 .panel-item-title {
   @include typescale.title-small;
 }
+
 .panel-item-subtitle {
-  margin-top: -4px;
-  font-size: 12px;
-  font-style: italic;
-  color: var(--md-sys-color-secondary);
+  @include typescale.label-small;
+  color: var(--md-sys-color-tertiary);
 }
 
 .profile {

--- a/frontend/src/components/stages/chat_panel.scss
+++ b/frontend/src/components/stages/chat_panel.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -15,6 +15,12 @@
 
 .panel-item-title {
   @include typescale.title-small;
+}
+.panel-item-subtitle {
+  margin-top: -4px;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--md-sys-color-secondary);
 }
 
 .profile {

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -1,3 +1,4 @@
+import '../../pair-components/tooltip';
 import './stage_description';
 import './stage_footer';
 
@@ -6,15 +7,15 @@ import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
+import {AuthService} from '../../services/auth.service';
 import {CohortService} from '../../services/cohort.service';
 
 import {
   ChatStageConfig,
+  MediatorConfig,
   ParticipantProfile,
 } from '@deliberation-lab/utils';
-import {
-  isActiveParticipant
-} from '../../shared/participant.utils';
+import {isActiveParticipant} from '../../shared/participant.utils';
 
 import {styles} from './chat_panel.scss';
 
@@ -23,6 +24,7 @@ import {styles} from './chat_panel.scss';
 export class ChatPanel extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly authService = core.getService(AuthService);
   private readonly cohortService = core.getService(CohortService);
 
   @property() stage: ChatStageConfig | null = null;
@@ -34,7 +36,25 @@ export class ChatPanel extends MobxLitElement {
 
     return html`
       <stage-description .stage=${this.stage}></stage-description>
-      ${this.renderParticipantList()}
+      ${this.renderParticipantList()} ${this.renderMediatorsList()}
+    `;
+  }
+
+  private renderMediatorsList() {
+    if (!this.authService.isExperimenter || !this.stage) {
+      return;
+    }
+
+    const mediators = this.stage.mediators;
+    if (!mediators) {
+      return;
+    }
+    return html`
+      <div class="panel-item">
+        <div class="panel-item-title">Agents (${mediators.length})</div>
+        <div class="panel-item-subtitle">Only visible to experimenters</div>
+        ${mediators.map((mediator) => this.renderMediator(mediator))}
+      </div>
     `;
   }
 
@@ -45,13 +65,23 @@ export class ChatPanel extends MobxLitElement {
         <div class="panel-item-title">
           Participants (${activeParticipants.length})
         </div>
-        ${activeParticipants.map(
-          participant => this.renderProfile(participant)
+        ${activeParticipants.map((participant) =>
+          this.renderProfile(participant)
         )}
       </div>
     `;
   }
 
+  private renderMediator(mediator: MediatorConfig) {
+    return html`
+      <pr-tooltip text=${mediator.prompt} position="BOTTOM_END">
+        <div class="profile">
+          <profile-avatar .emoji=${mediator.avatar}> </profile-avatar>
+          <div class="name">${mediator.name}</div>
+        </div>
+      </pr-tooltip>
+    `;
+  }
   private renderProfile(profile: ParticipantProfile) {
     return html`
       <div class="profile">

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -41,14 +41,13 @@ export class ChatPanel extends MobxLitElement {
   }
 
   private renderMediatorsList() {
-    if (!this.authService.isExperimenter || !this.stage) {
+    if (!this.authService.isDebugMode || !this.stage) {
       return;
     }
 
     const mediators = this.stage.mediators;
-    if (!mediators) {
-      return;
-    }
+    if (!mediators) return;
+
     return html`
       <div class="panel-item">
         <div class="panel-item-title">Agents (${mediators.length})</div>
@@ -76,12 +75,13 @@ export class ChatPanel extends MobxLitElement {
     return html`
       <pr-tooltip text=${mediator.prompt} position="BOTTOM_END">
         <div class="profile">
-          <profile-avatar .emoji=${mediator.avatar}> </profile-avatar>
+          <profile-avatar .emoji=${mediator.avatar}></profile-avatar>
           <div class="name">${mediator.name}</div>
         </div>
       </pr-tooltip>
     `;
   }
+
   private renderProfile(profile: ParticipantProfile) {
     return html`
       <div class="profile">

--- a/frontend/src/service_provider.ts
+++ b/frontend/src/service_provider.ts
@@ -7,6 +7,7 @@ import { FirebaseService } from "./services/firebase.service";
 import { HomeService } from "./services/home.service";
 import { ImageService } from "./services/image.service";
 import { InitializationService } from "./services/initialization.service";
+import { MediatorEditor } from "./services/mediator.editor";
 import { ParticipantService } from "./services/participant.service";
 import { ParticipantAnswerService } from "./services/participant.answer";
 import { RouterService } from "./services/router.service";
@@ -42,6 +43,9 @@ export function makeServiceProvider(self: Core) {
     },
     get initializationService() {
       return self.getService(InitializationService);
+    },
+    get mediatorEditor() {
+      return self.getService(MediatorEditor);
     },
     get participantService() {
       return self.getService(ParticipantService);

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -64,6 +64,8 @@ export class AuthService extends Service {
   @observable isExperimenter: boolean|null = null;
   @observable canEdit = false;
 
+  @observable private debugMode = false;
+
   @observable unsubscribe: Unsubscribe[] = [];
   @observable experimenterData: ExperimenterData|null = null;
   @observable isExperimentDataLoading = false;
@@ -78,6 +80,16 @@ export class AuthService extends Service {
 
   @computed get authenticated() {
     return this.initialAuthCheck && this.user !== null;
+  }
+
+  // If true and is experimenter, show debugging components
+  // in experimenter preview
+  @computed get isDebugMode() {
+    return this.isExperimenter && this.debugMode;
+  }
+
+  setDebugMode(debugMode: boolean) {
+    this.debugMode = debugMode;
   }
 
   subscribe() {

--- a/frontend/src/services/mediator.editor.ts
+++ b/frontend/src/services/mediator.editor.ts
@@ -1,0 +1,83 @@
+import {
+  ChatStageConfig,
+  Experiment,
+  StageConfig,
+  StageKind
+} from '@deliberation-lab/utils';
+import { Timestamp } from 'firebase/firestore';
+import {computed, makeObservable, observable} from 'mobx';
+
+import {AuthService} from './auth.service';
+import {ExperimentManager} from './experiment.manager';
+import {FirebaseService} from './firebase.service';
+import {Service} from './service';
+
+import {MediatorConfig} from '@deliberation-lab/utils';
+
+interface ServiceProvider {
+  authService: AuthService;
+  experimentManager: ExperimentManager;
+  firebaseService: FirebaseService;
+}
+
+/**
+ * Manage live mediator editing in experimenter panel.
+ */
+export class MediatorEditor extends Service {
+  constructor(private readonly sp: ServiceProvider) {
+    super();
+    makeObservable(this);
+  }
+
+  // Experiment ID
+  @observable experimentId: string|null = null;
+  // Stage ID to chat config
+  @observable configMap: Record<string, ChatStageConfig> = {};
+
+  setExperimentId(id: string) {
+    this.experimentId = id;
+  }
+
+  getMediators(stageId: string): MediatorConfig[] {
+    return this.configMap[stageId]?.mediators ?? [];
+  }
+
+  addConfig(config: ChatStageConfig) {
+    this.configMap[config.id] = config;
+  }
+
+  updateConfig(config: ChatStageConfig) {
+    this.configMap[config.id] = config;
+  }
+
+  updateMediator(
+    stageId: string,
+    mediator: MediatorConfig,
+    index: number
+  ) {
+    const config = this.configMap[stageId];
+    if (!config) return;
+
+    const mediators = [
+      ...config.mediators.slice(0, index),
+      mediator,
+      ...config.mediators.slice(index + 1)
+    ];
+
+    this.updateConfig({
+      ...config,
+      mediators,
+    });
+  }
+
+  reset() {
+    this.experimentId = null;
+    this.configMap = {};
+  }
+
+  // *********************************************************************** //
+  // FIRESTORE                                                               //
+  // *********************************************************************** //
+
+  // TODO: Add callable for mediator configs
+}

--- a/frontend/src/services/mediator.editor.ts
+++ b/frontend/src/services/mediator.editor.ts
@@ -7,16 +7,13 @@ import {
 import { Timestamp } from 'firebase/firestore';
 import {computed, makeObservable, observable} from 'mobx';
 
-import {AuthService} from './auth.service';
-import {ExperimentManager} from './experiment.manager';
 import {FirebaseService} from './firebase.service';
 import {Service} from './service';
 
 import {MediatorConfig} from '@deliberation-lab/utils';
+import {updateChatMediatorsCallable} from '../shared/callables';
 
 interface ServiceProvider {
-  authService: AuthService;
-  experimentManager: ExperimentManager;
   firebaseService: FirebaseService;
 }
 
@@ -79,5 +76,17 @@ export class MediatorEditor extends Service {
   // FIRESTORE                                                               //
   // *********************************************************************** //
 
-  // TODO: Add callable for mediator configs
+  // Write chat mediators to backend
+  async saveChatMediators(stageId: string) {
+    if (!this.experimentId || !this.configMap[stageId]) return;
+
+    await updateChatMediatorsCallable(
+      this.sp.firebaseService.functions,
+      {
+        experimentId: this.experimentId,
+        stageId,
+        mediatorList: this.configMap[stageId].mediators
+      }
+    );
+  }
 }

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -8,6 +8,7 @@ import {
   ExperimentDeletionData,
   ParticipantProfileExtendedData,
   SimpleResponse,
+  UpdateChatMediatorsData,
   UpdateChatStageParticipantAnswerData,
   UpdateRankingStageParticipantAnswerData,
   UpdateSurveyStageParticipantAnswerData
@@ -58,6 +59,14 @@ export const updateChatStageParticipantAnswerCallable = async(
   functions: Functions, config: UpdateChatStageParticipantAnswerData
 ) => {
   const { data } = await httpsCallable<UpdateChatStageParticipantAnswerData, CreationResponse>(functions, 'updateChatStageParticipantAnswer')(config);
+  return data;
+}
+
+/** Generic endpoint to update chat stage mediators */
+export const updateChatMediatorsCallable = async(
+  functions: Functions, config: UpdateChatMediatorsData
+) => {
+  const { data } = await httpsCallable<UpdateChatMediatorsData, CreationResponse>(functions, 'updateChatMediators')(config);
   return data;
 }
 

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -5,11 +5,18 @@ import {
   ChatMessageType,
   StageKind,
   addChatHistoryToPrompt,
-  createAgentMediatorChatMessage
+  createAgentMediatorChatMessage,
+  MediatorConfig,
 } from '@deliberation-lab/utils';
 
 import { app } from '../app';
 import { getGeminiAPIResponse } from '../api/gemini.api';
+
+export interface MediatorMessage {
+  mediator: MediatorConfig;
+  parsed: any;
+  message: string;
+}
 
 /** When chat message is created, generate mediator response if relevant. */
 export const createMediatorMessage = onDocumentCreated(
@@ -20,75 +27,97 @@ export const createMediatorMessage = onDocumentCreated(
 
     // Use experiment config to get ChatStageConfig with mediators.
     const stage = (
-      await app.firestore().doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`).get()
+      await app
+        .firestore()
+        .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`)
+        .get()
     ).data() as StageConfig;
-    if (stage.kind !== StageKind.CHAT) { return; }
+    if (stage.kind !== StageKind.CHAT) {
+      return;
+    }
 
     // Fetch experiment creator's API key.
-    const creatorId = (await app.firestore().collection('experiments').doc(event.params.experimentId).get())
-      .data().metadata.creator;
-    const creatorDoc = (await app.firestore().collection('experimenterData').doc(creatorId).get());
+    const creatorId = (
+      await app.firestore().collection('experiments').doc(event.params.experimentId).get()
+    ).data().metadata.creator;
+    const creatorDoc = await app.firestore().collection('experimenterData').doc(creatorId).get();
     if (!creatorDoc.exists) return;
 
     const apiKeys = creatorDoc.data().apiKeys;
 
-    for (const mediator of stage.mediators) {
-      // Use chats in collection to build chat history for prompt, get num chats
-      const chatMessages = (
-        await app
+    // Use chats in collection to build chat history for prompt, get num chats
+    const chatMessages = (
+      await app
         .firestore()
-        .collection(`experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}/chats`)
+        .collection(
+          `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}/chats`,
+        )
         .orderBy('timestamp', 'asc')
-        .get())
-      .docs.map(doc => doc.data() as ChatMessage);
+        .get()
+    ).docs.map((doc) => doc.data() as ChatMessage);
 
+    // Fetch messages from all mediators
+    const mediatorMessages: MediatorMessage[] = [];
+    for (const mediator of stage.mediators) {
       // Use last 10 messages to build chat history
       const prompt = addChatHistoryToPrompt(chatMessages.slice(-10), mediator.prompt);
-      const numChatsBeforeMediator = chatMessages.length;
 
       // Call Gemini API with given modelCall info
       const response = await getGeminiAPIResponse(apiKeys.geminiKey, prompt);
 
-      // If number of chats has not changed, add mediator message
-      const numChatsAfterMediator = (
-        await app
-        .firestore()
-        .collection(`experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}/chats`)
-        .count().get())
-      .data().count;
-      if (numChatsAfterMediator > numChatsBeforeMediator) { break; }
-
       // Add mediator message if non-empty
       const parsed = JSON.parse(response.text);
       const isJSON = mediator.responseConfig.isJSON;
-      const message = isJSON ?
-        (parsed[mediator.responseConfig.messageField] ?? '') : response.text;
+      const message = isJSON ? (parsed[mediator.responseConfig.messageField] ?? '') : response.text;
 
       if (message.trim() === '') break;
+      mediatorMessages.push({ mediator, parsed, message });
+    }
 
-      const mediatorMessage = createAgentMediatorChatMessage(
-        {
-          profile: { name: mediator.name, avatar: mediator.avatar, pronouns: null },
-          discussionId: data.discussionId,
-          message,
-          timestamp: Timestamp.now(),
-          mediatorId: mediator.id,
-          explanation: isJSON ? (parsed[mediator.responseConfig.explanationField] ?? '') : '',
-        }
-      );
-      const mediatorDocument = app.firestore()
-        .collection('experiments')
-        .doc(event.params.experimentId)
-        .collection('cohorts')
-        .doc(event.params.cohortId)
-        .collection('publicStageData')
-        .doc(event.params.stageId)
-        .collection('chats')
-        .doc(mediatorMessage.id);
+    if (mediatorMessages.length === 0) return;
 
-      await app.firestore().runTransaction(async (transaction) => {
-        transaction.set(mediatorDocument, mediatorMessage);
-      });
-    } // end mediator loop
-  }
+    // Randomly sample a message.
+    const mediatorMessage = mediatorMessages[Math.floor(Math.random() * mediatorMessages.length)];
+    const mediator = mediatorMessage.mediator;
+    const message = mediatorMessage.message;
+    const parsed = mediatorMessage.parsed;
+
+    // Don't send a message if the conversation has moved on. 
+    const numChatsBeforeMediator = chatMessages.length;
+    const numChatsAfterMediator = (
+      await app
+        .firestore()
+        .collection(
+          `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}/chats`,
+        )
+        .count()
+        .get()
+    ).data().count;
+    if (numChatsAfterMediator > numChatsBeforeMediator) {
+      return;
+    }
+
+    const chatMessage = createAgentMediatorChatMessage({
+      profile: { name: mediator.name, avatar: mediator.avatar, pronouns: null },
+      discussionId: data.discussionId,
+      message,
+      timestamp: Timestamp.now(),
+      mediatorId: mediator.id,
+      explanation: mediator.responseConfig.isJSON ? (parsed[mediator.responseConfig.explanationField] ?? '') : '',
+    });
+    const mediatorDocument = app
+      .firestore()
+      .collection('experiments')
+      .doc(event.params.experimentId)
+      .collection('cohorts')
+      .doc(event.params.cohortId)
+      .collection('publicStageData')
+      .doc(event.params.stageId)
+      .collection('chats')
+      .doc(chatMessage.id);
+
+    await app.firestore().runTransaction(async (transaction) => {
+      transaction.set(mediatorDocument, chatMessage);
+    });
+  },
 );

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -99,6 +99,7 @@ export interface HumanMediatorChatMessage extends BaseChatMessage {
 export interface AgentMediatorChatMessage extends BaseChatMessage {
   type: ChatMessageType.AGENT_MEDIATOR;
   mediatorId: string;
+  explanation: string;
 }
 
 /** LLM mediator config. */
@@ -107,7 +108,19 @@ export interface MediatorConfig {
   name: string;
   avatar: string; // emoji avatar for mediator
   prompt: string;
+  responseConfig: MediatorResponseConfig;
   // TODO: Add more settings, e.g., model, temperature, context window
+}
+
+/** Settings for formatting mediator response
+ *  (e.g., expect JSON, use specific JSON field for response, use end token)
+ */
+export interface MediatorResponseConfig {
+  isJSON: boolean;
+  // JSON field to extract chat message from
+  messageField: string;
+  // JSON field to extract explanation from
+  explanationField: string;
 }
 
 export type ChatMessage =
@@ -241,6 +254,7 @@ export function createAgentMediatorChatMessage(
     timestamp: config.timestamp ?? Timestamp.now(),
     profile: config.profile ?? { name: 'Mediator', avatar: '🤖', pronouns: null },
     mediatorId: config.mediatorId ?? '',
+    explanation: config.explanation ?? '',
   };
 }
 
@@ -275,7 +289,19 @@ export function createMediatorConfig(
     name: config.name ?? 'Mediator',
     avatar: config.avatar ?? '🤖',
     prompt: config.prompt ?? DEFAULT_MEDIATOR_PROMPT.trim(),
+    responseConfig: config.responseConfig ?? createMediatorResponseConfig(),
   };
+}
+
+/** Create mediator response config. */
+export function createMediatorResponseConfig(
+  config: Partial<MediatorResponseConfig> = {},
+): MediatorResponseConfig {
+  return {
+    isJSON: config.isJSON ?? false,
+    messageField: config.messageField ?? 'response',
+    explanationField: config.explanationField ?? 'explanation',
+  }
 }
 
 /** Create participant chat stage answer. */

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -72,6 +72,33 @@ export const CreateChatMessageData = Type.Object(
 export type CreateChatMessageData = Static<typeof CreateChatMessageData>;
 
 // ************************************************************************* //
+// updateChatMediators endpoint                                               //
+// ************************************************************************* //
+
+export const UpdateChatMediatorsData = Type.Object(
+  {
+    experimentId: Type.String({ minLength: 1}),
+    stageId: Type.String({ minLength: 1}),
+    // TODO: Refactor mediator config validation
+    mediatorList: Type.Array(
+      Type.Object({
+        id: Type.String({ minLength: 1 }),
+        name: Type.String(),
+        avatar: Type.String(),
+        prompt: Type.String(),
+        responseConfig: Type.Object({
+          isJSON: Type.Boolean(),
+          messageField: Type.String(),
+          explanationField: Type.String(),
+        })
+      })
+    )
+  },
+);
+
+export type UpdateChatMediatorsData = Static<typeof UpdateChatMediatorsData>;
+
+// ************************************************************************* //
 // updateChatStageParticipantAnswer endpoint                                 //
 // ************************************************************************* //
 


### PR DESCRIPTION
- Add a "debug" toggle button in experimenter header banner - when it's toggled on, the chat stage shows agents in the panel + explanations underneath LLM mediator messages; when it's off, the chat stage is identical to what participants see
- Add option to turn on "JSON mode" and specify which JSON fields should be used to populate the main chat message (defaults to "response") and explanation (defaults to "explanation")
- Add ability to edit prompt for existing mediators from experimenter right panel (also, add API key configuration editor to same panel)

<img width="873" alt="Debugging mode with LLM mediator JSON responses/explanations" src="https://github.com/user-attachments/assets/0093cf73-f001-48b7-b246-95526493c6ee">

<img width="1093" alt="Chat editor with JSON configuration options" src="https://github.com/user-attachments/assets/aa97b94f-5515-45f0-854f-aac1e191a191">

<img width="1101" alt="Edit prompt while in chat stage" src="https://github.com/user-attachments/assets/eba6fd40-40ed-4007-91f9-7990096e971d">


Fixes #284 