### PR TITLE
Fix chat stage bugs involving agent editing and discussion threads

### DIFF
--- a/frontend/src/components/stages/chat_editor.ts
+++ b/frontend/src/components/stages/chat_editor.ts
@@ -383,6 +383,11 @@ export class ChatEditor extends MobxLitElement {
   }
 
   private renderAgentSamplingParameters(agent: AgentConfig, index: number) {
+    // Check for generation config (backwards compatibility)
+    if (!agent.generationConfig) {
+      return nothing;
+    }
+
     const updateTemperature = (e: InputEvent) => {
       const temperature = Number((e.target as HTMLInputElement).value);
       if (!isNaN(temperature)) {
@@ -523,6 +528,11 @@ export class ChatEditor extends MobxLitElement {
     agent: AgentConfig,
     index: number,
   ) {
+    // Check for generation config (backwards compatibility)
+    if (!agent.generationConfig) {
+      return nothing;
+    }
+
     const addField = () => {
       this.updateAgent(
         {

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -93,7 +93,8 @@ export class ChatInterface extends MobxLitElement {
     if (stage.discussions.length > 0) {
       let discussions = stage.discussions;
       // Only show discussion threads that have been unlocked
-      if (currentDiscussionId !== null) {
+      // (if earlier experiment version without currentDiscussionId, show all)
+      if (currentDiscussionId !== null && currentDiscussionId !== undefined) {
         const index = discussions.findIndex(
           (discussion) => discussion.id === currentDiscussionId,
         );

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -174,10 +174,16 @@ export class ParticipantService extends Service {
   }
 
   isReadyToEndChatDiscussion(stageId: string, discussionId: string) {
-    const stageAnswer = this.answerMap[stageId];
-    if (!stageAnswer || stageAnswer.kind !== StageKind.CHAT) return false;
-
-    return stageAnswer.discussionTimestampMap[discussionId];
+    // Use public stage data as source of truth
+    // (since public stage data is used to determine current discussion ID)
+    const {completed, notCompleted} =
+      this.sp.cohortService.getParticipantsByChatDiscussionCompletion(
+        stageId,
+        discussionId,
+      );
+    return completed.find(
+      (participant) => participant.publicId === this.profile?.publicId,
+    );
   }
 
   @action setCurrentStageView(stageId: string | undefined) {


### PR DESCRIPTION
- Hide agent generation config fields in chat editor if agent is from a pre-generationConfig experiment version
- In chat participant view, show all chat threads for experiments missing the currentDiscussionIndex field
- Fix readyToEndDiscussion logic to use publicStageData source of truth