### PR TITLE
Use sampler parameters for Gemini and Ollama APIs.

### DIFF
--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -13,7 +13,7 @@ export async function getAgentResponse(
   let response;
 
   if (keyType === ApiKeyType.GEMINI_API_KEY) {
-    response =  getGeminiResponse(data, agent.model, prompt);
+    response = getGeminiResponse(data, agent.model, prompt, agent.generationConfig);
   } else if (keyType === ApiKeyType.OPENAI_API_KEY) {
     response = getOpenAIAPIResponse(
       data,
@@ -38,12 +38,14 @@ export async function getGeminiResponse(
   data: ExperimenterData,
   modelName: string,
   prompt: string,
-  // TODO: Add new agent model settings
-): Promise<ModelResponse> {
+  // TODO: Replace with new agent model settings
+  generationConfig: AgentGenerationConfig,
+  ): Promise<ModelResponse> {
   return await getGeminiAPIResponse(
     data.apiKeys.geminiApiKey,
     modelName,
     prompt,
+    generationConfig
   );
 }
 
@@ -52,7 +54,7 @@ export async function getOpenAIAPIResponse(
   model: string,
   prompt: string,
   // TODO: Replace with new agent model settings
-  generationConfig: GenerationConfig,
+  generationConfig: AgentGenerationConfig,
 ): Promise<ModelResponse> {
   return await getOpenAIAPITextCompletionResponse(
     data.apiKeys.openAIApiKey?.apiKey || '',
@@ -67,7 +69,8 @@ export async function getOllamaResponse(
   data: ExperimenterData,
   modelName: string,
   prompt: string,
-  // TODO: Add new agent model settings
+  // TODO: Replace with new agent model settings
+  generationConfig: AgentGenerationConfig,
 ): Promise<ModelResponse> {
-  return await ollamaChat([prompt], data.apiKeys.ollamaApiKey);
+  return await ollamaChat([prompt], modelName, data.apiKeys.ollamaApiKey, generationConfig);
 }

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -1,0 +1,52 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import nock = require('nock');
+
+import {AgentGenerationConfig} from '@deliberation-lab/utils';
+import {getGeminiAPIResponse} from './gemini.api';
+import {ModelResponse} from './model.response';
+
+const MODEL_NAME = 'gemini-1.5-flash';
+
+describe('Gemini API', () => {
+  it('handles text completion request', async () => {
+    nock('https://generativelanguage.googleapis.com')
+      .post(`/v1beta/models/${MODEL_NAME}:generateContent`)
+      .reply(200, (uri, requestBody) => {
+        return { candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: `test output, generation config: ${JSON.stringify(requestBody.generationConfig)}`,
+                }
+              ],
+            },
+            index: 0,
+            finish_reason: 'STOP',
+            avgLogprobs: -0.1
+          },
+        ],
+        modelVersion: MODEL_NAME
+               };});
+
+    const generationConfig: AgentGenerationConfig = {
+      temperature: 0.4,
+      topP: 0.9,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+
+    const response: ModelResponse = await getGeminiAPIResponse(
+      'testapikey',
+      MODEL_NAME,
+      'This is a test prompt.',
+      generationConfig,
+    );
+
+    expect(response.text).toContain('test output');
+    expect(response.text).toContain('"temperature":0.4');
+    expect(response.text).toContain('"topP":0.9');
+
+    nock.cleanAll();
+  });
+});

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -34,6 +34,7 @@ describe('Gemini API', () => {
       topP: 0.9,
       frequencyPenalty: 0,
       presencePenalty: 0,
+      customRequestBodyFields: [{name: 'seed', value: 123}],
     };
 
     const response: ModelResponse = await getGeminiAPIResponse(

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -4,6 +4,7 @@ import {
   HarmCategory,
   HarmBlockThreshold,
 } from '@google/generative-ai';
+import {AgentGenerationConfig} from '@deliberation-lab/utils';
 
 const GEMINI_DEFAULT_MODEL = 'gemini-1.5-pro-latest';
 const DEFAULT_FETCH_TIMEOUT = 300 * 1000; // This is the Chrome default
@@ -66,18 +67,17 @@ export async function getGeminiAPIResponse(
   apiKey: string,
   modelName: string,
   promptText: string,
+  generationConfig: AgentGenerationConfig,
   stopSequences: string[] = [],
-  maxOutputTokens = 300,
-  temperature = 0.5,
-  topP = 0.1,
-  topK = 16,
 ): Promise<ModelResponse> {
-  const generationConfig = {
+  const geminiConfig: GenerationConfig = {
     stopSequences,
-    maxOutputTokens,
-    temperature,
-    topP,
-    topK,
+    maxOutputTokens: 300,
+    temperature: generationConfig.temperature,
+    topP: generationConfig.topP,
+    topK: 16,
+    presencePenalty: generationConfig.presencePenalty,
+    frequencyPenalty: generationConfig.frequencyPenalty,
   };
 
   let response = {text: ''};
@@ -85,7 +85,7 @@ export async function getGeminiAPIResponse(
     response = await callGemini(
       apiKey,
       promptText,
-      generationConfig,
+      geminiConfig,
       modelName
     );
   } catch (error: any) {

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -70,6 +70,12 @@ export async function getGeminiAPIResponse(
   generationConfig: AgentGenerationConfig,
   stopSequences: string[] = [],
 ): Promise<ModelResponse> {
+  const customFields = Object.fromEntries(
+    generationConfig.customRequestBodyFields.map((field) => [
+      field.name,
+      field.value,
+    ]),
+  );
   const geminiConfig: GenerationConfig = {
     stopSequences,
     maxOutputTokens: 300,
@@ -78,6 +84,7 @@ export async function getGeminiAPIResponse(
     topK: 16,
     presencePenalty: generationConfig.presencePenalty,
     frequencyPenalty: generationConfig.frequencyPenalty,
+    ...customFields
   };
 
   let response = {text: ''};

--- a/functions/src/api/ollama.api.test.ts
+++ b/functions/src/api/ollama.api.test.ts
@@ -10,27 +10,63 @@ const LLM_SERVER_PATH = '/api/chat';
 const TEST_MESSAGE = 'Say hello!';
 
 describe('OllamaChat Client', () => {
-  it("should return a response containing 'hello' (case insensitive)", async () => {
+  beforeEach(() => {
     nock(LLM_SERVER_HOST)
       .post(LLM_SERVER_PATH, body => body.model == MODEL_NAME)
-      .reply(200, {
-        'created_at': Date.now(),
-        'model': MODEL_NAME,
-        'message': {
-          'role': 'assistant',
-          'content': 'Hello!',
-        },
-        done: true,
+      .reply(200, (uri, requestBody) => {
+        return {
+          'created_at': Date.now(),
+          'model': MODEL_NAME,
+          'message': {
+            'role': 'assistant',
+            'content': `Hello! request body: ${requestBody}`,
+          },
+          done: true,
+        };
       });
+  });
+  
+  afterEach(() => {
+    nock.cleanAll();
+  });
 
+  it("should return a response containing 'hello' (case insensitive)", async () => {
+    const generationConfig: AgentGenerationConfig = {
+      temperature: 0.7,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      customRequestBodyFields: [],
+    };
+    
     const response = await ollamaChat(
       [TEST_MESSAGE],
       MODEL_NAME,
-      {url: LLM_SERVER_ENDPOINT}
+      {url: LLM_SERVER_ENDPOINT},
+      generationConfig
     );
     expect(response.text.toLowerCase()).toContain('hello');
     console.log(response);
+  });
 
-    nock.cleanAll();
+  it("should pass through generation config", async () => {
+    const generationConfig: AgentGenerationConfig = {
+      temperature: 0.4,
+      topP: 0.9,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      customRequestBodyFields: [{name: 'foo', value: 'bar'}],
+    };
+    
+    const response = await ollamaChat(
+      [TEST_MESSAGE],
+      MODEL_NAME,
+      {url: LLM_SERVER_ENDPOINT},
+      generationConfig
+    );
+    expect(response.text.toLowerCase()).toContain('hello');
+    expect(response.text.toLowerCase()).toContain('"temperature":0.4');
+    expect(response.text.toLowerCase()).toContain('"top_p":0.9');
+    expect(response.text.toLowerCase()).toContain('"foo":"bar"');
   });
 });

--- a/functions/src/api/ollama.api.ts
+++ b/functions/src/api/ollama.api.ts
@@ -102,8 +102,10 @@ function encodeMessages(
     model: modelName,
     messages: messageObjs,
     stream: false,
-    temperature: generationConfig.temperature,
-    top_p: generationConfig.topP,
+    options: {
+      temperature: generationConfig.temperature,
+      top_p: generationConfig.topP,
+    },
     ...customFields
   };
 }

--- a/functions/src/api/ollama.api.ts
+++ b/functions/src/api/ollama.api.ts
@@ -8,7 +8,7 @@
  * Note: there already exists a client library for JavaScript, but not for Typescript.
  */
 
-import {OllamaServerConfig} from '@deliberation-lab/utils';
+import {OllamaServerConfig, AgentGenerationConfig} from '@deliberation-lab/utils';
 import {ModelResponse} from './model.response';
 
 /**
@@ -39,8 +39,9 @@ export async function ollamaChat(
   messages: string[],
   modelName: string,
   serverConfig: OllamaServerConfig,
+  generationConfig: AgentGenerationConfig,
 ): Promise<ModelResponse> {
-  const messageObjects = encodeMessages(messages, modelName);
+  const messageObjects = encodeMessages(messages, modelName, generationConfig);
   const response = await fetch(serverConfig.url, {
     method: 'POST',
     body: JSON.stringify(messageObjects),
@@ -82,16 +83,28 @@ async function decodeResponse(response: Response): Promise<string> {
  */
 function encodeMessages(
   messages: string[],
-  modelName: string
+  modelName: string,
+  generationConfig: AgentGenerationConfig,
 ): OutgoingMessage {
   const messageObjs: OllamaMessage[] = messages.map((message) => ({
     role: 'user',
     content: message
   }));
+
+  const customFields = Object.fromEntries(
+    generationConfig.customRequestBodyFields.map((field) => [
+      field.name,
+      field.value,
+    ]),
+  );
+
   return {
     model: modelName,
     messages: messageObjs,
-    stream: false
+    stream: false,
+    temperature: generationConfig.temperature,
+    top_p: generationConfig.topP,
+    ...customFields
   };
 }
 


### PR DESCRIPTION
Pass everything from AgentGenerationConfig through to the Gemini and Ollama APIs, except that frequency penalty and presence penalty aren't supported in Ollama.

Ollama puts some model parameters in a nested `options` field of the request body; for now, this doesn't support setting those, except for temperature and top_p.

Also fix a bug where agent.utils.ts wasn't calling into the Ollama API with the correct arguments.

This will have merge conflicts with the agent-refactor branch in progress.