### PR TITLE
Add endpoint to test agent participant prompts

### DIFF
--- a/frontend/src/components/experiment_dashboard/experiment_dashboard.ts
+++ b/frontend/src/components/experiment_dashboard/experiment_dashboard.ts
@@ -185,6 +185,29 @@ export class Component extends MobxLitElement {
       `;
     };
 
+    const renderAgentParticipantButton = () => {
+      const currentParticipant = this.experimentManager.currentParticipant;
+      const currentStageId = this.participantService.currentStageViewId;
+      if (!currentParticipant || !currentStageId) return nothing;
+
+      return html`
+        <pr-tooltip text="Experimental feature: Test agent participant prompt" position="BOTTOM_END">
+          <pr-icon-button
+            icon="robot_2"
+            size="small"
+            color="tertiary"
+            variant="default"
+            @click=${() => {
+              this.experimentManager.testAgentParticipantPrompt(
+                currentParticipant.privateId, currentStageId
+              );
+            }}
+          >
+          </pr-icon-button>
+        </pr-tooltip>
+      `;
+    }
+
     const renderStatusBanner = () => {
       if (!isPreview) return nothing;
       const text = this.getParticipantStatusText();
@@ -216,7 +239,10 @@ export class Component extends MobxLitElement {
           ${!isPreview ? getProfileString() : ''}
           ${renderStatusBanner()}
         </div>
-        ${this.renderTransferMenu()}
+        <div class="right">
+          ${renderAgentParticipantButton()}
+          ${this.renderTransferMenu()}
+        </div>
       </div>
     `;
   }

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -44,6 +44,7 @@ import {
   initiateParticipantTransferCallable,
   sendParticipantCheckCallable,
   setExperimentCohortLockCallable,
+  testAgentParticipantPromptCallable,
   updateCohortMetadataCallable,
   writeExperimentCallable,
 } from '../shared/callables';
@@ -628,6 +629,19 @@ export class ExperimentManager extends Service {
     return data;
   }
 
+  /** TEMPORARY: Test agent participant prompt for given participant/stage. */
+  async testAgentParticipantPrompt(participantId: string, stageId: string) {
+    if (this.experimentId) {
+      await testAgentParticipantPromptCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          participantId,
+          stageId
+        }
+      );
+    }
+  }
 
   /** Create a manual (human) agent chat message. */
   async createManualChatMessage(

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -1,4 +1,5 @@
 import {
+  AgentParticipantPromptTestData,
   BaseParticipantData,
   CreateChatMessageData,
   CohortCreationData,
@@ -209,5 +210,13 @@ export const setChipTurnCallable = async(
   functions: Functions, config: SetChipTurnData
 ) => {
   const { data } = await httpsCallable<SetChipTurnData, SuccessResponse>(functions, 'setChipTurn')(config);
+  return data;
+}
+
+/** Generic endpoint for testing agent participant stage prompts. */
+export const testAgentParticipantPromptCallable = async(
+  functions: Functions, config: AgentParticipantPromptTestData
+) => {
+  const { data } = await httpsCallable<AgentParticipantPromptTestData, SimpleResponse<string>>(functions, 'testAgentParticipantPrompt')(config);
   return data;
 }

--- a/functions/src/agent.endpoints.ts
+++ b/functions/src/agent.endpoints.ts
@@ -2,7 +2,9 @@ import { Value } from '@sinclair/typebox/value';
 import {
   ExperimenterData,
   StageConfig,
-  ParticipantProfileExtended
+  StageKind,
+  ParticipantProfileExtended,
+  createAgentParticipantRankingStagePrompt
 } from '@deliberation-lab/utils';
 import {getAgentResponse} from './agent.utils';
 
@@ -58,6 +60,9 @@ export const testAgentParticipantPrompt = onCall(async (request) => {
   // TODO: Use utils functions to construct prompt based on stage type
   let prompt = '';
   switch (stage.kind) {
+    case StageKind.RANKING:
+      prompt = createAgentParticipantRankingStagePrompt(participant, stage);
+      break;
     default:
       prompt = `This is a test prompt. Please output a funny joke.`;
   }

--- a/functions/src/agent.endpoints.ts
+++ b/functions/src/agent.endpoints.ts
@@ -1,0 +1,77 @@
+import { Value } from '@sinclair/typebox/value';
+import {
+  ExperimenterData,
+  StageConfig,
+  ParticipantProfileExtended
+} from '@deliberation-lab/utils';
+import {getAgentResponse} from './agent.utils';
+
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import { onCall } from 'firebase-functions/v2/https';
+
+import { app } from './app';
+import { AuthGuard } from './utils/auth-guard';
+
+// ****************************************************************************
+// Test agent participant prompts
+// Input structure: { experimentId, participantId, stageId }
+// Validation: utils/src/agent.validation.ts
+// ****************************************************************************
+export const testAgentParticipantPrompt = onCall(async (request) => {
+  const { data } = request;
+
+  // Only allow experimenters to use this test endpoint for now
+  await AuthGuard.isExperimenter(request);
+
+  const experimentId = data.experimentId;
+  const stageId = data.stageId;
+  const participantPrivateId = data.participantId;
+
+  // Fetch experiment creator's API key and other experiment data.
+  const creatorId = (
+    await app.firestore().collection('experiments').doc(experimentId).get()
+  ).data().metadata.creator;
+  const creatorDoc = await app.firestore().collection('experimenterData').doc(creatorId).get();
+  if (!creatorDoc.exists) return;
+
+  const experimenterData = creatorDoc.data() as ExperimenterData;
+
+  // Fetch participant config (in case needed to help construct prompt)
+  const participant = (await app.firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantPrivateId)
+    .get()
+  ).data() as ParticipantProfileExtended;
+
+  // Fetch stage config (to determine which prompt to send)
+  const stage = (await app.firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('stages')
+    .doc(stageId)
+    .get()
+  ).data() as StageConfig;
+
+  // TODO: Use utils functions to construct prompt based on stage type
+  let prompt = '';
+  switch (stage.kind) {
+    default:
+      prompt = `This is a test prompt. Please output a funny joke.`;
+  }
+
+  // Call LLM API
+  const response = await getAgentResponse(experimenterData, prompt);
+  // Check console log for response
+  console.log(
+    'TESTING AGENT PARTICIPANT PROMPT\n',
+    `Experiment: ${experimentId}\n`,
+    `Participant: ${participant.publicId}\n`,
+    `Stage: ${stage.name} (${stage.kind})\n`,
+    response
+  );
+
+  return { data: response };
+});

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -1,0 +1,37 @@
+import {
+  ApiKeyType,
+  ExperimenterData,
+} from '@deliberation-lab/utils';
+
+import { getGeminiAPIResponse } from './api/gemini.api';
+import { getOpenAIAPITextCompletionResponse } from './api/openai.api';
+import { ollamaChat } from './api/ollama.api';
+
+export async function getAgentResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
+  const keyType = data.apiKeys.activeApiKeyType;
+  let response;
+
+  if (process.env.OPENAI_BASE_URL) {
+    response = getOpenAIAPITextCompletionResponse(
+      process.env.OPENAI_API_KEY,
+      process.env.OPENAI_MODEL_NAME,
+      prompt)
+  } else if (keyType === ApiKeyType.GEMINI_API_KEY) {
+    response =  getGeminiResponse(data, prompt);
+  } else if (keyType === ApiKeyType.OLLAMA_CUSTOM_URL) {
+    response = await getOllamaResponse(data, prompt);
+  } else {
+    console.error("Error: invalid apiKey type: ", keyType)
+    response = {text: ""};
+  }
+
+  return response
+}
+
+export async function getGeminiResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
+  return await getGeminiAPIResponse(data.apiKeys.geminiApiKey, prompt);
+}
+
+export async function getOllamaResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
+  return await ollamaChat([prompt], data.apiKeys.ollamaApiKey);
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,8 @@ export * from './cohort.endpoints';
 export * from './participant.endpoints';
 export * from './participant.triggers';
 
+export * from './agent.utils';
+
 export * from './stages/chat.endpoints';
 export * from './stages/chat.triggers';
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,7 @@ export * from './cohort.endpoints';
 export * from './participant.endpoints';
 export * from './participant.triggers';
 
+export * from './agent.endpoints';
 export * from './agent.utils';
 
 export * from './stages/chat.endpoints';

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -14,14 +14,15 @@ import {
   createAgentMediatorChatMessage,
   AgentConfig,
   ChatStageConfig,
-  ApiKeyType,
   ExperimenterData,
 } from '@deliberation-lab/utils';
 
 import { app } from '../app';
-import { getGeminiAPIResponse } from '../api/gemini.api';
-import { getOpenAIAPITextCompletionResponse } from '../api/openai.api';
-import { ollamaChat } from '../api/ollama.api';
+import {
+  getAgentResponse,
+  getGeminiResponse,
+  getOllamaResponse
+} from '../agent.utils';
 
 export interface AgentMessage {
   agent: AgentConfig;
@@ -308,33 +309,4 @@ async function hasEndedChat(
     return true; // Indicate that the chat has ended.
   }
   return false;
-}
-
-async function getAgentResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
-  const keyType = data.apiKeys.activeApiKeyType;
-  let response;
-
-  if (process.env.OPENAI_BASE_URL) {
-    response = getOpenAIAPITextCompletionResponse(
-      process.env.OPENAI_API_KEY,
-      process.env.OPENAI_MODEL_NAME,
-      prompt)
-  } else if (keyType === ApiKeyType.GEMINI_API_KEY) {
-    response =  getGeminiResponse(data, prompt);
-  } else if (keyType === ApiKeyType.OLLAMA_CUSTOM_URL) {
-    response = await getOllamaResponse(data, prompt);
-  } else {
-    console.error("Error: invalid apiKey type: ", keyType)
-    response = {text: ""};
-  }
-
-  return response
-}
-
-async function getGeminiResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
-  return await getGeminiAPIResponse(data.apiKeys.geminiApiKey, prompt);
-}
-
-async function getOllamaResponse(data: ExperimenterData, prompt: string): Promise<ModelResponse> {
-  return await ollamaChat([prompt], data.apiKeys.ollamaApiKey);
 }

--- a/utils/src/agent.validation.ts
+++ b/utils/src/agent.validation.ts
@@ -1,0 +1,20 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+/** Shorthand for strict TypeBox object validation */
+const strict = { additionalProperties: false } as const;
+
+// ****************************************************************************
+// testAgentParticipantPrompt
+// ****************************************************************************
+
+/** AgentParticipantPromptTest input validation. */
+export const AgentParticipantPromptTestData = Type.Object(
+  {
+    experimentId: Type.String({ minLength: 1 }),
+    participantId: Type.String({ minLength: 1 }),
+    stageId: Type.String({ minLength: 1 }),
+  },
+  strict,
+);
+
+export type AgentParticipantPromptTestData = Static<typeof AgentParticipantPromptTestData>;

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -23,6 +23,9 @@ export * from './participant';
 export * from './participant.validation';
 export * from './profile_sets';
 
+// Agent
+export * from './agent.validation';
+
 // Stages
 export * from './stages/stage';
 export * from './stages/stage.validation';

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -36,6 +36,7 @@ export * from './stages/chip_stage.validation';
 export * from './stages/comprehension_stage';
 export * from './stages/comprehension_stage.validation';
 export * from './stages/ranking_stage';
+export * from './stages/ranking_stage.prompts';
 export * from './stages/ranking_stage.validation';
 export * from './stages/info_stage';
 export * from './stages/info_stage.validation';

--- a/utils/src/stages/ranking_stage.prompts.ts
+++ b/utils/src/stages/ranking_stage.prompts.ts
@@ -1,0 +1,106 @@
+/** Prompt constants and utils for interacting with ranking stage. */
+import {
+  ParticipantProfileExtended
+} from '../participant';
+import {
+  RankingStageConfig,
+  RankingType
+} from './ranking_stage';
+
+// ************************************************************************* //
+// CONSTANTS                                                                 //
+// ************************************************************************* //
+
+// TODO: Update example item-ranking prompt to use actual ranking logic, etc.
+export const DEFAULT_AGENT_PARTICIPANT_RANKING_ITEMS_PROMPT = `
+  Your job is to alphabetize the following items based on their name.
+  Return the alphabetized items' IDs in an ordered list.
+  For example: ['item3', 'item1', 'item2']. Do not include
+  any explanations or other information. Only return the list.
+`;
+
+// TODO: Update example participant-ranking prompt to use actual ranking logic,
+// etc.
+export const DEFAULT_AGENT_PARTICIPANT_RANKING_PARTICIPANTS_PROMPT = `
+  Your job is to alphabetize a series of participants. Return the alphabetized
+  participants' IDs in an ordered list. Do not include any explanations or
+  other information. Only return the list.
+`;
+
+// TODO: Remove temporary list of example participants
+// This is currently a shuffle list of participants (one for each letter A-Z)
+export const EXAMPLE_RANKING_PARTICIPANTS: { name: string, publicId: string }[] = [
+  { name: 'Strawberry Shortcake', publicId: 'strawberry-red-192' },
+  { name: 'Onion Rings', publicId: 'onion-white-158' },
+  { name: 'Zucchini Bread', publicId: 'zucchini-green-269' },
+  { name: 'Lasagna', publicId: 'lasagna-red-125' },
+  { name: 'Hamburger', publicId: 'hamburger-brown-896' },
+  { name: 'Vanilla Pudding', publicId: 'vanilla-white-225' },
+  { name: 'Apple Pie', publicId: 'apple-red-134' },
+  { name: 'Kale Salad', publicId: 'kale-green-114' },
+  { name: 'Udon Noodles', publicId: 'udon-white-214' },
+  { name: 'Raspberry Tart', publicId: 'raspberry-red-181' },
+  { name: 'Nachos', publicId: 'nachos-orange-147' },
+  { name: 'Ice Cream Sundae', publicId: 'icecream-pink-912' },
+  { name: 'Quiche Lorraine', publicId: 'quiche-yellow-170' },
+  { name: 'Tacos', publicId: 'tacos-yellow-203' },
+  { name: 'Eggplant Parmesan', publicId: 'eggplant-purple-538' },
+  { name: 'Yorkshire Pudding', publicId: 'yorkshire-brown-258' },
+  { name: 'Chocolate Cake', publicId: 'chocolate-brown-396' },
+  { name: 'Waffles', publicId: 'waffles-golden-236' },
+  { name: 'Donut Holes', publicId: 'donut-yellow-412' },
+  { name: 'Xigua (Watermelon)', publicId: 'xigua-red-247' },
+  { name: 'French Fries', publicId: 'frenchfries-golden-674' },
+  { name: 'Garlic Bread', publicId: 'garlic-white-785' },
+  { name: 'Macaroni and Cheese', publicId: 'macaroni-yellow-136' },
+  { name: 'Jalapeno Poppers', publicId: 'jalapeno-green-103' },
+  { name: 'Blueberry Muffins', publicId: 'blueberry-blue-265' },
+  { name: 'Pizza', publicId: 'pizza-red-169' }
+];
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+
+/**
+ *  Create prompt for current agent participant to 
+ *  complete ranking stage.
+ */
+// TODO: Update ranking prompt function to actually build working
+// ranking stage prompts for agent participants!
+export function createAgentParticipantRankingStagePrompt(
+  participant: ParticipantProfileExtended,
+  rankingStage: RankingStageConfig
+) {
+  // If ranking items, use items listed in stage config
+  if (rankingStage.rankingType === RankingType.ITEMS) {
+    const rankingItems = rankingStage.rankingItems;
+    const prompt = `
+      ${DEFAULT_AGENT_PARTICIPANT_RANKING_ITEMS_PROMPT}
+
+      Items to rank: ${JSON.stringify(rankingItems)}
+
+      List of item IDs:
+    `;
+    return prompt;
+  }
+  // TODO: If ranking participants, use given list of participants
+  // (this temporarily uses example participants + current given participant
+  // instead of passing in the list of actual cohort participants)
+  const participants: { name: string, id: string }[] =
+    [...EXAMPLE_RANKING_PARTICIPANTS, participant].map(
+      participant => {
+        return { name: participant.name ?? '', id: participant.publicId };
+      }
+    );
+
+  const prompt = `
+    ${DEFAULT_AGENT_PARTICIPANT_RANKING_PARTICIPANTS_PROMPT}
+
+    Participants to rank: ${JSON.stringify(participants)}
+
+    List of participant IDs:
+  `;
+
+  return prompt;
+}


### PR DESCRIPTION
This allows experimenters to use a frontend button to call an agent participant testing endpoint:

![image](https://github.com/user-attachments/assets/bfb70b95-1ab5-42d7-a469-2d42158f1941)

The endpoint then constructs a prompt based on the current stage (TODO: add these prompts! right now it just builds a dummy prompt), sends to API, and console logs the response:

![image](https://github.com/user-attachments/assets/3dfecd62-5e87-44a4-8e01-2939d4c21950)


As we complete bugs like #413, we can fill in the TODO area by calling new utils/functions to construct the correct prompt.