### PR TITLE
Enable random selection of payout items (per participant)

### DIFF
--- a/frontend/src/components/participant_view/participant_view.ts
+++ b/frontend/src/components/participant_view/participant_view.ts
@@ -230,7 +230,8 @@ export class ParticipantView extends MobxLitElement {
         `;
       case StageKind.PAYOUT:
         return html`
-          <payout-participant-view .stage=${stage}></payout-participant-view>
+          <payout-participant-view .stage=${stage} .answer=${answer}>
+          </payout-participant-view>
         `;
       case StageKind.REVEAL:
         return html`

--- a/frontend/src/components/stages/payout_editor.scss
+++ b/frontend/src/components/stages/payout_editor.scss
@@ -62,7 +62,7 @@
 
 .payout-item {
   @include common.flex-column;
-  background: var(--md-sys-color-surface);
+  background: var(--md-sys-color-surface-variant);
   border-radius: common.$spacing-medium;
   gap: common.$spacing-xl;
   padding: common.$spacing-large;

--- a/frontend/src/components/stages/payout_editor.ts
+++ b/frontend/src/components/stages/payout_editor.ts
@@ -387,11 +387,6 @@ export class PayoutEditor extends MobxLitElement {
   private renderBasePayoutEditor(item: PayoutItem, index: number) {
     if (!this.stage) return nothing;
 
-    const updateIsActive = () => {
-      const isActive = !item.isActive;
-      this.updatePayoutItem({...item, isActive}, index);
-    };
-
     const updateName = (e: InputEvent) => {
       const name = (e.target as HTMLTextAreaElement).value;
       this.updatePayoutItem({...item, name}, index);
@@ -417,16 +412,6 @@ export class PayoutEditor extends MobxLitElement {
           <div class="left">
             <div class="subtitle">
               Stage payout for: ${this.experimentEditor.getStage(item.stageId)?.name}
-            </div>
-            <div class="checkbox-wrapper">
-              <md-checkbox
-                touch-target="wrapper"
-                ?checked=${item.isActive}
-                ?disabled=${!this.experimentEditor.canEditStages}
-                @click=${updateIsActive}
-              >
-              </md-checkbox>
-              <div>Include this payout in experiment</div>
             </div>
           </div>
           ${this.renderPayoutItemNav(index)}

--- a/frontend/src/components/stages/payout_editor.ts
+++ b/frontend/src/components/stages/payout_editor.ts
@@ -392,6 +392,11 @@ export class PayoutEditor extends MobxLitElement {
       this.updatePayoutItem({...item, name}, index);
     };
 
+    const updateRandomSelectionId = (e: InputEvent) => {
+      const randomSelectionId = (e.target as HTMLTextAreaElement).value;
+      this.updatePayoutItem({...item, randomSelectionId}, index);
+    }
+
     const updateDescription = (e: InputEvent) => {
       const description = (e.target as HTMLTextAreaElement).value;
       this.updatePayoutItem({...item, description}, index);
@@ -405,6 +410,11 @@ export class PayoutEditor extends MobxLitElement {
     };
 
     const basePayoutId = `${item.id}-base`;
+    const randomSelectionLabel = `
+      Random selection group ID: Out of all payout items that share the
+      same group ID, one will be randomly selected to use for payout.
+      (Leave this field blank if the payout item should always be selected.)
+    `;
 
     return html`
       <div class="base-editor">
@@ -423,6 +433,14 @@ export class PayoutEditor extends MobxLitElement {
           .value=${item.name}
           ?disabled=${!this.experimentEditor.canEditStages}
           @input=${updateName}
+        >
+        </pr-textarea>
+        <pr-textarea
+          label=${randomSelectionLabel}
+          variant="outlined"
+          .value=${item.randomSelectionId}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @input=${updateRandomSelectionId}
         >
         </pr-textarea>
         <pr-textarea

--- a/frontend/src/components/stages/payout_participant_view.ts
+++ b/frontend/src/components/stages/payout_participant_view.ts
@@ -8,6 +8,7 @@ import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {
   PayoutStageConfig,
+  PayoutStageParticipantAnswer
 } from '@deliberation-lab/utils';
 
 import {styles} from './payout_view.scss';
@@ -18,6 +19,7 @@ export class PayoutView extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   @property() stage: PayoutStageConfig | null = null;
+  @property() answer: PayoutStageParticipantAnswer | null = null;
 
   override render() {
     if (!this.stage) {
@@ -26,7 +28,8 @@ export class PayoutView extends MobxLitElement {
 
     return html`
       <stage-description .stage=${this.stage}></stage-description>
-      <payout-summary-view .stage=${this.stage}></payout-summary-view>
+      <payout-summary-view .stage=${this.stage} .answer=${this.answer}>
+      </payout-summary-view>
       <stage-footer>
         ${this.stage.progress.showParticipantProgress
           ? html`<progress-stage-completed></progress-stage-completed>`

--- a/frontend/src/components/stages/payout_summary_view.ts
+++ b/frontend/src/components/stages/payout_summary_view.ts
@@ -48,6 +48,8 @@ export class PayoutView extends MobxLitElement {
       return nothing;
     }
 
+    // TODO: Pass in participant answer so that random selection items
+    // can be included accordingly
     const resultConfig = calculatePayoutResult(
       this.stage,
       this.experimentService.stageConfigMap,

--- a/frontend/src/components/stages/payout_summary_view.ts
+++ b/frontend/src/components/stages/payout_summary_view.ts
@@ -114,7 +114,13 @@ export class PayoutView extends MobxLitElement {
     item: DefaultPayoutItemResult,
     currency: PayoutCurrency
   ) {
-    return html` ${this.renderBaseAmountEarned(item, currency)} `;
+    return html`
+      <div class="scoring-bundle">
+        <h2>${item.name}</h2>
+        <div class="scoring-description">${item.description}</div>
+        ${this.renderBaseAmountEarned(item, currency)}
+      </div>
+    `;
   }
 
   private renderChipPayoutItemResult(

--- a/frontend/src/components/stages/payout_summary_view.ts
+++ b/frontend/src/components/stages/payout_summary_view.ts
@@ -18,6 +18,7 @@ import {
   PayoutItem,
   PayoutItemType,
   PayoutStageConfig,
+  PayoutStageParticipantAnswer,
   PayoutResultConfig,
   PayoutItemResult,
   StageConfig,
@@ -42,16 +43,16 @@ export class PayoutView extends MobxLitElement {
   private readonly participantService = core.getService(ParticipantService);
 
   @property() stage: PayoutStageConfig | null = null;
+  @property() answer: PayoutStageParticipantAnswer | null = null;
 
   override render() {
-    if (!this.stage || !this.participantService.profile) {
+    if (!this.stage || !this.answer || !this.participantService.profile) {
       return nothing;
     }
 
-    // TODO: Pass in participant answer so that random selection items
-    // can be included accordingly
     const resultConfig = calculatePayoutResult(
       this.stage,
+      this.answer,
       this.experimentService.stageConfigMap,
       this.cohortService.stagePublicDataMap,
       this.participantService.profile

--- a/frontend/src/components/stages/ranking_editor.scss
+++ b/frontend/src/components/stages/ranking_editor.scss
@@ -34,7 +34,7 @@ md-checkbox {
   @include common.flex-row-align-center;
   justify-content: space-between;
   padding: common.$spacing-medium;
-  background-color: var(--md-sys-color-surface);
+  background-color: var(--md-sys-color-surface-variant);
   border-radius: common.$spacing-medium;
 
   pr-textarea {

--- a/frontend/src/components/stages/survey_editor.scss
+++ b/frontend/src/components/stages/survey_editor.scss
@@ -18,7 +18,7 @@
 
 .question {
   @include common.flex-column;
-  background: var(--md-sys-color-surface);
+  background: var(--md-sys-color-surface-variant);
   border-radius: common.$spacing-medium;
   gap: common.$spacing-medium;
   padding: common.$spacing-xl;

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -85,6 +85,13 @@ export function downloadJSON(data: object, filename: string) {
   downloadBlob(blob, filename);
 }
 
+/** Make text CSV-compatibile. */
+export function toCSV(text: string|null) {
+  if (!text) return '';
+
+  return text.replaceAll(',', ''); // remove commas
+}
+
 // ****************************************************************************
 // EXPERIMENT DOWNLOAD JSON
 // ****************************************************************************
@@ -314,15 +321,15 @@ export function getChipNegotiationTurnColumns(
     return `${index + 1}`;
   };
 
-  columns.push(!turn ? 'Cohort' : game.cohortName);
-  columns.push(!turn ? 'Stage ID' : game.stageName);
+  columns.push(!turn ? 'Cohort' : toCSV(game.cohortName));
+  columns.push(!turn ? 'Stage ID' : toCSV(game.stageName));
   columns.push(!turn ? 'Round' : roundNumber.toString());
   columns.push(!turn ? 'Turn (player number)' : getPlayerNumber());
   columns.push(!turn ? 'Turn (sender ID)' : senderId);
   columns.push(
     !turn
       ? 'Turn (sender name)'
-      : data.participantMap[senderId]?.profile.name ?? ''
+      : toCSV(data.participantMap[senderId]?.profile.name) ?? ''
   );
   columns.push(
     !turn
@@ -505,13 +512,13 @@ export function getChipNegotiationPlayerMapCSV(
         : data.participantMap[player]?.profile.publicId ?? ''
     );
     columns.push(
-      !player ? 'Name' : data.participantMap[player]?.profile.name ?? ''
+      !player ? 'Name' : toCSV(data.participantMap[player]?.profile.name)
     );
     columns.push(
-      !player ? 'Avatar' : data.participantMap[player]?.profile.avatar ?? ''
+      !player ? 'Avatar' : toCSV(data.participantMap[player]?.profile.avatar)
     );
     columns.push(
-      !player ? 'Pronouns' : data.participantMap[player]?.profile.pronouns ?? ''
+      !player ? 'Pronouns' : toCSV(data.participantMap[player]?.profile.pronouns)
     );
 
     // Add column for each game
@@ -928,13 +935,13 @@ export function getParticipantProfileCSVColumns(
   columns.push(!profile ? 'Prolific ID' : profile.prolificId ?? '');
 
   // Profile name
-  columns.push(!profile ? 'Name' : profile.name ?? '');
+  columns.push(!profile ? 'Name' : toCSV(profile.name));
 
   // Profile avatar
-  columns.push(!profile ? 'Avatar' : profile.avatar ?? '');
+  columns.push(!profile ? 'Avatar' : toCSV(profile.avatar));
 
   // Profile pronouns
-  columns.push(!profile ? 'Pronouns' : profile.pronouns ?? '');
+  columns.push(!profile ? 'Pronouns' : toCSV(profile.pronouns));
 
   // Current status
   columns.push(!profile ? 'Current status' : profile.currentStatus);
@@ -1010,7 +1017,7 @@ export function getPayoutStageCSVColumns(
       resultConfig?.results.find((result) => result.id === item.id) ?? null;
 
     // Name of payout item
-    const name = `${item?.name} (${item?.id})`;
+    const name = `${toCSV(item?.name)} (${item?.id})`;
 
     // Column for amount earned if stage completed
     columns.push(
@@ -1043,7 +1050,7 @@ export function getPayoutStageCSVColumns(
               : null;
           columns.push(
             !participant
-              ? `Correct answer payout - ${question.questionTitle} - ${name} - Stage ${payoutStage.id}`
+              ? `Correct answer payout - "${toCSV(question.questionTitle)}" - ${name} - Stage ${payoutStage.id}`
               : questionResult?.amountEarned.toString() ?? ''
           );
         }
@@ -1142,8 +1149,8 @@ export function getSurveyStageCSVColumns(
           answer?.kind === SurveyQuestionKind.TEXT ? answer?.answer : '';
         columns.push(
           !participant
-            ? `${question.questionTitle} - Survey ${surveyStage.id}`
-            : textAnswer
+            ? `"${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
+            : toCSV(textAnswer)
         );
         break;
       case SurveyQuestionKind.CHECK:
@@ -1153,7 +1160,7 @@ export function getSurveyStageCSVColumns(
             : '';
         columns.push(
           !participant
-            ? `${question.questionTitle} - Survey ${surveyStage.id}`
+            ? `"${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
             : checkAnswer
         );
         break;
@@ -1166,9 +1173,9 @@ export function getSurveyStageCSVColumns(
         question.options.forEach((item, index) => {
           columns.push(
             !participant
-              ? `Option ${index + 1} (${item.id}) - ${
-                  question.questionTitle
-                } - Survey ${surveyStage.id}`
+              ? `Option ${index + 1} (${item.id}) - "${
+                  toCSV(question.questionTitle)
+                }" - Survey ${surveyStage.id}`
               : item.text
           );
         });
@@ -1176,7 +1183,7 @@ export function getSurveyStageCSVColumns(
         if (question.correctAnswerId) {
           columns.push(
             !participant
-              ? `Correct answer - ${question.questionTitle} - Survey ${surveyStage.id}`
+              ? `Correct answer - "${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
               : question.options.find(
                   (item) => item.id === question.correctAnswerId
                 )?.text ?? ''
@@ -1185,20 +1192,20 @@ export function getSurveyStageCSVColumns(
         // Add column for participant answer ID
         columns.push(
           !participant
-            ? `Participant answer (ID) - ${question.questionTitle} - Survey ${surveyStage.id}`
+            ? `Participant answer (ID) - "${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
             : mcAnswer
         );
         // Add column for participant text answer
         columns.push(
           !participant
-            ? `Participant answer (text) - ${question.questionTitle} - Survey ${surveyStage.id}`
+            ? `Participant answer (text) - "${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
             : question.options.find((item) => item.id === mcAnswer)?.text ?? ''
         );
         // If correct answer, add column for if answer was correct
         if (question.correctAnswerId) {
           columns.push(
             !participant
-              ? `Is participant correct? - ${question.questionTitle} - Survey ${surveyStage.id}`
+              ? `Is participant correct? - "${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
               : (mcAnswer === question.correctAnswerId).toString()
           );
         }
@@ -1210,7 +1217,7 @@ export function getSurveyStageCSVColumns(
             : '';
         columns.push(
           !participant
-            ? `${question.questionTitle} - Survey ${surveyStage.id}`
+            ? `"${toCSV(question.questionTitle)}" - Survey ${surveyStage.id}`
             : scaleAnswer
         );
         break;
@@ -1246,8 +1253,8 @@ export function getSurveyPerParticipantStageCSVColumns(
             answer?.kind === SurveyQuestionKind.TEXT ? answer?.answer : '';
           columns.push(
             !participant
-              ? `${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
-              : textAnswer
+              ? `"${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
+              : toCSV(textAnswer)
           );
           break;
         case SurveyQuestionKind.CHECK:
@@ -1257,7 +1264,7 @@ export function getSurveyPerParticipantStageCSVColumns(
               : '';
           columns.push(
             !participant
-              ? `${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+              ? `"${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
               : checkAnswer
           );
           break;
@@ -1270,9 +1277,9 @@ export function getSurveyPerParticipantStageCSVColumns(
           question.options.forEach((item, index) => {
             columns.push(
               !participant
-                ? `Option ${index + 1} (${item.id}) - ${
-                    question.questionTitle
-                  } - ${participantId} - Per-Participant Survey ${stage.id}`
+                ? `Option ${index + 1} (${item.id}) - "${
+                    toCSV(question.questionTitle)
+                  }" - ${participantId} - Per-Participant Survey ${stage.id}`
                 : item.text
             );
           });
@@ -1280,7 +1287,7 @@ export function getSurveyPerParticipantStageCSVColumns(
           if (question.correctAnswerId) {
             columns.push(
               !participant
-                ? `Correct answer - ${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+                ? `Correct answer - "${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
                 : question.options.find(
                     (item) => item.id === question.correctAnswerId
                   )?.text ?? ''
@@ -1289,13 +1296,13 @@ export function getSurveyPerParticipantStageCSVColumns(
           // Add column for participant answer ID
           columns.push(
             !participant
-              ? `Participant answer (ID) - ${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+              ? `Participant answer (ID) - "${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
               : mcAnswer
           );
           // Add column for participant text answer
           columns.push(
             !participant
-              ? `Participant answer (text) - ${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+              ? `Participant answer (text) - "${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
               : question.options.find((item) => item.id === mcAnswer)?.text ??
                   ''
           );
@@ -1303,7 +1310,7 @@ export function getSurveyPerParticipantStageCSVColumns(
           if (question.correctAnswerId) {
             columns.push(
               !participant
-                ? `Is participant correct? - ${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+                ? `Is participant correct? - "${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
                 : (mcAnswer === question.correctAnswerId).toString()
             );
           }
@@ -1315,7 +1322,7 @@ export function getSurveyPerParticipantStageCSVColumns(
               : '';
           columns.push(
             !participant
-              ? `${question.questionTitle} - ${participantId} - Per-Participant Survey ${stage.id}`
+              ? `"${toCSV(question.questionTitle)}" - ${participantId} - Per-Participant Survey ${stage.id}`
               : scaleAnswer
           );
           break;
@@ -1356,16 +1363,16 @@ export function getChatMessageCSVColumns(
   columns.push(!message ? 'Participant public ID' : publicId);
 
   // Profile name
-  columns.push(!message ? 'Sender name' : message.profile.name ?? '');
+  columns.push(!message ? 'Sender name' : toCSV(message.profile.name));
 
   // Profile avatar
-  columns.push(!message ? 'Sender avatar' : message.profile.avatar ?? '');
+  columns.push(!message ? 'Sender avatar' : toCSV(message.profile.avatar));
 
   // Profile pronouns
-  columns.push(!message ? 'Sender pronouns' : message.profile.pronouns ?? '');
+  columns.push(!message ? 'Sender pronouns' : toCSV(message.profile.pronouns));
 
   // Message content
-  columns.push(!message ? 'Message content' : message.message);
+  columns.push(!message ? 'Message content' : toCSV(message.message));
 
   return columns;
 }

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -1009,6 +1009,9 @@ export function getPayoutStageCSVColumns(
     const resultItem =
       resultConfig?.results.find((result) => result.id === item.id) ?? null;
 
+    // Name of payout item
+    const name = `${item?.name} (${item?.id})`;
+
     // Column for amount earned if stage completed
     columns.push(
       !participant
@@ -1022,7 +1025,7 @@ export function getPayoutStageCSVColumns(
       // (or null if using current participant's answers)
       columns.push(
         !participant
-          ? `Ranking stage used for payout- ${name} - Stage ${payoutStage.id}`
+          ? `Ranking stage used for payout - ${name} - Stage ${payoutStage.id}`
           : item.rankingStageId ?? ''
       );
 
@@ -1040,7 +1043,7 @@ export function getPayoutStageCSVColumns(
               : null;
           columns.push(
             !participant
-              ? `Correct answer payout - ${question.questionTitle} - Stage ${payoutStage.id}`
+              ? `Correct answer payout - ${question.questionTitle} - ${name} - Stage ${payoutStage.id}`
               : questionResult?.amountEarned.toString() ?? ''
           );
         }

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -27,6 +27,7 @@ import {
   ParticipantProfileExtended,
   PayoutItemType,
   PayoutStageConfig,
+  PayoutStageParticipantAnswer,
   RankingStageConfig,
   RankingStagePublicData,
   StageConfig,
@@ -985,12 +986,16 @@ export function getPayoutStageCSVColumns(
   const cohortId = participant ? participant.profile.currentCohortId : null;
   const publicDataMap = cohortId ? data.cohortMap[cohortId]?.dataMap : {};
 
+  // Get participant answer (which specifies which random selection
+  // payout items to use)
+  const answer = !participant ? null :
+    participant.answerMap[payoutStage.id] as PayoutStageParticipantAnswer;
+
   // Get payout results
-  // TODO: Pass in participant answer so that random selection items
-  // can be included accordingly
-  const resultConfig = participant
+  const resultConfig = participant && answer
     ? calculatePayoutResult(
         payoutStage,
+        answer,
         data.stageMap,
         publicDataMap,
         participant.profile

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -986,6 +986,8 @@ export function getPayoutStageCSVColumns(
   const publicDataMap = cohortId ? data.cohortMap[cohortId]?.dataMap : {};
 
   // Get payout results
+  // TODO: Pass in participant answer so that random selection items
+  // can be included accordingly
   const resultConfig = participant
     ? calculatePayoutResult(
         payoutStage,

--- a/frontend/src/shared/games/chip_negotiation.ts
+++ b/frontend/src/shared/games/chip_negotiation.ts
@@ -520,17 +520,19 @@ const CHIP_NEGOTIATION_STAGE2 = createChipStage({
 // Payout stage
 // ****************************************************************************
 export function createPayoutItems() {
-  const game1Selected = randint(0, 1) === 1;
+  // Only one payout item with this ID will be selected (at random)
+  // for each participant
+  const RANDOM_SELECTION_ID = 'negotiation-payout';
 
   const game1 = createChipPayoutItem({
-    isActive: game1Selected,
+    randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Payout from game 1 (one game was randomly selected)',
     stageId: CHIP_NEGOTIATION_STAGE1_ID,
     baseCurrencyAmount: 0,
   });
 
   const game2 = createChipPayoutItem({
-    isActive: !game1Selected,
+    randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Payout from game 2 (one game was randomly selected)',
     stageId: CHIP_NEGOTIATION_STAGE2_ID,
     baseCurrencyAmount: 0,

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -777,10 +777,12 @@ export function createLASPayoutItems() {
   const part1Question = choice(LAS_INDIVIDUAL_ITEMS_MULTIPLE_CHOICE_QUESTIONS);
   part1.questionMap[part1Question.id] = 2;
 
-  const part2Selected = randint(0, 1) === 1;
+  // Only one payout item with this ID will be selected (at random)
+  // for each participant
+  const RANDOM_SELECTION_ID = 'las-part';
 
   const part2 = createSurveyPayoutItem({
-    isActive: part2Selected,
+    randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Parts 2 and 3 payoff - Part 2 selected',
     description: [
       LAS_PAYMENT_PARTS_2_AND_3_DESCRIPTION,
@@ -793,7 +795,7 @@ export function createLASPayoutItems() {
   part2.questionMap[part2Question.id] = 2;
 
   const part3 = createSurveyPayoutItem({
-    isActive: !part2Selected,
+    randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Parts 2 and 3 payoff - Part 3 selected',
     description: [
       LAS_PAYMENT_PARTS_2_AND_3_DESCRIPTION,

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -769,6 +769,7 @@ const LAS_PAYOUT_INFO_STAGE = createInfoStage({
 
 export function createLASPayoutItems() {
   const part1 = createSurveyPayoutItem({
+    id: 'payout-part-1',
     name: 'Part 1 payoff',
     description: LAS_PAYMENT_PART_1_DESCRIPTION,
     stageId: LAS_PART_1_SURVIVAL_SURVEY_STAGE_ID,
@@ -782,6 +783,7 @@ export function createLASPayoutItems() {
   const RANDOM_SELECTION_ID = 'las-part';
 
   const part2 = createSurveyPayoutItem({
+    id: 'payout-part-2',
     randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Parts 2 and 3 payoff - Part 2 selected',
     description: [
@@ -795,6 +797,7 @@ export function createLASPayoutItems() {
   part2.questionMap[part2Question.id] = 2;
 
   const part3 = createSurveyPayoutItem({
+    id: 'payout-part-3',
     randomSelectionId: RANDOM_SELECTION_ID,
     name: 'Parts 2 and 3 payoff - Part 3 selected',
     description: [
@@ -812,6 +815,7 @@ export function createLASPayoutItems() {
 }
 
 const LAS_PAYOUT_STAGE = createPayoutStage({
+  id: 'payout',
   game: StageGame.LAS,
   currency: PayoutCurrency.GBP,
   descriptions: createStageTextConfig({

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,8 @@
         "name": "ts-lit-plugin"
       }
     ],
+    "lib": ["es2021", "dom"],
+    "target": "es2021",
     "outDir": "./dist/",
     "noImplicitAny": true,
     "module": "es6",

--- a/functions/src/participant.triggers.ts
+++ b/functions/src/participant.triggers.ts
@@ -5,6 +5,7 @@ import {
   StageConfig,
   StageKind,
   createChipStageParticipantAnswer,
+  createPayoutStageParticipantAnswer
 } from '@deliberation-lab/utils';
 
 import { app } from './app';
@@ -79,9 +80,9 @@ export const setParticipantStageData = onDocumentCreated(
             transaction.set(publicChipDoc, publicChipData);
             break;
           case StageKind.PAYOUT:
-            // TODO: Create utils function to create map of
-            // random selection ID to chosen payout item
-            // and store in new PayoutStageParticipantAnswer
+            // If payout stage, set random selection of payout items
+            const payoutAnswer = createPayoutStageParticipantAnswer(stage);
+            transaction.set(stageDoc, payoutAnswer);
           default:
             break;
         }

--- a/functions/src/participant.triggers.ts
+++ b/functions/src/participant.triggers.ts
@@ -78,6 +78,10 @@ export const setParticipantStageData = onDocumentCreated(
             publicChipData.participantChipValueMap[publicId] = chipAnswer.chipValueMap;
             transaction.set(publicChipDoc, publicChipData);
             break;
+          case StageKind.PAYOUT:
+            // TODO: Create utils function to create map of
+            // random selection ID to chosen payout item
+            // and store in new PayoutStageParticipantAnswer
           default:
             break;
         }

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -27,8 +27,9 @@ import { StageConfig } from './stages/stage';
   * VERSION 10 - add baseCurrencyAmount to PayoutItemResult (PR #384)
   * VERSION 11 - add anonymous profile map to ParticipantProfile (PR #391)
   * VERSION 12 - add cohortLockMap to Experiment (PR #402)
+  * VERSION 13 - add randomSelectionId to payout stage (PR #430)
   */
-export const EXPERIMENT_VERSION_ID = 12;
+export const EXPERIMENT_VERSION_ID = 13;
 
 /** Experiment. */
 export interface Experiment {

--- a/utils/src/stages/payout_stage.ts
+++ b/utils/src/stages/payout_stage.ts
@@ -245,22 +245,31 @@ export function generatePayoutRandomSelectionMap(
 /** Calculate payout results. */
 export function calculatePayoutResult(
   payoutConfig: PayoutStageConfig,
+  // Participant answer map contains random selection of relevant payout items
+  payoutAnswer: PayoutStageParticipantAnswer,
   stageConfigMap: Record<string, StageConfig>, // stage ID to config
   publicDataMap: Record<string, StagePublicData>, // stage ID to public data
   profile: ParticipantProfile, // current participant profile
 ): PayoutResultConfig {
   let results: PayoutItemResult[] = [];
 
-  // TODO: For each payout item with a randomSelectionId,
+  // For each payout item, only add result to list if item is active;
+  // if the payout item has a randomSelectionId,
   // only add the item if it was randomly selected for that participant
-
-  // For each payout item, add result to list if item is active
   payoutConfig.payoutItems.forEach((item) => {
-    if (item.isActive) {
-      const result = calculatePayoutItemResult(item, stageConfigMap, publicDataMap, profile);
-      if (result) {
-        results.push(result);
-      }
+    if (!item.isActive) {
+      return;
+    }
+    if (
+      item.randomSelectionId !== null &&
+      payoutAnswer.randomSelectionMap[item.randomSelectionId] !== item.id
+    ) {
+      return;
+    }
+    // Item is active and (if randomSelectionId) is selected
+    const result = calculatePayoutItemResult(item, stageConfigMap, publicDataMap, profile);
+    if (result) {
+      results.push(result);
     }
   });
 

--- a/utils/src/stages/payout_stage.ts
+++ b/utils/src/stages/payout_stage.ts
@@ -44,6 +44,10 @@ export interface BasePayoutItem {
   stageId: string;
   // Fixed payout added if stage is completed
   baseCurrencyAmount: number;
+  // Only select one payout item for each random selection ID
+  // e.g., if two payout items have random selection ID 'survival-task',
+  // one of them will be randomly selected (on participant creation)
+  randomSelectionId: string|null;
 }
 
 export enum PayoutItemType {
@@ -154,6 +158,7 @@ export function createDefaultPayoutItem(
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
+    randomSelectionId: config.randomSelectionId ?? null,
   };
 }
 
@@ -167,6 +172,7 @@ export function createChipPayoutItem(config: Partial<ChipPayoutItem> = {}): Chip
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
+    randomSelectionId: config.randomSelectionId ?? null,
   };
 }
 
@@ -180,6 +186,7 @@ export function createSurveyPayoutItem(config: Partial<SurveyPayoutItem> = {}): 
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
+    randomSelectionId: config.randomSelectionId ?? null,
     rankingStageId: config.rankingStageId ?? null,
     questionMap: config.questionMap ?? {},
   };
@@ -193,6 +200,9 @@ export function calculatePayoutResult(
   profile: ParticipantProfile, // current participant profile
 ): PayoutResultConfig {
   let results: PayoutItemResult[] = [];
+
+  // TODO: For each payout item with a randomSelectionId,
+  // only add the item if it was randomly selected for that participant
 
   // For each payout item, add result to list if item is active
   payoutConfig.payoutItems.forEach((item) => {

--- a/utils/src/stages/payout_stage.ts
+++ b/utils/src/stages/payout_stage.ts
@@ -45,10 +45,11 @@ export interface BasePayoutItem {
   stageId: string;
   // Fixed payout added if stage is completed
   baseCurrencyAmount: number;
-  // Only select one payout item for each random selection ID
+  // Only select one payout item for each (non-empty) random selection ID
   // e.g., if two payout items have random selection ID 'survival-task',
-  // one of them will be randomly selected (on participant creation)
-  randomSelectionId: string|null;
+  // one of them will be randomly selected (on participant creation).
+  // Leave empty if item should always be selected.
+  randomSelectionId: string;
 }
 
 export enum PayoutItemType {
@@ -166,7 +167,7 @@ export function createDefaultPayoutItem(
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
-    randomSelectionId: config.randomSelectionId ?? null,
+    randomSelectionId: config.randomSelectionId ?? '',
   };
 }
 
@@ -180,7 +181,7 @@ export function createChipPayoutItem(config: Partial<ChipPayoutItem> = {}): Chip
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
-    randomSelectionId: config.randomSelectionId ?? null,
+    randomSelectionId: config.randomSelectionId ?? '',
   };
 }
 
@@ -194,7 +195,7 @@ export function createSurveyPayoutItem(config: Partial<SurveyPayoutItem> = {}): 
     isActive: config.isActive ?? true,
     stageId: config.stageId ?? '',
     baseCurrencyAmount: config.baseCurrencyAmount ?? 0,
-    randomSelectionId: config.randomSelectionId ?? null,
+    randomSelectionId: config.randomSelectionId ?? '',
     rankingStageId: config.rankingStageId ?? null,
     questionMap: config.questionMap ?? {},
   };
@@ -224,7 +225,7 @@ export function generatePayoutRandomSelectionMap(
   // Group payout items by their random selection IDs (if applicable)
   payoutItems.forEach((item) => {
     const randomSelectionId = item.randomSelectionId;
-    if (randomSelectionId === null) return;
+    if (!randomSelectionId) return;
 
     if (!randomSelectionGroups[randomSelectionId]) {
       randomSelectionGroups[randomSelectionId] = [];
@@ -261,7 +262,7 @@ export function calculatePayoutResult(
       return;
     }
     if (
-      item.randomSelectionId !== null &&
+      item.randomSelectionId !== '' &&
       payoutAnswer.randomSelectionMap[item.randomSelectionId] !== item.id
     ) {
       return;

--- a/utils/src/stages/payout_stage.validation.ts
+++ b/utils/src/stages/payout_stage.validation.ts
@@ -34,7 +34,7 @@ export const DefaultPayoutItemData = Type.Object(
     isActive: Type.Boolean(),
     stageId: Type.String(),
     baseCurrencyAmount: Type.Number(),
-    randomSelectionId: Type.Union([Type.String(), Type.Null()]),
+    randomSelectionId: Type.String(),
   },
   strict
 );

--- a/utils/src/stages/payout_stage.validation.ts
+++ b/utils/src/stages/payout_stage.validation.ts
@@ -34,6 +34,7 @@ export const DefaultPayoutItemData = Type.Object(
     isActive: Type.Boolean(),
     stageId: Type.String(),
     baseCurrencyAmount: Type.Number(),
+    randomSelectionId: Type.Union([Type.String(), Type.Null()]),
   },
   strict
 );

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -21,7 +21,10 @@ import {
   createRankingStagePublicData,
 } from './ranking_stage';
 import { InfoStageConfig } from './info_stage';
-import { PayoutStageConfig } from './payout_stage';
+import {
+  PayoutStageConfig,
+  PayoutStageParticipantAnswer
+} from './payout_stage';
 import { ProfileStageConfig } from './profile_stage';
 import { RevealStageConfig } from './reveal_stage';
 import {
@@ -123,6 +126,7 @@ export type StageParticipantAnswer =
  | ChatStageParticipantAnswer
  | ChipStageParticipantAnswer
  | ComprehensionStageParticipantAnswer
+ | PayoutStageParticipantAnswer
  | RankingStageParticipantAnswer
  | SurveyStageParticipantAnswer
  | SurveyPerParticipantStageParticipantAnswer;


### PR DESCRIPTION
Fixes #422 #398 

When configuring payout items, experimenters can assign a "random selection ID" to each item. For each unique "random selection ID," one of the items tagged with that ID is randomly selected (for each participant as the participant profile is created).

> Example: Payout stage includes a payout item "survey-1" and a payout item "survey-2". Both payout items are assigned the random selection ID "survey-payout." When a participant joins the experiment, either survey-1 or survey-2 is selected (randomly), and a resulting map is written to the participant's stage data, e.g., `{ 'survey-payout': 'survey-1' }`. This map is then referenced when determining whether to calculate payout (e.g., if an item has the random selection ID 'survey-payout' but is not 'survey-1', it will not be included in payout).

The function `calculatePayoutResult` (used to render participant payout views and fill data download CSV columns) takes in an extra `PayoutStageParticipantAnswer` param and only constructs "payout item results" for items that are active AND (have no random selection ID XOR have a random selection ID and are selected as per the participant answer).

NOTE: This also fixes CSV comma/column bugs by running text values through a `toCSV` function.