### PR TITLE
Add unit test for OpenAI API.

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "firebase-functions-test": "^3.1.0",
+        "nock": "^14.0.1",
         "ts-jest": "^29.2.5",
         "typescript": "^4.9.0"
       },
@@ -2610,6 +2611,24 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2641,6 +2660,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
@@ -6136,6 +6180,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6998,6 +7049,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7413,6 +7471,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.1.tgz",
+      "integrity": "sha512-IJN4O9pturuRdn60NjQ7YkFt6Rwei7ZKaOwb1tvUIIqTgeD0SDDAX3vrqZD4wcXczeEy/AsUXxpGpP/yHqV7xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.37.3",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.62.0",
       "license": "MIT",
@@ -7682,6 +7755,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -8001,6 +8081,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proto3-json-serializer": {
@@ -8733,6 +8823,13 @@
       "version": "1.0.3",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "firebase-functions-test": "^3.1.0",
+    "nock": "^14.0.1",
     "ts-jest": "^29.2.5",
     "typescript": "^4.9.0"
   },

--- a/functions/src/api/model.response.ts
+++ b/functions/src/api/model.response.ts
@@ -1,7 +1,7 @@
 /**
  * Common interface for all model responses.
  */
-interface ModelResponse {
+export interface ModelResponse {
     score?: number;
     text: string;
 }

--- a/functions/src/api/ollama.api.test.ts
+++ b/functions/src/api/ollama.api.test.ts
@@ -1,22 +1,32 @@
-import { ollamaChat } from "./ollama.api";
+import nock = require('nock');
 
-/**
- * Test assumes a container with ollama is running on port 11434
- * Download the docker image to run :
- * https://ollama.com/blog/ollama-is-now-available-as-an-official-docker-image
- * 
- * Example docker instance hosting an ollama server: https://github.com/dimits-ts/deliberate-lab-utils/tree/master/llm_server
- */
+import { ollamaChat } from "./ollama.api";
 
 const MODEL_TYPE = "llama3.2";
 const LLM_SERVER_ENDPOINT = "http://localhost:11434/api/chat";
+const LLM_SERVER_HOST = "http://localhost:11434";
+const LLM_SERVER_PATH = "/api/chat";
 const TEST_MESSAGE = "Say hello!";
 
 
 describe("OllamaChat Client", () => {
-    it("should return a response containing 'hello' (case insensitive)", async () => {
-        const response = await ollamaChat([TEST_MESSAGE], {url: LLM_SERVER_ENDPOINT, llmType: MODEL_TYPE});
-        expect(response.text.toLowerCase()).toContain("hello");
-        console.log(response);
-    });
+  it("should return a response containing 'hello' (case insensitive)", async () => {
+    nock(LLM_SERVER_HOST)
+      .post(LLM_SERVER_PATH)
+      .reply(200, {
+        'created_at': Date.now(),
+        'model': MODEL_TYPE,
+        'message': {
+          'role': 'assistant',
+          'content': 'Hello!',
+        },
+        'done': true,
+      });
+    
+    const response = await ollamaChat([TEST_MESSAGE], {url: LLM_SERVER_ENDPOINT, llmType: MODEL_TYPE});
+    expect(response.text.toLowerCase()).toContain("hello");
+    console.log(response);
+    
+    nock.cleanAll();
+  });
 });

--- a/functions/src/api/ollama.api.ts
+++ b/functions/src/api/ollama.api.ts
@@ -9,6 +9,7 @@
  */
 
 import { OllamaServerConfig } from "@deliberation-lab/utils"
+import { ModelResponse } from './model.response';
 
 
 /**
@@ -56,7 +57,7 @@ async function decodeResponse(response: Response): Promise<string> {
         throw new Error("Failed to read response body");
     }
 
-    const { done, value } = await reader.read();
+    const { done: _, value } = await reader.read();
     const rawjson = new TextDecoder().decode(value);
 
     if (isError(rawjson)) {

--- a/functions/src/api/openai.api.test.ts
+++ b/functions/src/api/openai.api.test.ts
@@ -1,0 +1,47 @@
+import nock = require('nock');
+
+import { AgentGenerationConfig } from '@deliberation-lab/utils';
+import { getOpenAIAPITextCompletionResponse } from './openai.api';
+import { ModelResponse } from './model.response';
+
+
+describe('OpenAI-compatible API', () => {
+  it('handles text completion request', async () => {
+    nock('https://test.uri')
+      .post('/v1/completions')
+      .reply(200, {
+        'id': 'test-id',
+        'object': 'text_completion',
+        'created': Date.now(),
+        'model': 'test-model',
+        'choices': [
+          {
+            'text': 'test output',
+            'index': 0,
+            'logprobs': null,
+            'finish_reason': 'stop',
+          }
+        ],
+      });
+
+    const generationConfig: AgentGenerationConfig = {
+      temperature: 0.7,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      customRequestBodyFields: [ {name: 'foo', value: 'bar'} ]
+    };
+
+    const response: ModelResponse = await getOpenAIAPITextCompletionResponse(
+      'testapikey',
+      'https://test.uri/v1/',
+      'test-model',
+      'This is a test prompt.',
+      generationConfig
+    );
+
+    expect(response.text).toEqual('test output');
+
+    nock.cleanAll();
+  });
+});

--- a/functions/src/api/openai.api.ts
+++ b/functions/src/api/openai.api.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai"
 import {
   AgentGenerationConfig
 } from '@deliberation-lab/utils';
+import { ModelResponse } from './model.response';
 
 const MAX_TOKENS_FINISH_REASON = "length";
 
@@ -10,7 +11,7 @@ export async function callOpenAITextCompletion(
   baseUrl: string | null,
   modelName: string,
   prompt: string,
-  generationConfig: agentGenerationConfig
+  generationConfig: AgentGenerationConfig
 ) {
   const client = new OpenAI({
     apiKey: apiKey,
@@ -27,7 +28,6 @@ export async function callOpenAITextCompletion(
     top_p: generationConfig.topP,
     frequency_penalty: generationConfig.frequencyPenalty,
     presence_penalty: generationConfig.presencePenalty,
-    // @ts-expect-error allow extra request fields
     ...customFields
   });
 
@@ -37,7 +37,7 @@ export async function callOpenAITextCompletion(
     return { text: '' };
   }
 
-  const finishReason = response.choices[0].finishReason;
+  const finishReason = response.choices[0].finish_reason;
   if (finishReason === MAX_TOKENS_FINISH_REASON) {
     console.error(
       `Error: Token limit exceeded`


### PR DESCRIPTION
Add a unit test for the OpenAI API, using nock to mock out the API call. Also change the ollama unit test to use nock, so that it can run without a running ollama instance.

This also fixes a few minor errors in the two API implementations, that the tests caught.