### PR TITLE
Implement a working timer to the chat stage.

### DIFF
--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -106,20 +106,6 @@ export class Header extends MobxLitElement {
           });
           break;
         case Pages.PARTICIPANT_STAGE:
-          const stageId = this.routerService.activeRoute.params['stage'];
-          const stage = this.experimentService.getStage(
-            stageId
-          ) as ChatStageConfig;
-          if (
-            stage.mediators &&
-            stage.mediators.length > 0 &&
-            !stage.muteMediators!
-          ) {
-            const isConfirmed = window.confirm(
-              `Agents will still respond to new messages. Are you sure you want to go back without muting the agents first?`
-            );
-            if (!isConfirmed) return;
-          }
           this.routerService.navigate(Pages.EXPERIMENT, {
             experiment: params['experiment'],
           });
@@ -304,10 +290,7 @@ export class Header extends MobxLitElement {
           `;
         }
         return html`
-          <pr-tooltip
-            text="Download experiment data"
-            position="BOTTOM_END"
-          >
+          <pr-tooltip text="Download experiment data" position="BOTTOM_END">
             <pr-icon-button
               icon="download"
               color="neutral"

--- a/frontend/src/components/stages/chat_editor.scss
+++ b/frontend/src/components/stages/chat_editor.scss
@@ -95,3 +95,17 @@ pr-textarea {
   flex-grow: 1;
   width: 100%;
 }
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}
+
+.divider {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.tab {
+  margin-top: 0px;
+  margin-left: calc(48px + common.$spacing-medium);
+}

--- a/frontend/src/components/stages/chat_editor.ts
+++ b/frontend/src/components/stages/chat_editor.ts
@@ -55,6 +55,10 @@ export class ChatEditor extends MobxLitElement {
     }
 
     return html`
+      <div class="title">Conversation settings</div>
+      ${this.renderTimeLimit()}
+      <div class="divider"></div>
+      <div class="title">Agent settings</div>
       ${apiCheck}
       ${this.stage.mediators.map((mediator, index) =>
         this.renderMediator(mediator, index)
@@ -72,6 +76,68 @@ export class ChatEditor extends MobxLitElement {
     `;
   }
 
+  private renderTimeLimit() {
+    const timeLimit = this.stage?.timeLimitInMinutes;
+
+    const updateCheck = () => {
+      if (!this.stage) return;
+      if (this.stage.timeLimitInMinutes) {
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          timeLimitInMinutes: null,
+        });
+      } else {
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          timeLimitInMinutes: 20, // Default to 20 if checked
+        });
+      }
+    };
+
+    const updateNum = (e: InputEvent) => {
+      if (!this.stage) return;
+      const timeLimit = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentEditor.updateStage({
+        ...this.stage,
+        timeLimitInMinutes: timeLimit,
+      });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${timeLimit !== null}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateCheck}
+          >
+          </md-checkbox>
+          <div>End convo after time elapsed</div>
+        </div>
+        ${timeLimit !== null
+          ? html`
+              <div class="number-input tab">
+                <label for="timeLimit">
+                  Elapsed time from first message to conversation close (in
+                  minutes)
+                </label>
+                <input
+                  type="number"
+                  id="timeLimit"
+                  name="timeLimit"
+                  min="0"
+                  .value=${timeLimit}
+                  ?disabled=${!this.experimentEditor.canEditStages}
+                  @input=${updateNum}
+                />
+              </div>
+            `
+          : ''}
+      </div>
+    `;
+  }
+  
   addMediator() {
     if (!this.stage) return;
     const mediators = [...this.stage.mediators, createMediatorConfig()];

--- a/frontend/src/components/stages/chat_message.scss
+++ b/frontend/src/components/stages/chat_message.scss
@@ -15,8 +15,13 @@ $bubble-radius-small: common.$spacing-small;
 
 .label {
   @include typescale.label-medium;
-  color: var(--md-sys-color-outline);
+  color: var(--md-sys-color-on-surface-variant);
   width: max-content;
+}
+
+.date {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
 }
 
 .content {

--- a/frontend/src/components/stages/chat_message.ts
+++ b/frontend/src/components/stages/chat_message.ts
@@ -101,7 +101,7 @@ export class ChatMessageComponent extends MobxLitElement {
         <profile-avatar .emoji=${profile.avatar}></profile-avatar>
         <div class="content">
           <div class="label">
-            ${profile.name}
+            ${profile.name} <span class="date">${convertUnifiedTimestampToDate(chatMessage.timestamp, false)}</span>
           </div>
           <div class="chat-bubble">${chatMessage.message}</div>
           ${this.renderDebuggingExplanation(chatMessage)}

--- a/frontend/src/components/stages/chat_panel.scss
+++ b/frontend/src/components/stages/chat_panel.scss
@@ -48,6 +48,10 @@
   color: var(--md-sys-color-secondary);
 }
 
+.ended {
+  color: var(--md-sys-color-tertiary);
+}
+
 .divider {
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }

--- a/frontend/src/components/stages/chat_panel.scss
+++ b/frontend/src/components/stages/chat_panel.scss
@@ -41,3 +41,13 @@
   color: var(--md-sys-color-on-error-container);
   padding: common.$spacing-small common.$spacing-medium;
 }
+
+.countdown {
+  @include typescale.label-medium;
+  font-style: italic;
+  color: var(--md-sys-color-secondary);
+}
+
+.divider {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -39,8 +39,36 @@ export class ChatPanel extends MobxLitElement {
 
     return html`
       <stage-description .stage=${this.stage}></stage-description>
+      ${this.renderTimeRemaining()}
+      <div class="divider"></div>
       ${this.renderParticipantList()} ${this.renderMediatorsList()}
     `;
+  }
+
+  private renderTimeRemaining() {
+    if (!this.stage || this.stage.timeLimitInMinutes === null) {
+      return '';
+    }
+
+    return html`<div class="countdown">
+      Time remaining: ${this.formatTime(this.stage.timeLimitInMinutes * 60)}
+    </div>`;
+  }
+
+  private formatTime(seconds: number): string {
+    const hours = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hours > 0) {
+      return `${hours.toString().padStart(2, '0')}:${mins
+        .toString()
+        .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    } else {
+      return `${mins.toString().padStart(2, '0')}:${secs
+        .toString()
+        .padStart(2, '0')}`;
+    }
   }
 
   private renderMediatorsList() {

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -20,6 +20,7 @@ import {
   getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {isActiveParticipant} from '../../shared/participant.utils';
+import {convertUnifiedTimestampToDate} from '../../shared/utils';
 import {styles} from './chat_panel.scss';
 
 /** Chat panel view with stage info, participants. */
@@ -101,7 +102,13 @@ export class ChatPanel extends MobxLitElement {
     ] as ChatStagePublicData;
     if (!publicStageData) return;
     if (publicStageData.discussionEndTimestamp) {
-      return html`<div class="ended countdown">Discussion ended.</div>`;
+      return html`<div class="ended countdown">
+        Discussion ended at
+        ${convertUnifiedTimestampToDate(
+          publicStageData.discussionEndTimestamp,
+          false
+        )}.
+      </div>`;
     } else if (!publicStageData.discussionStartTimestamp) {
       const timeText = `Time remaining: ${this.formatTime(
         this.stage.timeLimitInMinutes * 60
@@ -109,10 +116,14 @@ export class ChatPanel extends MobxLitElement {
       return html`<div class="countdown">${timeText}</div>`;
     }
 
+    const startText = `Conversation started at: ${convertUnifiedTimestampToDate(
+      publicStageData.discussionStartTimestamp,
+      false
+    )}`;
     const timeText = `Time remaining: ${this.formatTime(
       this.timeRemainingInSeconds!
     )}`;
-    return html`<div class="countdown">${timeText}</div>`;
+    return html`<div class="countdown">${startText}<br />${timeText}</div>`;
   }
 
   private formatTime(seconds: number): string {
@@ -148,7 +159,6 @@ export class ChatPanel extends MobxLitElement {
         </div>
         ${mediators.map((mediator) => this.renderMediator(mediator))}
       </div>
-      ${this.renderMuteButton()}
     `;
   }
   private renderApiCheck() {
@@ -163,31 +173,6 @@ export class ChatPanel extends MobxLitElement {
     return '';
   }
 
-  private renderMuteButton() {
-    if (!this.stage || this.stage.mediators.length == 0) return;
-    const isMuted = this.mediatorEditor.configMap[this.stage.id].muteMediators;
-    return html`
-      <div class="panel-item">
-        <pr-tooltip
-          position="BOTTOM_END"
-          text=${isMuted
-            ? 'Unmuting agents will allow them to speak after a new message is shown.'
-            : 'Muting agents will stop their speaking.'}
-        >
-          <pr-button
-            color="${isMuted ? 'neutral' : 'error'}"
-            variant="tonal"
-            ?disabled=${!this.experimentManager.isCreator}
-            @click=${async () => {
-              this.mediatorEditor.toggleMuteMediators(this.stage!.id!);
-            }}
-          >
-            ${isMuted ? '🔈 Unmute agents' : '🔇 Mute agents'}
-          </pr-button>
-        </pr-tooltip>
-      </div>
-    `;
-  }
   private renderParticipantList() {
     const activeParticipants = this.cohortService.activeParticipants;
     return html`

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -100,18 +100,18 @@ export class ChatPanel extends MobxLitElement {
       this.stage.id
     ] as ChatStagePublicData;
     if (!publicStageData) return;
-    let timeText = '';
     if (publicStageData.discussionEndTimestamp) {
-      timeText = 'Discussion ended';
+      return html`<div class="ended countdown">Discussion ended.</div>`;
     } else if (!publicStageData.discussionStartTimestamp) {
-      timeText = `Time remaining: ${this.formatTime(
+      const timeText = `Time remaining: ${this.formatTime(
         this.stage.timeLimitInMinutes * 60
       )}`;
-    } else {
-      timeText = `Time remaining: ${this.formatTime(
-        this.timeRemainingInSeconds!
-      )}`;
+      return html`<div class="countdown">${timeText}</div>`;
     }
+
+    const timeText = `Time remaining: ${this.formatTime(
+      this.timeRemainingInSeconds!
+    )}`;
     return html`<div class="countdown">${timeText}</div>`;
   }
 

--- a/frontend/src/services/mediator.editor.ts
+++ b/frontend/src/services/mediator.editor.ts
@@ -78,21 +78,6 @@ export class MediatorEditor extends Service {
   // *********************************************************************** //
 
   // Write chat mediators to backend
-  async toggleMuteMediators(stageId: string | null) {
-    if (!stageId || !this.experimentId || !this.configMap[stageId]) return;
-
-    await updateChatMediatorsCallable(
-      this.sp.firebaseService.functions,
-      {
-        experimentId: this.experimentId,
-        stageId,
-        mediatorList: this.configMap[stageId].mediators,
-        muteMediators: !this.configMap[stageId].muteMediators
-      }
-    );
-  }
-
-  // Write chat mediators to backend
   async saveChatMediators(stageId: string) {
     if (!this.experimentId || !this.configMap[stageId]) return;
 
@@ -102,7 +87,6 @@ export class MediatorEditor extends Service {
         experimentId: this.experimentId,
         stageId,
         mediatorList: this.configMap[stageId].mediators,
-        muteMediators: this.configMap[stageId].muteMediators ?? false,
       }
     );
   }

--- a/frontend/src/shared/utils.ts
+++ b/frontend/src/shared/utils.ts
@@ -1,8 +1,6 @@
 import {micromark} from 'micromark';
 import {gfm, gfmHtml} from 'micromark-extension-gfm';
-import {
-  UnifiedTimestamp
-} from '@deliberation-lab/utils';
+import {UnifiedTimestamp} from '@deliberation-lab/utils';
 import {Snapshot} from './types';
 
 /**
@@ -38,7 +36,20 @@ export function collectSnapshotWithId<T>(snapshot: Snapshot, idKey: keyof T) {
 /**
  * Converts UnifiedTimestamp to previewable date.
  */
-export function convertUnifiedTimestampToDate(timestamp: UnifiedTimestamp) {
+export function convertUnifiedTimestampToDate(
+  timestamp: UnifiedTimestamp,
+  showLongFormat: boolean = true
+) {
   const date = new Date(timestamp.seconds * 1000);
-  return `${date.toDateString()} (${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')})`;
+  if (showLongFormat) {
+    return `${date.toDateString()} (${date
+      .getHours()
+      .toString()
+      .padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')})`;
+  } else {
+    return `${date.getHours().toString().padStart(2, '0')}:${date
+      .getMinutes()
+      .toString()
+      .padStart(2, '0')}`;
+  }
 }

--- a/functions/src/stages/chat.endpoints.ts
+++ b/functions/src/stages/chat.endpoints.ts
@@ -100,7 +100,6 @@ export const updateChatMediators = onCall(async (request) => {
     if (!stageConfig || stageConfig.kind !== StageKind.CHAT) return {};
 
     stageConfig.mediators = data.mediatorList;
-    stageConfig.muteMediators = data.muteMediators;
     transaction.set(document, stageConfig);
   });
 

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -140,7 +140,11 @@ export const updateTimeElapsed = onDocumentUpdated(
 
 /** When chat message is created, generate mediator response if relevant. */
 export const createMediatorMessage = onDocumentCreated(
-  'experiments/{experimentId}/cohorts/{cohortId}/publicStageData/{stageId}/chats/{chatId}',
+  {
+    document:
+      'experiments/{experimentId}/cohorts/{cohortId}/publicStageData/{stageId}/chats/{chatId}',
+    timeoutSeconds: 60, // Maximum timeout of 1 minute for typing delay.
+  },
   async (event) => {
     const data = event.data?.data() as ChatMessage | undefined;
 
@@ -229,7 +233,7 @@ export const createMediatorMessage = onDocumentCreated(
       !stage ||
       !publicStageData ||
       Boolean(publicStageData.discussionEndTimestamp) ||
-      await hasEndedChat(event, stage, publicStageData)
+      (await hasEndedChat(event, stage, publicStageData))
     )
       return;
 

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -24,38 +24,84 @@ export interface MediatorMessage {
   message: string;
 }
 
+// Function to get the chat stage configuration based on the event.
+async function getChatStage(event: any): Promise<ChatStageConfig | null> {
+  const stageRef = app
+    .firestore()
+    .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`);
+
+  const stageDoc = await stageRef.get();
+  if (!stageDoc.exists) return null; // Return null if the stage doesn't exist.
+
+  return stageDoc.data() as ChatStageConfig; // Return the stage data.
+}
+
+// Function to get the public data for the chat stage.
+async function getChatStagePublicData(event: any): Promise<ChatStagePublicData | null> {
+  const publicStageRef = app
+    .firestore()
+    .doc(
+      `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
+    );
+
+  const publicStageDoc = await publicStageRef.get();
+  if (!publicStageDoc.exists) return null; // Return null if the public stage data doesn't exist.
+
+  return publicStageDoc.data() as ChatStagePublicData; // Return the public stage data.
+}
+
 // Function to start tracking elapsed time when a chat is created
 export const startTimeElapsed = onDocumentCreated(
   'experiments/{experimentId}/cohorts/{cohortId}/publicStageData/{stageId}/chats/{chatId}',
   async (event) => {
-    const stageRef = app
-      .firestore()
-      .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`);
-    const publicStageRef = app
-      .firestore()
-      .doc(
-        `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
-      );
-
-    const stage = (await stageRef.get()).data() as ChatStageConfig;
+    const stage = await getChatStage(event);
     if (!stage) return;
 
-    const publicStageDataDoc = await publicStageRef.get();
-    if (!publicStageDataDoc.exists) return;
-    let publicStageData = publicStageDataDoc.data() as ChatStagePublicData;
+    const publicStageData = await getChatStagePublicData(event);
+    if (!publicStageData) return;
 
     // Exit if discussion has already ended.
     if (publicStageData.discussionEndTimestamp) return;
 
     // Update the start timestamp and checkpoint timestamp if not set.
     if (publicStageData.discussionStartTimestamp === null) {
-      await publicStageRef.update({
-        discussionStartTimestamp: Timestamp.now(),
-        discussionCheckpointTimestamp: Timestamp.now(),
-      });
+      await app
+        .firestore()
+        .doc(
+          `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
+        )
+        .update({
+          discussionStartTimestamp: Timestamp.now(),
+          discussionCheckpointTimestamp: Timestamp.now(),
+        });
     }
   },
 );
+
+// Checks whether the chat has ended, returning true if ending chat.
+async function hasEndedChat(
+  event: any,
+  stage: ChatStageConfig | null,
+  stageData: ChatStagePublicData | null,
+): Promise<boolean> {
+  const chatStage = stage || (await getChatStage(event));
+  const publicStageData = stageData || (await getChatStagePublicData(event));
+  if (!chatStage || !publicStageData || !chatStage.timeLimitInMinutes) return false;
+
+  const elapsedMinutes = getTimeElapsed(publicStageData.discussionStartTimestamp!, 'm');
+
+  // Check if the elapsed time has reached or exceeded the time limit
+  if (elapsedMinutes >= chatStage.timeLimitInMinutes) {
+    await app
+      .firestore()
+      .doc(
+        `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
+      )
+      .update({ discussionEndTimestamp: Timestamp.now() });
+    return true; // Indicate that the chat has ended.
+  }
+  return false;
+}
 
 // Function to update elapsed time and potentially end the discussion.
 export const updateTimeElapsed = onDocumentUpdated(
@@ -64,39 +110,31 @@ export const updateTimeElapsed = onDocumentUpdated(
     timeoutSeconds: 360, // Maximum timeout of 6 minutes.
   },
   async (event) => {
-    const publicStageRef = app
-      .firestore()
-      .doc(
-        `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
-      );
-
-    const publicStageDataDoc = await publicStageRef.get();
-    if (!publicStageDataDoc.exists) return;
-    let publicStageData = publicStageDataDoc.data() as ChatStagePublicData;
+    const publicStageData = await getChatStagePublicData(event);
+    if (!publicStageData) return;
 
     // Only update time if the conversation is in progress.
     if (!publicStageData.discussionStartTimestamp || publicStageData.discussionEndTimestamp) return;
 
-    const stageRef = app
-      .firestore()
-      .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`);
-    const stage = (await stageRef.get()).data() as ChatStageConfig;
+    const stage = await getChatStage(event);
     if (!stage || !stage.timeLimitInMinutes) return;
-
-    const elapsedMinutes = getTimeElapsed(publicStageData.discussionStartTimestamp!, 'm');
-    if (elapsedMinutes >= stage.timeLimitInMinutes) {
-      await publicStageRef.update({ discussionEndTimestamp: Timestamp.now() });
-      return;
-    }
+    // Maybe end the chat.
+    if (await hasEndedChat(event, stage, publicStageData)) return;
 
     // Calculate how long to wait.
+    const elapsedMinutes = getTimeElapsed(publicStageData.discussionStartTimestamp!, 'm');
     const maxWaitTimeInMinutes = 5;
     const remainingTime = stage.timeLimitInMinutes - elapsedMinutes;
     const intervalTime = Math.min(maxWaitTimeInMinutes, remainingTime);
 
     // Wait for the determined interval time, and then re-trigger the function.
     await new Promise((resolve) => setTimeout(resolve, intervalTime * 60 * 1000));
-    await publicStageRef.update({ discussionCheckpointTimestamp: Timestamp.now() });
+    await app
+      .firestore()
+      .doc(
+        `experiments/${event.params.experimentId}/cohorts/${event.params.cohortId}/publicStageData/${event.params.stageId}`,
+      )
+      .update({ discussionCheckpointTimestamp: Timestamp.now() });
   },
 );
 
@@ -107,18 +145,15 @@ export const createMediatorMessage = onDocumentCreated(
     const data = event.data?.data() as ChatMessage | undefined;
 
     // Use experiment config to get ChatStageConfig with mediators.
-    let stage = (
-      await app
-        .firestore()
-        .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`)
-        .get()
-    ).data() as StageConfig;
-    if (stage.kind !== StageKind.CHAT) {
+    let stage = await getChatStage(event);
+    if (!stage || stage.muteMediators) {
       return;
     }
-    if (stage.muteMediators) {
-      return;
-    }
+
+    let publicStageData = await getChatStagePublicData(event);
+    // Make sure the conversation hasn't ended.
+    if (!publicStageData || Boolean(publicStageData.discussionEndTimestamp)) return;
+
     // Fetch experiment creator's API key.
     const creatorId = (
       await app.firestore().collection('experiments').doc(event.params.experimentId).get()
@@ -187,12 +222,17 @@ export const createMediatorMessage = onDocumentCreated(
     await awaitTypingDelay(message);
 
     // Refresh the stage to check if mediators have been muted.
-    stage = (
-      await app
-        .firestore()
-        .doc(`experiments/${event.params.experimentId}/stages/${event.params.stageId}`)
-        .get()
-    ).data() as StageConfig;
+    stage = await getChatStage(event);
+    publicStageData = await getChatStagePublicData(event);
+
+    if (
+      !stage ||
+      stage.muteMediators ||
+      !publicStageData ||
+      Boolean(publicStageData.discussionEndTimestamp) ||
+      await hasEndedChat(event, stage, publicStageData)
+    )
+      return;
 
     // Don't send a message if the conversation has moved on.
     const numChatsBeforeMediator = chatMessages.length;
@@ -205,7 +245,7 @@ export const createMediatorMessage = onDocumentCreated(
         .count()
         .get()
     ).data().count;
-    if (numChatsAfterMediator > numChatsBeforeMediator || stage.muteMediators) {
+    if (numChatsAfterMediator > numChatsBeforeMediator) {
       return;
     }
 

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -146,7 +146,7 @@ export const createMediatorMessage = onDocumentCreated(
 
     // Use experiment config to get ChatStageConfig with mediators.
     let stage = await getChatStage(event);
-    if (!stage || stage.muteMediators) {
+    if (!stage) {
       return;
     }
 
@@ -221,13 +221,12 @@ export const createMediatorMessage = onDocumentCreated(
 
     await awaitTypingDelay(message);
 
-    // Refresh the stage to check if mediators have been muted.
+    // Refresh the stage to check if the conversation has ended..
     stage = await getChatStage(event);
     publicStageData = await getChatStagePublicData(event);
 
     if (
       !stage ||
-      stage.muteMediators ||
       !publicStageData ||
       Boolean(publicStageData.discussionEndTimestamp) ||
       await hasEndedChat(event, stage, publicStageData)

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -14,8 +14,8 @@ import { StageConfig } from './stages/stage';
 // ************************************************************************* //
 
 /** Increment this ID when changes to any Firestore objects are made. */
-/** Version 3: PR#310. */
-export const EXPERIMENT_VERSION_ID = 3;
+/** Version 4: PR#324. */
+export const EXPERIMENT_VERSION_ID = 4;
 
 /** Experiment. */
 export interface Experiment {

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -27,6 +27,7 @@ export interface ChatStageConfig extends BaseStageConfig {
   discussions: ChatDiscussion[]; // ordered list of discussions
   mediators: MediatorConfig[];
   muteMediators: boolean; // Whether mediators are muted.
+  timeLimitInMinutes: number | null; // How long remaining in the chat.
 }
 
 /** Chat discussion. */
@@ -214,6 +215,7 @@ export function createChatStage(config: Partial<ChatStageConfig> = {}): ChatStag
     discussions: config.discussions ?? [],
     mediators: config.mediators ?? [],
     muteMediators: config.muteMediators ?? false,
+    timeLimitInMinutes: config.timeLimitInMinutes ?? 20,
   };
 }
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -192,7 +192,7 @@ export const DEFAULT_STRING_FORMATTING_INSTRUCTIONS = `If you would like to resp
 // FUNCTIONS                                                                 //
 // ************************************************************************* //
 export async function awaitTypingDelay(message: string): Promise<void> {
-  const delay = getTypingDelay(message);
+  const delay = Math.min(getTypingDelay(message), 30 * 1000); // Cap delay at 30 seconds.
   console.log(`Waiting ${(delay / 1000).toFixed(2)} seconds to simulate delay.`);
   return new Promise((resolve) => setTimeout(resolve, delay));
 }

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -26,7 +26,6 @@ export interface ChatStageConfig extends BaseStageConfig {
   kind: StageKind.CHAT;
   discussions: ChatDiscussion[]; // ordered list of discussions
   mediators: MediatorConfig[];
-  muteMediators: boolean; // Whether mediators are muted.
   timeLimitInMinutes: number | null; // How long remaining in the chat.
 }
 
@@ -220,7 +219,6 @@ export function createChatStage(config: Partial<ChatStageConfig> = {}): ChatStag
     progress: config.progress ?? createStageProgressConfig({ waitForAllParticipants: true }),
     discussions: config.discussions ?? [],
     mediators: config.mediators ?? [],
-    muteMediators: config.muteMediators ?? false,
     timeLimitInMinutes: config.timeLimitInMinutes ?? 20,
   };
 }

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -148,6 +148,12 @@ export interface ChatStagePublicData extends BaseStagePublicData {
   kind: StageKind.CHAT;
   // discussionId --> map of participant public ID to readyToEndDiscussion timestamp
   discussionTimestampMap: Record<string, Record<string, UnifiedTimestamp | null>>;
+  // The timestamp of the first message, or null if not started.
+  discussionStartTimestamp: UnifiedTimestamp | null;
+  // A timestamp used for in progress checkpoint.
+  discussionCheckpointTimestamp: UnifiedTimestamp | null;
+  // If the end timestamp is not null, the conversation has ended.
+  discussionEndTimestamp: UnifiedTimestamp | null;
 }
 
 // ************************************************************************* //
@@ -357,5 +363,8 @@ export function createChatStagePublicData(stage: ChatStageConfig): ChatStagePubl
     id: stage.id,
     kind: StageKind.CHAT,
     discussionTimestampMap: {},
+    discussionStartTimestamp: null,
+    discussionCheckpointTimestamp: null,
+    discussionEndTimestamp: null,
   };
 }

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -23,6 +23,7 @@ export const ChatStageConfigData = Type.Object(
     descriptions: StageTextConfigSchema,
     progress: StageProgressConfigSchema,
     muteMediators: Type.Boolean(),
+    timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
     // discussions
     // mediators
   },

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -21,7 +21,6 @@ export const ChatStageConfigData = Type.Object({
   name: Type.String(),
   descriptions: StageTextConfigSchema,
   progress: StageProgressConfigSchema,
-  muteMediators: Type.Boolean(),
   timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
   // discussions
   // mediators
@@ -90,7 +89,6 @@ export const UpdateChatMediatorsData = Type.Object({
       }),
     }),
   ),
-  muteMediators: Type.Boolean(),
 });
 
 export type UpdateChatMediatorsData = Static<typeof UpdateChatMediatorsData>;

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -4,7 +4,7 @@ import { StageKind } from './stage';
 import {
   StageGameSchema,
   StageTextConfigSchema,
-  StageProgressConfigSchema
+  StageProgressConfigSchema,
 } from './stage.validation';
 import { ChatMessageType } from './chat_stage';
 
@@ -14,21 +14,18 @@ const strict = { additionalProperties: false } as const;
 // ************************************************************************* //
 // updateChatStageConfig endpoint                                            //
 // ************************************************************************* //
-export const ChatStageConfigData = Type.Object(
-  {
-    id: Type.String(),
-    kind: Type.Literal(StageKind.CHAT),
-    game: StageGameSchema,
-    name: Type.String(),
-    descriptions: StageTextConfigSchema,
-    progress: StageProgressConfigSchema,
-    muteMediators: Type.Boolean(),
-    timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
-    // discussions
-    // mediators
-  },
-);
-
+export const ChatStageConfigData = Type.Object({
+  id: Type.String(),
+  kind: Type.Literal(StageKind.CHAT),
+  game: StageGameSchema,
+  name: Type.String(),
+  descriptions: StageTextConfigSchema,
+  progress: StageProgressConfigSchema,
+  muteMediators: Type.Boolean(),
+  timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
+  // discussions
+  // mediators
+});
 
 // ************************************************************************* //
 // updateChatMessage endpoint                                                //
@@ -42,23 +39,21 @@ export const ChatMessageTypeData = Type.Union([
 ]);
 
 /** ChatMessage input validation. */
-export const ChatMessageData = Type.Object(
-  {
-    id: Type.String({ minLength: 1 }),
-    discussionId: Type.Union([Type.Null(), Type.String()]),
-    type: ChatMessageTypeData,
-    message: Type.String(),
-    profile: Type.Object(
-      {
-        name: Type.Union([Type.Null(), Type.String()]),
-        avatar: Type.Union([Type.Null(), Type.String()]),
-        pronouns: Type.Union([Type.Null(), Type.String()]),
-      },
-      strict
-    ),
-    // timestamp
-  },
-);
+export const ChatMessageData = Type.Object({
+  id: Type.String({ minLength: 1 }),
+  discussionId: Type.Union([Type.Null(), Type.String()]),
+  type: ChatMessageTypeData,
+  message: Type.String(),
+  profile: Type.Object(
+    {
+      name: Type.Union([Type.Null(), Type.String()]),
+      avatar: Type.Union([Type.Null(), Type.String()]),
+      pronouns: Type.Union([Type.Null(), Type.String()]),
+    },
+    strict,
+  ),
+  // timestamp
+});
 
 /** CreateChatMessageData. */
 export const CreateChatMessageData = Type.Object(
@@ -68,7 +63,7 @@ export const CreateChatMessageData = Type.Object(
     stageId: Type.String({ minLength: 1 }),
     chatMessage: ChatMessageData,
   },
-  strict
+  strict,
 );
 
 export type CreateChatMessageData = Static<typeof CreateChatMessageData>;
@@ -77,28 +72,26 @@ export type CreateChatMessageData = Static<typeof CreateChatMessageData>;
 // updateChatMediators endpoint                                               //
 // ************************************************************************* //
 
-export const UpdateChatMediatorsData = Type.Object(
-  {
-    experimentId: Type.String({ minLength: 1}),
-    stageId: Type.String({ minLength: 1}),
-    // TODO: Refactor mediator config validation
-    mediatorList: Type.Array(
-      Type.Object({
-        id: Type.String({ minLength: 1 }),
-        name: Type.String(),
-        avatar: Type.String(),
-        prompt: Type.String(),
-        responseConfig: Type.Object({
-          isJSON: Type.Boolean(),
-          messageField: Type.String(),
-          explanationField: Type.String(),
-          formattingInstructions: Type.String(),
-        })
-      })
-    ),
-    muteMediators: Type.Boolean(),
-  },
-);
+export const UpdateChatMediatorsData = Type.Object({
+  experimentId: Type.String({ minLength: 1 }),
+  stageId: Type.String({ minLength: 1 }),
+  // TODO: Refactor mediator config validation
+  mediatorList: Type.Array(
+    Type.Object({
+      id: Type.String({ minLength: 1 }),
+      name: Type.String(),
+      avatar: Type.String(),
+      prompt: Type.String(),
+      responseConfig: Type.Object({
+        isJSON: Type.Boolean(),
+        messageField: Type.String(),
+        explanationField: Type.String(),
+        formattingInstructions: Type.String(),
+      }),
+    }),
+  ),
+  muteMediators: Type.Boolean(),
+});
 
 export type UpdateChatMediatorsData = Static<typeof UpdateChatMediatorsData>;
 
@@ -113,7 +106,7 @@ export const ChatStageParticipantAnswerData = Type.Object(
     kind: Type.Literal(StageKind.CHAT),
     discussionTimestampMap: Type.Record(
       Type.String({ minLength: 1 }),
-      Type.Union([Type.Null(), UnifiedTimestampSchema])
+      Type.Union([Type.Null(), UnifiedTimestampSchema]),
     ),
   },
   strict,
@@ -128,7 +121,9 @@ export const UpdateChatStageParticipantAnswerData = Type.Object(
     participantPublicId: Type.String({ minLength: 1 }),
     chatStageParticipantAnswer: ChatStageParticipantAnswerData,
   },
-  strict
+  strict,
 );
 
-export type UpdateChatStageParticipantAnswerData = Static<typeof UpdateChatStageParticipantAnswerData>;
+export type UpdateChatStageParticipantAnswerData = Static<
+  typeof UpdateChatStageParticipantAnswerData
+>;


### PR DESCRIPTION
Fixes #308.

* Experiment creators can add a "time in minutes" when creating a chat stage.
* Mute mediators is removed: it should not have been created at the experiment level, and was a stop gap for this feature.
* Countdowns are rendered for all participants.
* When the time has elapsed, human and agent participants can no longer respond.

Note: There can be a bit of latency sometimes before the discussion is "ended". I think this is because the "update" logic is awaiting and the mediator typing simulation is also awaiting. These are done in parallel, but there might be some lag.
