### PR TITLE
Add new (refactored) agent configs and UI editor

### DIFF
--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -1,0 +1,105 @@
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+:host {
+  @include common.flex-column;
+  overflow: auto;
+  padding: common.$main-content-padding;
+}
+
+.agent-wrapper {
+  @include common.flex-column;
+  gap: common.$spacing-xl;
+  max-width: common.$info-content-max-width;
+}
+
+.section-header {
+  @include common.flex-column;
+}
+
+.section-title {
+  @include typescale.title-medium;
+}
+
+.section {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+}
+
+.field {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
+.field-title,
+.radio-question-label {
+  @include typescale.label-small;
+}
+
+.description {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  font-style: italic;
+}
+
+.radio-question {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+}
+
+.radio-button {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-medium;
+  min-height: calc(var(--md-sys-typescale-body-small-line-height) * 1.5);
+}
+
+.radio-wrapper {
+  @include common.flex-row;
+  flex-wrap: wrap;
+  gap: common.$spacing-xl;
+  max-width: 500px;
+}
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+pr-textarea {
+  flex-grow: 1;
+  width: 100%;
+}
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}
+
+.name-value-input {
+  @include common.flex-row;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  width: max-content;
+}
+
+.divider {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.tab {
+  margin-top: 0px;
+  margin-left: calc(48px + common.$spacing-medium);
+}
+
+.error-message {
+  font-style: italic;
+  color: red;
+}

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -1,0 +1,394 @@
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/textarea';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {AgentEditor} from '../../services/agent.editor';
+import {ExperimentEditor} from '../../services/experiment.editor';
+
+import {AgentMediatorConfig, checkApiKeyExists} from '@deliberation-lab/utils';
+import {LLM_AGENT_AVATARS} from '../../shared/constants';
+import {getHashBasedColor} from '../../shared/utils';
+
+import {styles} from './agent_editor.scss';
+
+/** Editor for configuring agents. */
+@customElement('agent-editor')
+export class AgentEditorComponent extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly agentEditor = core.getService(AgentEditor);
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  @property() agent: AgentMediatorConfig | undefined = undefined;
+
+  override render() {
+    if (this.agent === undefined) {
+      return nothing;
+    }
+
+    const agentConfig = this.agent;
+    // TODO: Add API key check
+    return html`
+      <div class="agent-wrapper">
+        ${this.renderAgentName(agentConfig)} ${this.renderAvatars(agentConfig)}
+        ${this.renderAgentModel(agentConfig)}
+        ${this.renderAgentPrompt(agentConfig)}
+        ${this.renderAgentWordsPerMinute(agentConfig)}
+        <div class="divider"></div>
+        ${this.renderAgentSamplingParameters(agentConfig)}
+        <div class="divider"></div>
+        ${this.renderAgentCustomRequestBodyFields(agentConfig)}
+      </div>
+    `;
+  }
+
+  private renderAgentName(agent: AgentMediatorConfig) {
+    const updateName = (e: InputEvent) => {
+      const name = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorName(agent.id, name);
+    };
+
+    return html`
+      <pr-textarea
+        label="Name"
+        placeholder="Display name for agent"
+        variant="outlined"
+        .value=${agent.name}
+        ?disabled=${!this.experimentEditor.canEditStages}
+        @input=${updateName}
+      >
+      </pr-textarea>
+    `;
+  }
+
+  private renderAgentModel(agent: AgentMediatorConfig) {
+    const updateModel = (e: InputEvent) => {
+      const modelName = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorModelSettings(agent.id, {modelName});
+    };
+
+    return html`
+      <pr-textarea
+        label="Model"
+        placeholder="Model ID"
+        variant="outlined"
+        .value=${agent.modelSettings.modelName}
+        ?disabled=${!this.experimentEditor.canEditStages}
+        @input=${updateModel}
+      >
+      </pr-textarea>
+    `;
+  }
+
+  private renderAgentPrompt(agent: AgentMediatorConfig) {
+    const updatePrompt = (e: InputEvent) => {
+      const prompt = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorPromptConfig(agent.id, {prompt});
+    };
+
+    return html`
+      <div class="field">
+        <div class="field-title">Prompt</div>
+        <div class="description">
+          <b>Note:</b> Your custom prompt will be concatenated with the chat
+          history (last 10 messages) and sent to the model (i.e., chat history +
+          custom prompt => response)
+        </div>
+        <pr-textarea
+          placeholder="Custom prompt for agent"
+          variant="outlined"
+          .value=${agent.promptConfig.prompt}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @input=${updatePrompt}
+        >
+        </pr-textarea>
+      </div>
+    `;
+  }
+
+  private renderAvatars(agent: AgentMediatorConfig) {
+    const handleAvatarClick = (e: Event) => {
+      const value = Number((e.target as HTMLInputElement).value);
+      const avatar = LLM_AGENT_AVATARS[value];
+      this.agentEditor.updateAgentMediatorAvatar(agent.id, avatar);
+    };
+
+    const renderAvatarRadio = (emoji: string, index: number) => {
+      return html`
+        <div class="radio-button">
+          <md-radio
+            id=${emoji}
+            name="${agent.id}-avatar"
+            value=${index}
+            aria-label=${emoji}
+            ?checked=${agent.avatar === emoji}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @change=${handleAvatarClick}
+          >
+          </md-radio>
+          <avatar-icon
+            .emoji=${emoji}
+            .square=${true}
+            .color=${getHashBasedColor(emoji)}
+          >
+          </avatar-icon>
+        </div>
+      `;
+    };
+
+    return html`
+      <div class="radio-question">
+        <div class="radio-question-label">Avatar</div>
+        <div class="radio-wrapper">
+          ${LLM_AGENT_AVATARS.map((avatar, index) =>
+            renderAvatarRadio(avatar, index),
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentWordsPerMinute(agent: AgentMediatorConfig) {
+    const updateWordsPerMinute = (e: InputEvent) => {
+      const wordsPerMinute = Number((e.target as HTMLInputElement).value);
+      if (!isNaN(wordsPerMinute)) {
+        this.agentEditor.updateAgentMediatorModelSettings(agent.id, {
+          wordsPerMinute,
+        });
+      }
+    };
+
+    const currentWPM = agent.modelSettings.wordsPerMinute;
+    return html`
+      <div class="field">
+        <div class="field-title">Words per minute</div>
+        <div class="description">
+          The higher this value, the faster the agent will respond. This can
+          also be used to set a priority on which agent should respond first.
+        </div>
+        <div class="number-input">
+          <input
+            .disabled=${!this.experimentEditor.canEditStages}
+            type="number"
+            min="1"
+            max="1000"
+            .value=${currentWPM}
+            @input=${updateWordsPerMinute}
+          />
+          ${currentWPM < 1 || currentWPM > 1000
+            ? html`<div class="error-message">
+                Please enter a value between 1 and 1000.
+              </div>`
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentSamplingParameters(agent: AgentMediatorConfig) {
+    const updateTemperature = (e: InputEvent) => {
+      const temperature = Number((e.target as HTMLInputElement).value);
+      if (!isNaN(temperature)) {
+        this.agentEditor.updateAgentMediatorModelSettings(agent.id, {
+          temperature,
+        });
+      }
+    };
+
+    const updateTopP = (e: InputEvent) => {
+      const topP = Number((e.target as HTMLInputElement).value);
+      if (!isNaN(topP)) {
+        this.agentEditor.updateAgentMediatorModelSettings(agent.id, {topP});
+      }
+    };
+
+    const updateFrequencyPenalty = (e: InputEvent) => {
+      const frequencyPenalty = Number((e.target as HTMLInputElement).value);
+      if (!isNaN(frequencyPenalty)) {
+        this.agentEditor.updateAgentMediatorModelSettings(agent.id, {
+          frequencyPenalty,
+        });
+      }
+    };
+
+    const updatePresencePenalty = (e: InputEvent) => {
+      const presencePenalty = Number((e.target as HTMLInputElement).value);
+      if (!isNaN(presencePenalty)) {
+        this.agentEditor.updateAgentMediatorModelSettings(agent.id, {
+          presencePenalty,
+        });
+      }
+    };
+
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Sampling parameters</div>
+          <div class="description">
+            Currently only used for OpenAI and OAI-compatible APIs.
+          </div>
+        </div>
+        <div class="field">
+          <label for="temperature">Temperature</label>
+          <div class="description">
+            The lower this value, the more deterministic the model's outcome
+            will be.
+          </div>
+          <div class="number-input">
+            <input
+              .disabled=${!this.experimentEditor.canEditStages}
+              type="number"
+              min="0.0"
+              max="1.0"
+              step="0.1"
+              .value=${agent.modelSettings.temperature}
+              @input=${updateTemperature}
+            />
+          </div>
+        </div>
+        <div class="field">
+          <label for="topP">Top P</label>
+          <div class="description">
+            If this value is less than 1.0, the model will discard unlikely
+            tokens and sample from only tokens comprising that much probability
+            mass.
+          </div>
+          <div class="number-input">
+            <input
+              .disabled=${!this.experimentEditor.canEditStages}
+              type="number"
+              min="0.0"
+              max="1.0"
+              step="0.1"
+              .value=${agent.modelSettings.topP}
+              @input=${updateTopP}
+            />
+          </div>
+        </div>
+        <div class="field">
+          <label for="frequencyPenalty">Frequency penalty</label>
+          <div class="description">
+            Positive values will penalize tokens based on how frequently they
+            have appeared in the text.
+          </div>
+          <div class="number-input">
+            <input
+              .disabled=${!this.experimentEditor.canEditStages}
+              type="number"
+              min="0.0"
+              max="2.0"
+              step="0.1"
+              .value=${agent.modelSettings.frequencyPenalty}
+              @input=${updateFrequencyPenalty}
+            />
+          </div>
+        </div>
+        <div class="field">
+          <label for="presencePenalty">Presence penalty</label>
+          <div class="description">
+            Positive values will penalize tokens that have already appeared in
+            the text (regardless of frequency).
+          </div>
+          <div class="number-input">
+            <input
+              .disabled=${!this.experimentEditor.canEditStages}
+              type="number"
+              min="0.0"
+              max="2.0"
+              step="0.1"
+              .value=${agent.modelSettings.presencePenalty}
+              @input=${updatePresencePenalty}
+            />
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentCustomRequestBodyFields(agent: AgentMediatorConfig) {
+    const addField = () => {
+      this.agentEditor.addAgentMediatorCustomRequestBodyField(agent.id);
+    };
+
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Custom request body fields</div>
+          <div class="description">Add custom fields to the request body.</div>
+        </div>
+        ${agent.modelSettings.customRequestBodyFields.map((field, fieldIndex) =>
+          this.renderAgentCustomRequestBodyField(agent, field, fieldIndex),
+        )}
+        <pr-button @click=${addField}>Add field</pr-button>
+      </div>
+    `;
+  }
+
+  private renderAgentCustomRequestBodyField(
+    agent: AgentMediatorConfig,
+    field: {name: string; value: string},
+    fieldIndex: number,
+  ) {
+    const updateName = (e: InputEvent) => {
+      const name = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorCustomRequestBodyField(
+        agent.id,
+        fieldIndex,
+        {name},
+      );
+    };
+
+    const updateValue = (e: InputEvent) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorCustomRequestBodyField(
+        agent.id,
+        fieldIndex,
+        {value},
+      );
+    };
+
+    const deleteField = () => {
+      this.agentEditor.deleteAgentMediatorCustomRequestBodyField(
+        agent.id,
+        fieldIndex,
+      );
+    };
+    return html`
+                 <div class="name-value-input">
+           <pr-textarea
+             label="Field name"
+             variant="outlined"
+             .value=${field.name}
+             @input=${updateName}
+           >
+           </pr-textarea>
+           <pr-textarea
+             label="Field value"
+             variant="outlined"
+             .value=${field.value}
+             @input=${updateValue}
+           >
+           </pr-textarea>
+           <pr-icon-button
+              icon="close"
+              color="neutral"
+              padding="small"
+              variant="default"
+              ?disabled=${!this.experimentEditor.canEditStages}
+              @click=${deleteField}
+           >
+         </div>
+      `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'agent-editor': AgentEditorComponent;
+  }
+}

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -101,3 +101,19 @@
 pr-button pr-icon {
   margin-right: common.$spacing-medium;
 }
+
+.banner {
+  @include typescale.label-small;
+  @include common.flex-column;
+  gap: common.$spacing-small;
+  padding: common.$spacing-medium;
+
+  &.warning {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-on-error-container);
+  }
+
+  p {
+    margin: 0;
+  }
+}

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -159,7 +159,7 @@ export class ExperimentBuilder extends MobxLitElement {
                   await this.experimentManager.testAgentConfig();
               }}
             >
-              Test default agent mediator
+              Test agent mediator
             </pr-button>
             <div>${this.testAgentConfigResponse}</div>
           </div>

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -32,6 +32,7 @@ import {StageConfig, StageKind, generateId} from '@deliberation-lab/utils';
 import {styles} from './experiment_builder.scss';
 
 enum PanelView {
+  AGENTS = 'agents',
   DEFAULT = 'default',
   STAGES = 'stages',
 }
@@ -47,6 +48,7 @@ export class ExperimentBuilder extends MobxLitElement {
   private readonly routerService = core.getService(RouterService);
 
   @state() panelView: PanelView = PanelView.DEFAULT;
+  @state() testAgentConfigResponse = '';
 
   override render() {
     return html`
@@ -87,6 +89,18 @@ export class ExperimentBuilder extends MobxLitElement {
             >
             </pr-icon-button>
           </pr-tooltip>
+          <pr-tooltip text="Agents" position="RIGHT_END">
+            <pr-icon-button
+              color="secondary"
+              icon="robot_2"
+              size="medium"
+              variant=${isSelected(PanelView.AGENTS) ? 'tonal' : 'default'}
+              @click=${() => {
+                this.panelView = PanelView.AGENTS;
+              }}
+            >
+            </pr-icon-button>
+          </pr-tooltip>
         </div>
         ${this.renderPanelView()}
       </div>
@@ -119,6 +133,31 @@ export class ExperimentBuilder extends MobxLitElement {
         </div>
       `;
     }
+    if (this.panelView === PanelView.AGENTS) {
+      return html`
+        <div class="panel-view">
+          <div class="banner warning">
+            <p>
+              For testing only! Settings on this page do not yet connect to the
+              saved experiment.
+            </p>
+          </div>
+          <div class="top">
+            <div class="panel-view-header">Agents</div>
+            <pr-button
+              @click=${async () => {
+                this.testAgentConfigResponse =
+                  await this.experimentManager.testAgentConfig();
+              }}
+            >
+              Test default agent mediator
+            </pr-button>
+            <div>${this.testAgentConfigResponse}</div>
+          </div>
+        </div>
+      `;
+    }
+    return nothing;
   }
 
   private renderStageButtons() {

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -13,6 +13,7 @@ import '../../pair-components/icon_button';
 import '../../pair-components/tooltip';
 import '../stages/tos_editor';
 import '../stages/transfer_editor';
+import './agent_editor';
 import './experiment_builder_nav';
 import './experiment_settings_editor';
 import './stage_builder_dialog';
@@ -23,11 +24,17 @@ import {customElement, property, state} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
 import {AnalyticsService, ButtonClick} from '../../services/analytics.service';
+import {AgentEditor} from '../../services/agent.editor';
 import {ExperimentEditor} from '../../services/experiment.editor';
 import {ExperimentManager} from '../../services/experiment.manager';
 import {Pages, RouterService} from '../../services/router.service';
 
-import {StageConfig, StageKind, generateId} from '@deliberation-lab/utils';
+import {
+  StageConfig,
+  StageKind,
+  generateId,
+  createAgentMediatorConfig,
+} from '@deliberation-lab/utils';
 
 import {styles} from './experiment_builder.scss';
 
@@ -42,6 +49,7 @@ enum PanelView {
 export class ExperimentBuilder extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly agentEditor = core.getService(AgentEditor);
   private readonly analyticsService = core.getService(AnalyticsService);
   private readonly experimentEditor = core.getService(ExperimentEditor);
   private readonly experimentManager = core.getService(ExperimentManager);
@@ -53,7 +61,8 @@ export class ExperimentBuilder extends MobxLitElement {
   override render() {
     return html`
       ${this.renderNavPanel()} ${this.renderExperimentConfigBuilder()}
-      ${this.renderStageBuilder()} ${this.renderStageBuilderDialog()}
+      ${this.renderAgentBuilder()} ${this.renderStageBuilder()}
+      ${this.renderStageBuilderDialog()}
     `;
   }
 
@@ -209,6 +218,20 @@ export class ExperimentBuilder extends MobxLitElement {
         <pr-icon color="error" icon="delete"></pr-icon>
         Delete experiment
       </pr-button>
+    `;
+  }
+
+  private renderAgentBuilder() {
+    if (this.panelView !== PanelView.AGENTS) {
+      return nothing;
+    }
+
+    const agent = this.agentEditor.getAgentMediator('test');
+
+    return html`
+      <div class="experiment-builder">
+        <agent-editor .agent=${agent}></agent-editor>
+      </div>
     `;
   }
 

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -117,7 +117,7 @@ export class ExperimentSettingsEditor extends MobxLitElement {
           </md-checkbox>
           <div>
             Make experiment public (all researchers on platform can view and
-            edit)
+            edit if you share the link with them)
           </div>
         </div>
       </div>

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -10,7 +10,13 @@ import {computed, makeObservable, observable} from 'mobx';
 import {FirebaseService} from './firebase.service';
 import {Service} from './service';
 
-import {AgentConfig} from '@deliberation-lab/utils';
+import {
+  AgentConfig,
+  AgentPromptConfig,
+  AgentMediatorConfig,
+  AgentMediatorModelSettings,
+  createAgentMediatorConfig,
+} from '@deliberation-lab/utils';
 import {updateChatAgentsCallable} from '../shared/callables';
 
 interface ServiceProvider {
@@ -25,6 +31,11 @@ export class AgentEditor extends Service {
     super();
     makeObservable(this);
   }
+
+  // *********************************************************************** //
+  // WARNING: Variables/functions for old chat agent config are soon to be   //
+  //          deprecated.                                                    //
+  // *********************************************************************** //
 
   // Experiment ID
   @observable experimentId: string | null = null;
@@ -67,6 +78,103 @@ export class AgentEditor extends Service {
   reset() {
     this.experimentId = null;
     this.configMap = {};
+  }
+
+  // *********************************************************************** //
+  // TODO: VARIABLES/FUNCTIONS FOR NEW AGENT MEDIATOR/PARTICIPANT CONFIGS    //
+  // *********************************************************************** //
+  // TODO: Instead of creating a single test agent mediator,
+  // enable users to create multiple mediators for specific stages
+  @observable agentMediators: AgentMediatorConfig[] = [
+    createAgentMediatorConfig('testChatId', {id: 'test'}),
+  ];
+
+  addAgentMediator(chatStageId: string = '') {
+    this.agentMediators.push(createAgentMediatorConfig(chatStageId));
+  }
+
+  getAgentMediator(id: string) {
+    return this.agentMediators.find((agent) => agent.id === id);
+  }
+
+  updateAgentMediatorName(id: string, name: string) {
+    const agent = this.getAgentMediator(id);
+    if (agent) {
+      agent.name = name;
+    }
+  }
+
+  updateAgentMediatorAvatar(id: string, avatar: string) {
+    const agent = this.getAgentMediator(id);
+    if (agent) {
+      agent.avatar = avatar;
+    }
+  }
+
+  updateAgentMediatorModelSettings(
+    id: string,
+    modelSettings: Partial<AgentMediatorModelSettings>,
+  ) {
+    const agent = this.getAgentMediator(id);
+    if (agent) {
+      agent.modelSettings = {...agent.modelSettings, ...modelSettings};
+    }
+  }
+
+  updateAgentMediatorPromptConfig(
+    id: string,
+    promptConfig: Partial<AgentPromptConfig>,
+  ) {
+    const agent = this.getAgentMediator(id);
+    if (agent) {
+      agent.promptConfig = {...agent.promptConfig, ...promptConfig};
+    }
+  }
+
+  addAgentMediatorCustomRequestBodyField(agentId: string) {
+    const agent = this.getAgentMediator(agentId);
+    if (agent) {
+      const fields = agent.modelSettings.customRequestBodyFields;
+      const newField = {name: '', value: ''};
+      const customRequestBodyFields = [...fields, newField];
+      agent.modelSettings = {...agent.modelSettings, customRequestBodyFields};
+    }
+  }
+
+  updateAgentMediatorCustomRequestBodyField(
+    agentId: string,
+    fieldIndex: number,
+    field: Partial<{name: string; value: string}>,
+  ) {
+    const agent = this.getAgentMediator(agentId);
+    if (agent) {
+      const customRequestBodyFields =
+        agent.modelSettings.customRequestBodyFields;
+      customRequestBodyFields[fieldIndex] = {
+        ...customRequestBodyFields[fieldIndex],
+        ...field,
+      };
+      agent.modelSettings = {...agent.modelSettings, customRequestBodyFields};
+    }
+  }
+
+  deleteAgentMediatorCustomRequestBodyField(
+    agentId: string,
+    fieldIndex: number,
+  ) {
+    const agent = this.getAgentMediator(agentId);
+    if (agent) {
+      const fields = agent.modelSettings.customRequestBodyFields;
+      const customRequestBodyFields = [
+        ...fields.slice(0, fieldIndex),
+        ...fields.slice(fieldIndex + 1),
+      ];
+      agent.modelSettings = {...agent.modelSettings, customRequestBodyFields};
+    }
+  }
+
+  resetAgents() {
+    this.agentMediators = [];
   }
 
   // *********************************************************************** //

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -9,6 +9,7 @@ import {
   Unsubscribe,
   where,
 } from 'firebase/firestore';
+import {AgentEditor} from './agent.editor';
 import {AuthService} from './auth.service';
 import {CohortService} from './cohort.service';
 import {ExperimentEditor} from './experiment.editor';
@@ -30,7 +31,6 @@ import {
   ParticipantProfileExtended,
   ParticipantStatus,
   StageConfig,
-  createAgentMediatorConfig,
   createCohortConfig,
   createHumanMediatorChatMessage,
   generateId,
@@ -70,6 +70,7 @@ import {
 } from '../shared/participant.utils';
 
 interface ServiceProvider {
+  agentEditor: AgentEditor;
   authService: AuthService;
   cohortService: CohortService;
   experimentEditor: ExperimentEditor;
@@ -688,12 +689,14 @@ export class ExperimentManager extends Service {
   /** TEMPORARY: Test new agent config. */
   async testAgentConfig() {
     let response = '';
-    if (this.sp.authService.experimenterData) {
+    const creatorId = this.sp.authService.experimenterData?.email;
+    const agentConfig = this.sp.agentEditor.getAgentMediator('test');
+    if (creatorId && agentConfig) {
       response =
         (
           await testAgentConfigCallable(this.sp.firebaseService.functions, {
-            creatorId: this.sp.authService.experimenterData.email,
-            agentConfig: createAgentMediatorConfig('test-id'),
+            creatorId,
+            agentConfig,
           })
         ).data ?? '';
     }

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -30,6 +30,7 @@ import {
   ParticipantProfileExtended,
   ParticipantStatus,
   StageConfig,
+  createAgentMediatorConfig,
   createCohortConfig,
   createHumanMediatorChatMessage,
   generateId,
@@ -44,6 +45,7 @@ import {
   initiateParticipantTransferCallable,
   sendParticipantCheckCallable,
   setExperimentCohortLockCallable,
+  testAgentConfigCallable,
   testAgentParticipantPromptCallable,
   updateCohortMetadataCallable,
   writeExperimentCallable,
@@ -681,6 +683,21 @@ export class ExperimentManager extends Service {
         },
       );
     }
+  }
+
+  /** TEMPORARY: Test new agent config. */
+  async testAgentConfig() {
+    let response = '';
+    if (this.sp.authService.experimenterData) {
+      response =
+        (
+          await testAgentConfigCallable(this.sp.firebaseService.functions, {
+            creatorId: this.sp.authService.experimenterData.email,
+            agentConfig: createAgentMediatorConfig('test-id'),
+          })
+        ).data ?? '';
+    }
+    return response;
   }
 
   /** Create a manual (human) agent chat message. */

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -1,4 +1,5 @@
 import {
+  AgentConfigTestData,
   AgentParticipantPromptTestData,
   BaseParticipantData,
   CreateChatMessageData,
@@ -403,6 +404,21 @@ export const testAgentParticipantPromptCallable = async (
   >(
     functions,
     'testAgentParticipantPrompt',
+  )(config);
+  return data;
+};
+
+/** Generic endpoint for testing agent config. */
+export const testAgentConfigCallable = async (
+  functions: Functions,
+  config: AgentConfigTestData,
+) => {
+  const {data} = await httpsCallable<
+    AgentConfigTestData,
+    SimpleResponse<string>
+  >(
+    functions,
+    'testAgentConfig',
   )(config);
   return data;
 };

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -19,7 +19,7 @@ export async function getAgentResponse(
       prompt,
     );
   } else if (keyType === ApiKeyType.GEMINI_API_KEY) {
-    response =  getGeminiResponse(data, agent.model, prompt);
+    response = getGeminiResponse(data, agent.model, prompt);
   } else if (keyType === ApiKeyType.OPENAI_API_KEY) {
     response = getOpenAIAPIResponse(
       data,
@@ -37,22 +37,27 @@ export async function getAgentResponse(
   return response;
 }
 
+// TODO: Refactor model call functions to take in direct API configs,
+// not full ExperimenterData
+
 export async function getGeminiResponse(
   data: ExperimenterData,
-   modelName: string,
-   prompt: string
-  ): Promise<ModelResponse> {
+  modelName: string,
+  prompt: string,
+  // TODO: Add new agent model settings
+): Promise<ModelResponse> {
   return await getGeminiAPIResponse(
     data.apiKeys.geminiApiKey,
     modelName,
-    prompt
+    prompt,
   );
 }
 
-async function getOpenAIAPIResponse(
+export async function getOpenAIAPIResponse(
   data: ExperimenterData,
   model: string,
   prompt: string,
+  // TODO: Replace with new agent model settings
   generationConfig: GenerationConfig,
 ): Promise<ModelResponse> {
   return await getOpenAIAPITextCompletionResponse(
@@ -67,7 +72,8 @@ async function getOpenAIAPIResponse(
 export async function getOllamaResponse(
   data: ExperimenterData,
   modelName: string,
-  prompt: string
+  prompt: string,
+  // TODO: Add new agent model settings
 ): Promise<ModelResponse> {
   return await ollamaChat([prompt], data.apiKeys.ollamaApiKey);
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -1,5 +1,6 @@
 import {generateId} from './shared';
 import {StageKind} from './stages/stage';
+import {DEFAULT_AGENT_MEDIATOR_PROMPT} from './stages/chat_stage';
 
 /** Agent types and functions. */
 
@@ -141,7 +142,7 @@ export function createAgentChatPromptConfig(
 ): AgentChatPromptConfig {
   return {
     type: StageKind.CHAT,
-    prompt: config.prompt ?? '', // TODO: Set default chat prompt
+    prompt: config.prompt ?? DEFAULT_AGENT_MEDIATOR_PROMPT,
     includeStageHistory: config.includeStageHistory ?? false,
     includeStageInfo: config.includeStageInfo ?? false,
   };

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -10,3 +10,11 @@ export interface AgentGenerationConfig {
   presencePenalty: number;
   customRequestBodyFields: CustomRequestBodyField[];
 }
+
+// Specifies which API to use for model calls
+// TODO: Rename enum (ApiType? LLMApiType?)
+export enum ApiKeyType {
+  GEMINI_API_KEY = 'GEMINI',
+  OPENAI_API_KEY = 'OPENAI',
+  OLLAMA_CUSTOM_URL = 'OLLAMA',
+}

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -93,7 +93,7 @@ export interface AgentMediatorConfig {
   name: string; // display name
   avatar: string;
   modelSettings: AgentMediatorModelSettings;
-  promptSettings: AgentChatPromptConfig;
+  promptConfig: AgentChatPromptConfig;
 }
 
 // ************************************************************************* //
@@ -158,6 +158,6 @@ export function createAgentMediatorConfig(
     name: config.name ?? 'Agent',
     avatar: config.avatar ?? '🤖',
     modelSettings: config.modelSettings ?? createAgentMediatorModelSettings(),
-    promptSettings: config.promptSettings ?? createAgentChatPromptConfig(),
+    promptConfig: config.promptConfig ?? createAgentChatPromptConfig(),
   };
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -1,7 +1,11 @@
+import {generateId} from './shared';
 import {StageKind} from './stages/stage';
 
-/** Agent types. */
+/** Agent types and functions. */
 
+// ************************************************************************* //
+// TYPES                                                                     //
+// ************************************************************************* //
 export interface CustomRequestBodyField {
   name: string;
   value: string;
@@ -51,8 +55,8 @@ export interface AgentMediatorModelSettings extends AgentModelSettings {
   // Whether the agent can respond multiple times in a row
   // (i.e., whether an agent's own message can trigger a new model call)
   canSelfTriggerCalls: boolean;
-  // Maximum total responses during the chat conversation
-  maxTotalResponses: number;
+  // Maximum total responses during the chat conversation (or null if no max)
+  maxTotalResponses: number | null;
 }
 
 // Specifies how prompt should be built
@@ -89,4 +93,70 @@ export interface AgentMediatorConfig {
   avatar: string;
   modelSettings: AgentMediatorModelSettings;
   promptSettings: AgentChatPromptConfig;
+}
+
+// ************************************************************************* //
+// CONSTANTS                                                                 //
+// ************************************************************************* //
+export const DEFAULT_AGENT_API_TYPE = ApiKeyType.GEMINI_API_KEY;
+
+export const DEFAULT_AGENT_API_MODEL = 'gemini-1.5-pro-latest';
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+
+export function createAgentModelSettings(
+  config: Partial<AgentModelSettings> = {},
+): AgentModelSettings {
+  return {
+    // TODO: pick first API that has a valid key?
+    apiType: config.apiType ?? DEFAULT_AGENT_API_TYPE,
+    // TODO: pick model name that matches API?
+    modelName: config.modelName ?? DEFAULT_AGENT_API_MODEL,
+    numRetries: config.numRetries ?? 0,
+    maxTokens: config.maxTokens ?? 8192,
+    temperature: config.temperature ?? 0.7,
+    topP: config.topP ?? 1.0,
+    frequencyPenalty: config.frequencyPenalty ?? 0.0,
+    presencePenalty: config.presencePenalty ?? 0.0,
+    customRequestBodyFields: config.customRequestBodyFields ?? [],
+  };
+}
+
+export function createAgentMediatorModelSettings(
+  config: Partial<AgentMediatorModelSettings> = {},
+): AgentMediatorModelSettings {
+  return {
+    ...createAgentModelSettings(config),
+    wordsPerMinute: config.wordsPerMinute ?? 80,
+    minMessagesBeforeResponding: config.minMessagesBeforeResponding ?? 0,
+    canSelfTriggerCalls: config.canSelfTriggerCalls ?? true,
+    maxTotalResponses: config.maxTotalResponses ?? null,
+  };
+}
+
+export function createAgentChatPromptConfig(
+  config: Partial<AgentChatPromptConfig> = {},
+): AgentChatPromptConfig {
+  return {
+    type: StageKind.CHAT,
+    prompt: config.prompt ?? '', // TODO: Set default chat prompt
+    includeStageHistory: config.includeStageHistory ?? false,
+    includeStageInfo: config.includeStageInfo ?? false,
+  };
+}
+
+export function createAgentMediatorConfig(
+  stageId: string, // ID of chat stage that agent should mediate
+  config: Partial<AgentMediatorConfig> = {},
+): AgentMediatorConfig {
+  return {
+    id: config.id ?? generateId(),
+    stageId,
+    name: config.name ?? 'Agent',
+    avatar: config.avatar ?? '🤖',
+    modelSettings: config.modelSettings ?? createAgentMediatorModelSettings(),
+    promptSettings: config.promptSettings ?? createAgentChatPromptConfig(),
+  };
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -1,3 +1,7 @@
+import {StageKind} from './stages/stage';
+
+/** Agent types. */
+
 export interface CustomRequestBodyField {
   name: string;
   value: string;
@@ -17,4 +21,72 @@ export enum ApiKeyType {
   GEMINI_API_KEY = 'GEMINI',
   OPENAI_API_KEY = 'OPENAI',
   OLLAMA_CUSTOM_URL = 'OLLAMA',
+}
+
+// ----------------------------------------------------------------------------
+// NOTE: Everything below this is in progress and not yet connected
+// to experiment logic (e.g., chat mediation)
+// ----------------------------------------------------------------------------
+
+// TODO: Rename?
+export interface AgentModelSettings {
+  apiType: ApiKeyType;
+  modelName: string;
+  numRetries: number; // Number of times to retry API call if it fails
+  maxTokens: number; // Max tokens per model call response
+  temperature: number;
+  topP: number;
+  frequencyPenalty: number;
+  presencePenalty: number;
+  customRequestBodyFields: CustomRequestBodyField[];
+}
+
+// Settings specifically for agent chat mediators
+// TODO: Adjust fields as appropriate
+export interface AgentMediatorModelSettings extends AgentModelSettings {
+  // Agent's "typing speed" during the chat conversation
+  wordsPerMinute: number;
+  // Number of chat messages that must exist before the agent can respond
+  minMessagesBeforeResponding: number;
+  // Whether the agent can respond multiple times in a row
+  // (i.e., whether an agent's own message can trigger a new model call)
+  canSelfTriggerCalls: boolean;
+  // Maximum total responses during the chat conversation
+  maxTotalResponses: number;
+}
+
+// Specifies how prompt should be built
+// TODO: Adjust fields as appropriate
+export interface AgentBasePromptConfig {
+  type: StageKind;
+  prompt: string;
+  // Whether or not to include context from all previously completed
+  // stages
+  includeStageHistory: boolean;
+  // Whether or not to include information (e.g., stage description)
+  // shown to users
+  includeStageInfo: boolean;
+  // TODO: Add stop sequence?
+  // TODO: Add structured output config/fields
+  // TODO: Add structure for few-shot examples?
+}
+
+export interface AgentChatPromptConfig extends AgentBasePromptConfig {
+  type: StageKind.CHAT;
+}
+
+export type AgentPromptConfig = AgentChatPromptConfig;
+
+// TODO: Config for agent participant
+// For each stage agent is participating in,
+// include model + prompt settings?
+
+// Config for agent mediator
+export interface AgentMediatorConfig {
+  id: string;
+  stageId: string; // chat stage that mediator is part of
+  name: string; // display name
+  avatar: string;
+  modelSettings: AgentMediatorModelSettings;
+  promptSettings: AgentChatPromptConfig;
 }

--- a/utils/src/agent.validation.ts
+++ b/utils/src/agent.validation.ts
@@ -20,3 +20,22 @@ export const AgentParticipantPromptTestData = Type.Object(
 export type AgentParticipantPromptTestData = Static<
   typeof AgentParticipantPromptTestData
 >;
+
+// ****************************************************************************
+// testAgentConfig
+// ****************************************************************************
+
+export const AgentConfigData = Type.Object({
+  id: Type.String({minLength: 1}),
+  name: Type.String(),
+  avatar: Type.String(),
+  // TODO: Add other agent config fields
+});
+
+/** AgentConfigTest input validation. */
+export const AgentConfigTestData = Type.Object({
+  creatorId: Type.String({minLength: 1}),
+  agentConfig: AgentConfigData,
+});
+
+export type AgentConfigTestData = Static<typeof AgentConfigTestData>;

--- a/utils/src/experimenter.test.ts
+++ b/utils/src/experimenter.test.ts
@@ -1,6 +1,6 @@
+import {ApiKeyType} from './agent';
 import {
   ExperimenterData,
-  ApiKeyType,
   checkApiKeyExists,
   createExperimenterData,
 } from './experimenter';

--- a/utils/src/experimenter.ts
+++ b/utils/src/experimenter.ts
@@ -2,6 +2,7 @@
 
 import {Timestamp} from 'firebase/firestore';
 import {UnifiedTimestamp} from './shared';
+import {ApiKeyType} from './agent';
 
 // ************************************************************************* //
 // TYPES                                                                     //
@@ -22,10 +23,6 @@ export interface ExperimenterProfileExtended extends ExperimenterProfile {
 
 /** Experimenter data (written to Firestore under experimenterData/{id}). */
 export interface ExperimenterData {
-  /* 
-  Currently supports either all ollama or all gemini
-  TODO: refactor this as a list of types and values for each mediator(see design document)
-  */
   id: string;
   email: string;
   apiKeys: APIKeyConfig;
@@ -37,13 +34,9 @@ export interface APIKeyConfig {
   geminiApiKey: string; // distinct types since we don't want to lose information when switching between them
   openAIApiKey?: OpenAIServerConfig;
   ollamaApiKey: OllamaServerConfig;
-  activeApiKeyType: ApiKeyType; // keeps track of model type selection
-}
-
-export enum ApiKeyType {
-  GEMINI_API_KEY = 'GEMINI',
-  OPENAI_API_KEY = 'OPENAI',
-  OLLAMA_CUSTOM_URL = 'OLLAMA',
+  // Keeps track of model type selection
+  // TODO: Remove field and specify model API in agent config
+  activeApiKeyType: ApiKeyType;
 }
 
 export interface OpenAIServerConfig {

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -171,7 +171,9 @@ export interface ChatStagePublicData extends BaseStagePublicData {
 // CONSTANTS                                                                 //
 // ************************************************************************* //
 export const DEFAULT_MODEL = 'gemini-1.5-pro-latest';
-export const DEFAULT_AGENT_PROMPT = `You are a agent for a chat conversation. Your task is to ensure that the conversation is polite.
+
+// TODO: Refactor chat prompts into chat_stage.prompts.ts file
+export const DEFAULT_AGENT_MEDIATOR_PROMPT = `You are a agent for a chat conversation. Your task is to ensure that the conversation is polite.
 If you notice that participants are being rude, step in to make sure that everyone is respectful. 
 Otherwise, do not respond.`;
 
@@ -357,7 +359,7 @@ export function createAgentConfig(
     name: config.name ?? 'Agent',
     avatar: config.avatar ?? '🤖',
     model: config.model ?? DEFAULT_MODEL,
-    prompt: config.prompt ?? DEFAULT_AGENT_PROMPT.trim(),
+    prompt: config.prompt ?? DEFAULT_AGENT_MEDIATOR_PROMPT.trim(),
     wordsPerMinute: config.wordsPerMinute ?? 80, // Default 80 WPM.
     generationConfig: config.generationConfig ?? createAgentGenerationConfig(),
     responseConfig: config.responseConfig ?? createAgentResponseConfig(),


### PR DESCRIPTION
Note: Agent configs still in progress with fields subject to change.

This is not yet connected to actual experiment logic; rather, it enables us to edit and test new agent configs in the frontend experiment editor.

![image](https://github.com/user-attachments/assets/0c16182c-2dc2-45d1-8ec2-ea942edf0aa8)

Fixes #418 