### PR TITLE
Add alert system for participants to notify experimenters

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -89,6 +89,11 @@ service cloud.firestore {
       // Experimenters can use `writeExperiment`, `deleteExperiment` endpoints
       allow write: if false;
 
+      match /alerts/{alertId} {
+        allow read: if isExperimenter();
+        allow write: if false; // Use cloud functions
+      }
+
       match /stages/{stageId} {
         allow read: if true; // Public read
         // Experimenters can use `writeExperiment`, `deleteExperiment`
@@ -145,6 +150,11 @@ service cloud.firestore {
 
           // Participants can use cloud function endpoints
           allow write: if false;
+        }
+
+        match /alerts/{alertId} {
+          allow read: if true;
+          allow write: if false; // Use cloud functions
         }
       }
 

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -1,6 +1,6 @@
-@use "../../sass/colors";
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-row;
@@ -171,4 +171,12 @@ pr-button pr-icon {
   p {
     margin: 0;
   }
+}
+
+.alert {
+  @include common.flex-column;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  gap: common.$spacing-small;
+  padding: common.$spacing-medium;
 }

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -176,7 +176,12 @@ pr-button pr-icon {
 .alert {
   @include common.flex-column;
   background: var(--md-sys-color-surface-variant);
+  border: 2px solid transparent;
   border-radius: common.$spacing-small;
   gap: common.$spacing-small;
   padding: common.$spacing-medium;
+
+  &.new {
+    border-color: var(--md-sys-color-error);
+  }
 }

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -25,6 +25,7 @@ import {RouterService} from '../../services/router.service';
 import {
   AgentConfig,
   AlertMessage,
+  AlertStatus,
   ParticipantProfileExtended,
   StageKind,
   EXPERIMENT_VERSION_ID,
@@ -61,6 +62,7 @@ export class Panel extends MobxLitElement {
   @state() panelView: PanelView = PanelView.DEFAULT;
   @state() isLoading = false;
   @state() isDownloading = false;
+  @state() isAckAlertLoading = false;
   @state() participantSearchQuery = '';
 
   override render() {
@@ -397,6 +399,15 @@ export class Panel extends MobxLitElement {
       const participant =
         this.experimentManager.participantMap[alert.participantId];
 
+      const onAck = () => {
+        // TODO: Add UI so the experimenter can send a custom response
+        // (and add UI for the participant to view alert status/response)
+        this.isAckAlertLoading = true;
+        const response = 'Acknowledged';
+        this.experimentManager.ackAlertMessage(alert.id, response);
+        this.isAckAlertLoading = false;
+      };
+
       return html`
         <div class="alert">
           <div class="subtitle">
@@ -407,6 +418,17 @@ export class Panel extends MobxLitElement {
             (${participant?.name ?? 'Unknown participant'})
           </div>
           <div>${alert.message}</div>
+          ${alert.status === AlertStatus.NEW
+            ? html`
+                <pr-icon-button
+                  icon="check_circle"
+                  variant="default"
+                  ?loading=${this.isAckAlertLoading}
+                  @click=${onAck}
+                >
+                </pr-icon-button>
+              `
+            : nothing}
         </div>
       `;
     };

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -143,8 +143,14 @@ export class Panel extends MobxLitElement {
           </pr-tooltip>
           <pr-tooltip text="Alerts" position="RIGHT_END">
             <pr-icon-button
-              color="secondary"
-              icon="notifications"
+              color=${this.experimentManager.hasNewAlerts &&
+              !isSelected(PanelView.ALERTS)
+                ? 'error'
+                : 'secondary'}
+              icon=${this.experimentManager.hasNewAlerts &&
+              !isSelected(PanelView.ALERTS)
+                ? 'notifications_active'
+                : 'notifications'}
               size="medium"
               variant=${isSelected(PanelView.ALERTS) ? 'tonal' : 'default'}
               @click=${() => {
@@ -392,7 +398,8 @@ export class Panel extends MobxLitElement {
   }
 
   private renderAlertPanel() {
-    const alerts = this.experimentManager.alerts;
+    const newAlerts = this.experimentManager.newAlerts;
+    const oldAlerts = this.experimentManager.oldAlerts;
 
     const renderAlert = (alert: AlertMessage) => {
       const cohort = this.experimentManager.getCohort(alert.cohortId);
@@ -409,7 +416,7 @@ export class Panel extends MobxLitElement {
       };
 
       return html`
-        <div class="alert">
+        <div class="alert ${alert.status === AlertStatus.NEW ? 'new' : ''}">
           <div class="subtitle">
             ${convertUnifiedTimestampToDate(alert.timestamp)}
           </div>
@@ -436,8 +443,10 @@ export class Panel extends MobxLitElement {
     return html`
       <div class="main">
         <div class="top">
-          <div class="header">Alerts</div>
-          ${alerts.map((alert) => renderAlert(alert))}
+          <div class="header">New Alerts</div>
+          ${newAlerts.map((alert) => renderAlert(alert))}
+          <div class="header">Past Alerts</div>
+          ${oldAlerts.map((alert) => renderAlert(alert))}
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -50,6 +50,7 @@ export class ChatInterface extends MobxLitElement {
   @property() disableInput = false;
   @property() showInfo = false;
   @state() readyToEndDiscussionLoading = false;
+  @state() isAlertLoading = false;
 
   private sendUserInput() {
     if (!this.stage) return;
@@ -264,6 +265,12 @@ export class ChatInterface extends MobxLitElement {
         currentDiscussionId,
       );
 
+    const sendAlert = async () => {
+      this.isAlertLoading = true;
+      await this.participantService.sendAlertMessage('Stuck in chat stage!');
+      this.isAlertLoading = false;
+    };
+
     return html`
       <pr-tooltip
         text=${isDisabled
@@ -280,6 +287,19 @@ export class ChatInterface extends MobxLitElement {
         >
           Ready to end discussion
         </pr-button>
+      </pr-tooltip>
+      <pr-tooltip
+        position="TOP_END"
+        text="Click this to alert the experimenter if you have trouble ending discussion"
+      >
+        <pr-icon-button
+          icon="contact_support"
+          variant="default"
+          color="error"
+          ?loading=${this.isAlertLoading}
+          @click=${sendAlert}
+        >
+        </pr-icon-button>
       </pr-tooltip>
     `;
   }

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -98,7 +98,7 @@ export class ExperimentManager extends Service {
   @observable experimentId: string | undefined = undefined;
   @observable cohortMap: Record<string, CohortConfig> = {};
   @observable participantMap: Record<string, ParticipantProfileExtended> = {};
-  @observable alerts: AlertMessage[] = [];
+  @observable alertMap: Record<string, AlertMessage> = {};
 
   // Loading
   @observable unsubscribe: Unsubscribe[] = [];
@@ -300,11 +300,15 @@ export class ExperimentManager extends Service {
   }
 
   @computed get newAlerts() {
-    return this.alerts.filter((alert) => alert.status === AlertStatus.NEW);
+    return Object.values(this.alertMap).filter(
+      (alert) => alert.status === AlertStatus.NEW,
+    );
   }
 
   @computed get oldAlerts() {
-    return this.alerts.filter((alert) => alert.status !== AlertStatus.NEW);
+    return Object.values(this.alertMap).filter(
+      (alert) => alert.status !== AlertStatus.NEW,
+    );
   }
 
   @computed get isLoading() {
@@ -348,7 +352,7 @@ export class ExperimentManager extends Service {
 
           changedDocs.forEach((doc) => {
             const data = doc.data() as AlertMessage;
-            this.alerts.push(data);
+            this.alertMap[data.id] = data;
           });
         },
       ),
@@ -415,7 +419,7 @@ export class ExperimentManager extends Service {
     // Reset experiment data
     this.cohortMap = {};
     this.participantMap = {};
-    this.alerts = [];
+    this.alertMap = {};
   }
 
   reset() {

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -22,6 +22,7 @@ import JSZip from 'jszip';
 
 import {
   AlertMessage,
+  AlertStatus,
   CohortConfig,
   CohortParticipantConfig,
   CreateChatMessageData,
@@ -292,6 +293,18 @@ export class ExperimentManager extends Service {
       );
     }
     return Object.values(this.cohortMap);
+  }
+
+  @computed get hasNewAlerts() {
+    return this.newAlerts.length > 0;
+  }
+
+  @computed get newAlerts() {
+    return this.alerts.filter((alert) => alert.status === AlertStatus.NEW);
+  }
+
+  @computed get oldAlerts() {
+    return this.alerts.filter((alert) => alert.status !== AlertStatus.NEW);
   }
 
   @computed get isLoading() {

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -37,6 +37,7 @@ import {
   generateId,
 } from '@deliberation-lab/utils';
 import {
+  ackAlertMessageCallable,
   bootParticipantCallable,
   createChatMessageCallable,
   createCohortCallable,
@@ -731,6 +732,22 @@ export class ExperimentManager extends Service {
         ).data ?? '';
     }
     return response;
+  }
+
+  /** Acknowledge alert message. */
+  async ackAlertMessage(alertId: string, response = '') {
+    let output = {};
+    if (this.experimentId) {
+      output = await ackAlertMessageCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          alertId,
+          response,
+        },
+      );
+    }
+    return output;
   }
 
   /** Create a manual (human) agent chat message. */

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -40,6 +40,7 @@ import {
   acceptParticipantExperimentStartCallable,
   acceptParticipantTransferCallable,
   createChatMessageCallable,
+  sendAlertMessageCallable,
   sendChipOfferCallable,
   sendChipResponseCallable,
   setChipTurnCallable,
@@ -753,5 +754,22 @@ export class ParticipantService extends Service {
       );
     }
     return output.success;
+  }
+
+  async sendAlertMessage(message: string) {
+    let response = {};
+    if (this.experimentId && this.profile) {
+      response = await sendAlertMessageCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          cohortId: this.profile.currentCohortId,
+          stageId: this.profile.currentStageId,
+          participantId: this.profile.privateId,
+          message,
+        },
+      );
+    }
+    return response;
   }
 }

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -14,6 +14,7 @@ import {
   InitiateParticipantTransferData,
   ParticipantNextStageResponse,
   ParticipantProfile,
+  SendAlertMessageData,
   SendChipOfferData,
   SendChipResponseData,
   SendParticipantCheckData,
@@ -464,6 +465,21 @@ export const testAgentConfigCallable = async (
   >(
     functions,
     'testAgentConfig',
+  )(config);
+  return data;
+};
+
+/** Generic endpoint for sending alert message. */
+export const sendAlertMessageCallable = async (
+  functions: Functions,
+  config: SendAlertMessageData,
+) => {
+  const {data} = await httpsCallable<
+    SendAlertMessageData,
+    SimpleResponse<string>
+  >(
+    functions,
+    'sendAlertMessage',
   )(config);
   return data;
 };

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -1,4 +1,5 @@
 import {
+  AckAlertMessageData,
   AgentConfigTestData,
   AgentParticipantPromptTestData,
   BaseParticipantData,
@@ -480,6 +481,21 @@ export const sendAlertMessageCallable = async (
   >(
     functions,
     'sendAlertMessage',
+  )(config);
+  return data;
+};
+
+/** Generic endpoint for acknowledging alert message. */
+export const ackAlertMessageCallable = async (
+  functions: Functions,
+  config: AckAlertMessageData,
+) => {
+  const {data} = await httpsCallable<
+    AckAlertMessageData,
+    SimpleResponse<string>
+  >(
+    functions,
+    'ackAlertMessage',
   )(config);
   return data;
 };

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -89,7 +89,7 @@ export function downloadJSON(data: object, filename: string) {
 export function toCSV(text: string | null) {
   if (!text) return '';
 
-  return text.replaceAll(',', ''); // remove commas
+  return text.replaceAll(',', '').replaceAll('\n', '');
 }
 
 // ****************************************************************************

--- a/functions/src/alert.endpoints.ts
+++ b/functions/src/alert.endpoints.ts
@@ -1,0 +1,58 @@
+import {
+  AlertMessage,
+  AlertStatus,
+  createAlertMessage,
+} from '@deliberation-lab/utils';
+
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {Timestamp} from 'firebase-admin/firestore';
+import {onCall} from 'firebase-functions/v2/https';
+
+import {app} from './app';
+import {AuthGuard} from './utils/auth-guard';
+
+// Send alert message (from participant to experimenter)
+export const sendAlertMessage = onCall(async (request) => {
+  const {data} = request;
+  const experimentId = data.experimentId;
+  const cohortId = data.cohortId;
+  const stageId = data.stageId;
+  const participantId = data.participantId;
+  const message = data.message;
+
+  const alert: AlertMessage = createAlertMessage({
+    experimentId,
+    cohortId,
+    stageId,
+    participantId,
+    message,
+    timestamp: Timestamp.now(),
+  });
+
+  // Store alert message under participant's alerts collection
+  const participantAlertDoc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('alerts')
+    .doc(alert.id);
+
+  // Also store alert message under experiment's alerts collection
+  const experimenterAlertDoc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('alerts')
+    .doc(alert.id);
+
+  // Run document write as transaction to ensure consistency
+  await app.firestore().runTransaction(async (transaction) => {
+    transaction.set(participantAlertDoc, alert);
+    transaction.set(experimenterAlertDoc, alert);
+  });
+
+  return {success: true};
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,6 +11,8 @@ export * from './participant.endpoints';
 export * from './participant.triggers';
 export * from './participant.utils';
 
+export * from './alert.endpoints';
+
 export * from './agent.endpoints';
 export * from './agent.utils';
 

--- a/functions/src/stages/chat.endpoints.ts
+++ b/functions/src/stages/chat.endpoints.ts
@@ -126,6 +126,11 @@ export const updateChatStageParticipantAnswer = onCall(async (request) => {
     .collection('publicStageData')
     .doc(data.chatStageParticipantAnswer.id);
 
+  // Set random timeout to avoid data contention with transaction
+  await new Promise((resolve) => {
+    setTimeout(resolve, Math.random() * 2000);
+  });
+
   // Run document write as transaction to ensure consistency
   await app.firestore().runTransaction(async (transaction) => {
     transaction.set(document, data.chatStageParticipantAnswer);
@@ -160,6 +165,7 @@ export const updateChatStageParticipantAnswer = onCall(async (request) => {
   return {id: document.id};
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function handleUpdateChatStageParticipantAnswerValidationErrors(data: any) {
   for (const error of Value.Errors(
     UpdateChatStageParticipantAnswerData,

--- a/utils/src/alert.ts
+++ b/utils/src/alert.ts
@@ -11,7 +11,7 @@ export interface AlertMessage {
   participantId: string; // private ID of participant
   message: string; // message from participant
   timestamp: UnifiedTimestamp; // time that message was sent
-  response: string[]; // responses from experimenter
+  responses: string[]; // responses from experimenter
   status: AlertStatus;
 }
 
@@ -31,7 +31,7 @@ export function createAlertMessage(
     stageId: config.stageId ?? '',
     participantId: config.participantId ?? '',
     message: config.message ?? '',
-    response: config.response ?? [],
+    responses: config.responses ?? [],
     timestamp: config.timestamp ?? Timestamp.now(),
     status: config.status ?? AlertStatus.NEW,
   };

--- a/utils/src/alert.ts
+++ b/utils/src/alert.ts
@@ -1,0 +1,38 @@
+import {UnifiedTimestamp, generateId} from './shared';
+import {Timestamp} from 'firebase/firestore';
+
+/** Alert types and functions. */
+
+export interface AlertMessage {
+  id: string;
+  experimentId: string;
+  cohortId: string;
+  stageId: string;
+  participantId: string; // private ID of participant
+  message: string; // message from participant
+  timestamp: UnifiedTimestamp; // time that message was sent
+  response: string[]; // responses from experimenter
+  status: AlertStatus;
+}
+
+export enum AlertStatus {
+  NEW = 'new', // sent by participant but not acknowledged by experimenter
+  READ = 'read', // read by experimenter
+  RESOLVED = 'resolved', // resolved by experimenter
+}
+
+export function createAlertMessage(
+  config: Partial<AlertMessage> = {},
+): AlertMessage {
+  return {
+    id: config.id ?? generateId(),
+    experimentId: config.experimentId ?? '',
+    cohortId: config.cohortId ?? '',
+    stageId: config.stageId ?? '',
+    participantId: config.participantId ?? '',
+    message: config.message ?? '',
+    response: config.response ?? [],
+    timestamp: config.timestamp ?? Timestamp.now(),
+    status: config.status ?? AlertStatus.NEW,
+  };
+}

--- a/utils/src/alert.validation.ts
+++ b/utils/src/alert.validation.ts
@@ -20,3 +20,19 @@ export const SendAlertMessageData = Type.Object(
 );
 
 export type SendAlertMessageData = Static<typeof SendAlertMessageData>;
+
+// ****************************************************************************
+// ackAlertMessage
+// ****************************************************************************
+
+/** AckAlertMessage input validation. */
+export const AckAlertMessageData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    alertId: Type.String({minLength: 1}),
+    response: Type.String(),
+  },
+  strict,
+);
+
+export type AckAlertMessageData = Static<typeof AckAlertMessageData>;

--- a/utils/src/alert.validation.ts
+++ b/utils/src/alert.validation.ts
@@ -1,0 +1,22 @@
+import {Type, type Static} from '@sinclair/typebox';
+
+/** Shorthand for strict TypeBox object validation */
+const strict = {additionalProperties: false} as const;
+
+// ****************************************************************************
+// sendAlertMessage
+// ****************************************************************************
+
+/** SendAlertMessage input validation. */
+export const SendAlertMessageData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    cohortId: Type.String({minLength: 1}),
+    stageId: Type.String({minLength: 1}),
+    participantId: Type.String({minLength: 1}),
+    message: Type.String({minLength: 1}),
+  },
+  strict,
+);
+
+export type SendAlertMessageData = Static<typeof SendAlertMessageData>;

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -1,5 +1,9 @@
 // Re export everything to simplify imports
 
+// Alert
+export * from './alert';
+export * from './alert.validation';
+
 // Experimenter
 export * from './experimenter';
 


### PR DESCRIPTION
This sets up AlertMessage objects that can be written to collections both under participants (for the participant to view) and under the experiment (for the experimenter to view all alerts across all participants).

A participant submits an alert with a custom message (right now, the message is hardcoded in the frontend because alerts are currently only used in chat threads); since it is written both to the participant's alerts collection and the experiment alerts collection, the experimenter is able to view the new alert(s) (from a listener on the latter collection) in their experiment dashboard (via a new notifications panel). They can then mark the alert as read and send a custom response.

Note that right now, the alert message from the participant and responses from the experimenter are not surfaced in the UI - there are only "send alert" and "acknowledge alert" buttons.