### PR TITLE
Improve styling for sampling parameters.

### DIFF
--- a/frontend/src/components/stages/chat_editor.scss
+++ b/frontend/src/components/stages/chat_editor.scss
@@ -101,6 +101,15 @@ pr-textarea {
   width: max-content;
 }
 
+.name-value-input {
+  @include common.flex-row;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  width: max-content;
+}
+
 .divider {
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }

--- a/frontend/src/components/stages/chat_editor.ts
+++ b/frontend/src/components/stages/chat_editor.ts
@@ -450,11 +450,11 @@ export class ChatEditor extends MobxLitElement {
       <div class="description">
         Currently only used for OpenAI and OAI-compatible APIs.
       </div>
+      <label for="temperature">Temperature</label>
+        <div class="description">
+          The lower this value, the more deterministic the model's outcome will be.
+        </div>
       <div class="number-input">
-        <label for="temperature">Temperature</label>
-          <div class="description">
-            The lower this value, the more deterministic the model's outcome will be.
-          </div>
         <input
           .disabled=${!this.experimentEditor.canEditStages}
           type="number"
@@ -464,10 +464,12 @@ export class ChatEditor extends MobxLitElement {
           .value=${agent.generationConfig.temperature}
           @input=${updateTemperature}
         />
-        <label for="topP">Top P</label>
-          <div class="description">
-            If this value is less than 1.0, the model will discard unlikely tokens and sample from only tokens comprising that much probability mass.
-          </div>
+       </div>
+       <label for="topP">Top P</label>
+         <div class="description">
+           If this value is less than 1.0, the model will discard unlikely tokens and sample from only tokens comprising that much probability mass.
+         </div>
+      <div class="number-input">
         <input
           .disabled=${!this.experimentEditor.canEditStages}
           type="number"
@@ -477,27 +479,31 @@ export class ChatEditor extends MobxLitElement {
           .value=${agent.generationConfig.topP}
           @input=${updateTopP}
         />
-        <label for="frequencyPenalty">Frequency penalty</label>
-          <div class="description">
-            Positive values will penalize tokens based on how frequently they have appeared in the text.
-          </div>
+      </div>
+      <label for="frequencyPenalty">Frequency penalty</label>
+        <div class="description">
+          Positive values will penalize tokens based on how frequently they have appeared in the text.
+        </div>
+      <div class="number-input">
         <input
           .disabled=${!this.experimentEditor.canEditStages}
           type="number"
-          min="-2.0"
+          min="0.0"
           max="2.0"
           step="0.1"
           .value=${agent.generationConfig.frequencyPenalty}
           @input=${updateFrequencyPenalty}
         />
+      </div>
         <label for="presencePenalty">Presence penalty</label>
           <div class="description">
             Positive values will penalize tokens that have already appeared in the text (regardless of frequency).
           </div>
+      <div class="number-input">
         <input
           .disabled=${!this.experimentEditor.canEditStages}
           type="number"
-          min="-2.0"
+          min="0.0"
           max="2.0"
           step="0.1"
           .value=${agent.generationConfig.presencePenalty}
@@ -550,7 +556,7 @@ export class ChatEditor extends MobxLitElement {
          Add custom fields to the request body.
        </div>
        ${agent.generationConfig.customRequestBodyFields.map((field, fieldIndex) => html`
-         <div class="custom-field">
+         <div class="name-value-input">
            <pr-textarea
              label="Field name"
              variant="outlined"


### PR DESCRIPTION
Add a new name-value-input for custom body request fields. Move each numerical sampling parameter into its own number-input div so they're not as wide.

Also set the minimum of the frequency penalty and presence penalty boxes to 0; this makes them equal in width to the others, and it's unlikely that a user would want to set them below 0. (If they really want to type a negative number, I think it will work anyway.)