### PR TITLE
Add backwards compatibility for loading cohortLockMap field in Experi…

### DIFF
--- a/frontend/src/services/experiment.service.ts
+++ b/frontend/src/services/experiment.service.ts
@@ -71,7 +71,11 @@ export class ExperimentService extends Service {
       onSnapshot(
         doc(this.sp.firebaseService.firestore, 'experiments', id),
         (doc) => {
-          this.experiment = {id: doc.id, ...doc.data()} as Experiment;
+          this.experiment = {
+            id: doc.id,
+            cohortLockMap: {}, // for experiments version <= 11
+            ...doc.data()
+          } as Experiment;
           this.sp.agentEditor.setExperimentId(doc.id);
           this.isExperimentLoading = false;
         }

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -26,7 +26,7 @@ import { StageConfig } from './stages/stage';
   *             and rename chip quantity field to startingQuantity
   * VERSION 10 - add baseCurrencyAmount to PayoutItemResult (PR #384)
   * VERSION 11 - add anonymous profile map to ParticipantProfile (PR #391)
-  * VERSION 12 - add cohortLockMap to Experiment
+  * VERSION 12 - add cohortLockMap to Experiment (PR #402)
   */
 export const EXPERIMENT_VERSION_ID = 12;
 


### PR DESCRIPTION
On Firebase load, this defaults cohortLockMap to {} for older experiments (version <=11) that don't have the field.