### PR TITLE
Add structured output support for agents

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ layout: default
 
 This page summarizes notable updates to the Deliberate Lab platform.
 
+## 2025-04-07: Add structured output support to agent prompts
+Experiment Version: 17 / [PR #495](https://github.com/PAIR-code/deliberate-lab/pull/495)
+
+- Experimenters can now configure custom schemas for structured outputs
+- Three special fields are supported: a field for the message, a field for whether or not to respond, and a field for an explanation or chain of thought. Experimenters can configure what these fields are named.
+- The prompt will include a description of the output schema. Experimenters can disable this if they'd rather supply their own output examples.
+- Experimenters can constrain the sampler to output valid json, or to output valid json in the specified schema. This is only supported for the Gemini API so far.
+- Experiments with the old isJSON config should still work, but when loaded on frontend for editing, they will be ported to the new structured output config.
+- New experiments have a default config with structured outputs enabled, a premade schema with the three special fields, schema prompting, and no output constraints.
+- All schemas must be flat. Nested objects and arrays are supported in the backend, but don't have UI support.
+
 ## 2025-03-24: Set up new agent configuration workflow at experiment level
 Experiment Version: 16 /
 [PR #468](https://github.com/PAIR-code/deliberate-lab/pull/468)

--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -47,7 +47,8 @@
   padding: common.$main-content-padding;
 }
 
-.section-header {
+.section-header,
+.subsection-header {
   @include common.flex-column;
 }
 
@@ -55,7 +56,8 @@
   @include typescale.title-medium;
 }
 
-.section {
+.section,
+.subsection {
   @include common.flex-column;
   gap: common.$spacing-large;
 }

--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -191,3 +191,17 @@ select {
   border-radius: common.$spacing-medium;
   color: var(--md-sys-color-on-surface-variant);
 }
+
+.code-wrapper {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+  max-width: calc(common.$info-content-max-width - common.$spacing-xxl);
+  width: 100%;
+}
+
+pre {
+  background: var(--md-sys-color-surface-variant);
+  margin: 0;
+  overflow: auto;
+  padding: common.$spacing-medium;
+}

--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -180,8 +180,14 @@ pr-textarea {
   }
 }
 
+.select-field {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
 select {
   @include common.select;
   background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-medium;
   color: var(--md-sys-color-on-surface-variant);
 }

--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -176,3 +176,9 @@ pr-textarea {
     color: var(--md-sys-color-on-error-container);
   }
 }
+
+select {
+  @include common.select;
+  background: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-on-surface-variant);
+}

--- a/frontend/src/components/experiment_builder/agent_editor.scss
+++ b/frontend/src/components/experiment_builder/agent_editor.scss
@@ -67,7 +67,8 @@
 }
 
 .field-title,
-.radio-question-label {
+.radio-question-label,
+.small {
   @include typescale.label-small;
 }
 

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -170,7 +170,10 @@ export class AgentEditorComponent extends MobxLitElement {
           ${this.renderAgentStructuredOutputConfig(agentConfig, promptConfig)}
         </div>
         <div class="divider"></div>
-        ${this.renderAgentWordsPerMinute(agentConfig, promptConfig)}
+        <div class="section">
+          <div class="section-title">Chat settings</div>
+          ${this.renderAgentWordsPerMinute(agentConfig, promptConfig)}
+        </div>
         <div class="divider"></div>
         ${this.renderAgentSamplingParameters(agentConfig, promptConfig)}
         <div class="divider"></div>
@@ -481,7 +484,6 @@ export class AgentEditorComponent extends MobxLitElement {
 
     const currentWPM = agentPromptConfig.chatSettings.wordsPerMinute;
     return html`
-      <div class="section-title">Chat settings</div>
       <div class="field">
         <div class="field-title">Words per minute</div>
         <div class="description">
@@ -864,9 +866,9 @@ export class AgentEditorComponent extends MobxLitElement {
     };
 
     return html`
-      <div class="section">
-        <div class="section-header">
-          <div class="section-title">Structured output schema fields</div>
+      <div class="subsection">
+        <div class="subsection-header">
+          <div>Structured output schema fields</div>
           <div class="description">
             Add fields to the structured output schema.
           </div>

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -724,7 +724,6 @@ export class AgentEditorComponent extends MobxLitElement {
 
   // TODO: allow for reordering config fields
   // TODO: add checkbox for whether to append schema prompt
-  // TODO: StructuredOutputType dropdown renders blank initially
   private renderAgentStructuredOutputConfig(
     agent: AgentPersonaConfig,
     agentPromptConfig: AgentChatPromptConfig,
@@ -745,7 +744,7 @@ export class AgentEditorComponent extends MobxLitElement {
         <label for="structuredOutputType">Structured Output Type</label>
         <select
           id="structuredOutputType"
-          .value=${config.type}
+          .selected=${config.type}
           @change=${updateType}
           ?disabled=${!this.experimentEditor.canEditStages}
         >

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -22,7 +22,7 @@ import {
   StructuredOutputType,
   StructuredOutputDataType,
   StructuredOutputSchema,
-  printSchema,
+  makeStructuredOutputPrompt,
   structuredOutputEnabled,
 } from '@deliberation-lab/utils';
 import {LLM_AGENT_AVATARS} from '../../shared/constants';
@@ -168,6 +168,7 @@ export class AgentEditorComponent extends MobxLitElement {
           <div class="section-title">Prompt settings</div>
           ${this.renderAgentPrompt(agentConfig, promptConfig)}
           ${this.renderAgentStructuredOutputConfig(agentConfig, promptConfig)}
+          ${this.renderPromptPreview(promptConfig)}
         </div>
         <div class="divider"></div>
         <div class="section">
@@ -409,18 +410,16 @@ export class AgentEditorComponent extends MobxLitElement {
     `;
   }
 
-  private renderAgentStructuredOutputSchema(
-    agentPromptConfig: AgentChatPromptConfig,
-  ) {
+  private renderPromptPreview(agentPromptConfig: AgentChatPromptConfig) {
     const config = agentPromptConfig.structuredOutputConfig;
-    if (!structuredOutputEnabled(config) || !config.schema) {
-      return nothing;
+    let prompt = agentPromptConfig.promptContext;
+    if (structuredOutputEnabled(config) && config.schema) {
+      prompt += `\n${makeStructuredOutputPrompt(config)}`;
     }
     return html`
-      <div>
-        <div>Structured output schema (defined by fields above):</div>
-        <div class="description">${printSchema(config.schema)}</div>
-        <div></div>
+      <div class="code-wrapper">
+        <div class="field-title">Prompt preview</div>
+        <pre><code>${prompt}</code></pre>
       </div>
     `;
   }

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -974,12 +974,15 @@ export class AgentEditorComponent extends MobxLitElement {
           @input=${updateName}
         >
         </pr-textarea>
-        <select .value=${field.schema.type} @change=${updateType}>
-          <option value="${StructuredOutputDataType.STRING}">STRING</option>
-          <option value="${StructuredOutputDataType.NUMBER}">NUMBER</option>
-          <option value="${StructuredOutputDataType.INTEGER}">INTEGER</option>
-          <option value="${StructuredOutputDataType.BOOLEAN}">BOOLEAN</option>
-        </select>
+        <div class="select-field">
+          <div class="field-title">Field type</div>
+          <select .value=${field.schema.type} @change=${updateType}>
+            <option value="${StructuredOutputDataType.STRING}">STRING</option>
+            <option value="${StructuredOutputDataType.NUMBER}">NUMBER</option>
+            <option value="${StructuredOutputDataType.INTEGER}">INTEGER</option>
+            <option value="${StructuredOutputDataType.BOOLEAN}">BOOLEAN</option>
+          </select>
+        </div>
         <pr-textarea
           label="Field description"
           variant="outlined"

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -18,6 +18,7 @@ import {
   ApiKeyType,
   StageConfig,
   StageKind,
+  StructuredOutputConfig,
   StructuredOutputType,
   StructuredOutputDataType,
   StructuredOutputSchema,
@@ -767,14 +768,32 @@ export class AgentEditorComponent extends MobxLitElement {
     agent: AgentPersonaConfig,
     agentPromptConfig: AgentChatPromptConfig,
   ) {
+    const config = agentPromptConfig.structuredOutputConfig;
     const addField = () => {
       this.agentEditor.addAgentMediatorStructuredOutputSchemaField(
         agent.id,
         agentPromptConfig.id,
       );
     };
-
-    const structuredOutputConfig = agentPromptConfig.structuredOutputConfig;
+    const updateConfig = (structuredOutputConfig: Partial<StructuredOutputConfig>) => {
+      this.agentEditor.updateAgentMediatorStructuredOutputConfig(
+        agent.id,
+        agentPromptConfig.id,
+        structuredOutputConfig,
+      );
+    };
+    const updateMessageField = (e: InputEvent) => {
+      const messageField = (e.target as HTMLTextAreaElement).value;
+      updateConfig({messageField});
+    };
+    const updateExplanationField = (e: InputEvent) => {
+      const explanationField = (e.target as HTMLTextAreaElement).value;
+      updateConfig({explanationField});
+    };
+    const updateShouldRespondField = (e: InputEvent) => {
+      const shouldRespondField = (e.target as HTMLTextAreaElement).value;
+      updateConfig({shouldRespondField});
+    };
 
     return html`
       <div class="section">
@@ -782,7 +801,7 @@ export class AgentEditorComponent extends MobxLitElement {
           <div class="section-title">Structured output schema fields</div>
           <div class="description">Add fields to the structured output schema.</div>
         </div>
-        ${structuredOutputConfig.schema?.properties?.map((field, fieldIndex) =>
+        ${config.schema?.properties?.map((field, fieldIndex) =>
           this.renderAgentStructuredOutputSchemaField(
             agent,
             agentPromptConfig,
@@ -791,6 +810,39 @@ export class AgentEditorComponent extends MobxLitElement {
           ),
         )}
         <pr-button @click=${addField}>Add field</pr-button>
+      </div>
+      <div class="field">
+        <pr-textarea
+          label="JSON field to extract debugging explanation or chain of thought from"
+          placeholder="JSON field to extract debugging explanation from"
+          variant="outlined"
+          .value=${config.explanationField}
+          ?disabled=${!this.experimentEditor.isCreator}
+          @input=${updateExplanationField}
+        >
+        </pr-textarea>
+      </div>
+      <div class="field">
+        <pr-textarea
+          label="JSON field to extract boolean decision to respond from"
+          placeholder="JSON field to extract boolean decision to respond from"
+          variant="outlined"
+          .value=${config.shouldRespondField}
+          ?disabled=${!this.experimentEditor.isCreator}
+          @input=${updateShouldRespondField}
+        >
+        </pr-textarea>
+      </div>
+      <div class="field">
+        <pr-textarea
+          label="JSON field to extract chat message from"
+          placeholder="JSON field to extract chat message from"
+          variant="outlined"
+          .value=${config.messageField}
+          ?disabled=${!this.experimentEditor.isCreator}
+          @input=${updateMessageField}
+        >
+        </pr-textarea>
       </div>
     `;
   }
@@ -839,7 +891,7 @@ export class AgentEditorComponent extends MobxLitElement {
       );
     };
 
-    // TODO: prettify type dropdown
+    // TODO(mkbehr): type dropdown is too tall
     return html`
       <div class="name-value-input">
         <pr-textarea

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -21,6 +21,7 @@ import {
   StructuredOutputType,
   StructuredOutputDataType,
   StructuredOutputSchema,
+  makeStructuredOutputPrompt,
 } from '@deliberation-lab/utils';
 import {LLM_AGENT_AVATARS} from '../../shared/constants';
 import {getHashBasedColor} from '../../shared/utils';
@@ -393,6 +394,17 @@ export class AgentEditorComponent extends MobxLitElement {
           @input=${updatePrompt}
         >
         </pr-textarea>
+        <div class="description">
+          Structured output formatting instructions: configure under "Structured Output Type"
+        </div>
+        <pr-textarea
+          placeholder="Structured output formatting instructions"
+          variant="outlined"
+          .value=${makeStructuredOutputPrompt(agentPromptConfig.structuredOutputConfig)}
+          disabled=true
+          maxViewportHeight=20
+        >
+        </pr-textarea>
       </div>
     `;
   }
@@ -709,6 +721,9 @@ export class AgentEditorComponent extends MobxLitElement {
     `;
   }
 
+  // TODO: allow for reordering config fields
+  // TODO: add checkbox for whether to append schema prompt
+  // TODO: StructuredOutputType dropdown renders blank initially
   private renderAgentStructuredOutputConfig(
     agent: AgentPersonaConfig,
     agentPromptConfig: AgentChatPromptConfig,
@@ -734,7 +749,7 @@ export class AgentEditorComponent extends MobxLitElement {
           ?disabled=${!this.experimentEditor.canEditStages}
         >
           <option value="${StructuredOutputType.NONE}">
-            No structured output
+            No output forcing
           </option>
           <option value="${StructuredOutputType.JSON_FORMAT}">
             Force JSON output
@@ -761,7 +776,6 @@ export class AgentEditorComponent extends MobxLitElement {
 
     const structuredOutputConfig = agentPromptConfig.structuredOutputConfig;
 
-    // TODO fix the rendering
     return html`
       <div class="section">
         <div class="section-header">
@@ -825,6 +839,7 @@ export class AgentEditorComponent extends MobxLitElement {
       );
     };
 
+    // TODO: prettify type dropdown
     return html`
       <div class="name-value-input">
         <pr-textarea

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -392,18 +392,21 @@ export class AgentEditorComponent extends MobxLitElement {
       }
       return html`
         <div class="description">
-          Structured output formatting instructions: configure under structured output settings
+          Structured output formatting instructions: configure under structured
+          output settings
         </div>
         <pr-textarea
           placeholder="Structured output formatting instructions"
           variant="outlined"
-          .value=${makeStructuredOutputPrompt(agentPromptConfig.structuredOutputConfig)}
-          disabled=true
-          maxViewportHeight=20
+          .value=${makeStructuredOutputPrompt(
+            agentPromptConfig.structuredOutputConfig,
+          )}
+          disabled="true"
+          maxViewportHeight="20"
         >
         </pr-textarea>
       `;
-    }
+    };
 
     return html`
       <div class="field">
@@ -745,7 +748,9 @@ export class AgentEditorComponent extends MobxLitElement {
     agentPromptConfig: AgentChatPromptConfig,
   ) {
     const config = agentPromptConfig.structuredOutputConfig;
-    const updateConfig = (structuredOutputConfig: Partial<StructuredOutputConfig>) => {
+    const updateConfig = (
+      structuredOutputConfig: Partial<StructuredOutputConfig>,
+    ) => {
       this.agentEditor.updateAgentMediatorStructuredOutputConfig(
         agent.id,
         agentPromptConfig.id,
@@ -761,7 +766,8 @@ export class AgentEditorComponent extends MobxLitElement {
       updateConfig({appendToPrompt});
     };
     const updateType = (e: InputEvent) => {
-      const type = (e.target as HTMLSelectElement).value as StructuredOutputType;
+      const type = (e.target as HTMLSelectElement)
+        .value as StructuredOutputType;
       updateConfig({type});
     };
 
@@ -770,39 +776,45 @@ export class AgentEditorComponent extends MobxLitElement {
         return nothing;
       }
       return html`
-      <div class="field">
-        <label for="structuredOutputType">Structured Output Type</label>
-        <div class="description">Constrain the sampler to produce valid JSON. Only supported for Gemini.</div>
-        <select
-          id="structuredOutputType"
-          .selected=${config.type}
-          @change=${updateType}
-          ?disabled=${!this.experimentEditor.canEditStages}
-        >
-          <option value="${StructuredOutputType.NONE}">
-            No output forcing
-          </option>
-          <option value="${StructuredOutputType.JSON_FORMAT}">
-            Force JSON output
-          </option>
-          <option value="${StructuredOutputType.JSON_SCHEMA}">
-            Force JSON output with schema
-          </option>
-        </select>
-      </div>
-      <div class="checkbox-wrapper">
-        <md-checkbox
-          touch-target="wrapper"
-          ?checked=${config.appendToPrompt}
-          ?disabled=${!this.experimentEditor.canEditStages}
-          @click=${updateAppendToPrompt}
-        >
-        </md-checkbox>
-        <div>Add formatting instructions to prompt</div>
-      </div>
-      ${this.renderAgentStructuredOutputSchemaFields(agent, agentPromptConfig)}
-    `;
-    }
+        <div class="field">
+          <label for="structuredOutputType">Structured Output Type</label>
+          <div class="description">
+            Constrain the sampler to produce valid JSON. Only supported for
+            Gemini.
+          </div>
+          <select
+            id="structuredOutputType"
+            .selected=${config.type}
+            @change=${updateType}
+            ?disabled=${!this.experimentEditor.canEditStages}
+          >
+            <option value="${StructuredOutputType.NONE}">
+              No output forcing
+            </option>
+            <option value="${StructuredOutputType.JSON_FORMAT}">
+              Force JSON output
+            </option>
+            <option value="${StructuredOutputType.JSON_SCHEMA}">
+              Force JSON output with schema
+            </option>
+          </select>
+        </div>
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${config.appendToPrompt}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateAppendToPrompt}
+          >
+          </md-checkbox>
+          <div>Add formatting instructions to prompt</div>
+        </div>
+        ${this.renderAgentStructuredOutputSchemaFields(
+          agent,
+          agentPromptConfig,
+        )}
+      `;
+    };
 
     return html`
       <div class="section>
@@ -833,7 +845,9 @@ export class AgentEditorComponent extends MobxLitElement {
         agentPromptConfig.id,
       );
     };
-    const updateConfig = (structuredOutputConfig: Partial<StructuredOutputConfig>) => {
+    const updateConfig = (
+      structuredOutputConfig: Partial<StructuredOutputConfig>,
+    ) => {
       this.agentEditor.updateAgentMediatorStructuredOutputConfig(
         agent.id,
         agentPromptConfig.id,
@@ -857,7 +871,9 @@ export class AgentEditorComponent extends MobxLitElement {
       <div class="section">
         <div class="section-header">
           <div class="section-title">Structured output schema fields</div>
-          <div class="description">Add fields to the structured output schema.</div>
+          <div class="description">
+            Add fields to the structured output schema.
+          </div>
         </div>
         ${config.schema?.properties?.map((field, fieldIndex) =>
           this.renderAgentStructuredOutputSchemaField(
@@ -922,7 +938,8 @@ export class AgentEditorComponent extends MobxLitElement {
     };
 
     const updateType = (e: Event) => {
-      const type = (e.target as HTMLSelectElement).value as StructuredOutputDataType;
+      const type = (e.target as HTMLSelectElement)
+        .value as StructuredOutputDataType;
       this.agentEditor.updateAgentMediatorStructuredOutputSchemaField(
         agent.id,
         agentPromptConfig.id,

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -22,7 +22,7 @@ import {
   StructuredOutputType,
   StructuredOutputDataType,
   StructuredOutputSchema,
-  makeStructuredOutputPrompt,
+  printSchema,
   structuredOutputEnabled,
 } from '@deliberation-lab/utils';
 import {LLM_AGENT_AVATARS} from '../../shared/constants';
@@ -164,12 +164,16 @@ export class AgentEditorComponent extends MobxLitElement {
       return html`
         <div>${this.renderTestPromptButton(agentConfig, promptConfig)}</div>
         <div class="divider"></div>
-        ${this.renderAgentPrompt(agentConfig, promptConfig)}
-        <div class="divider"></div>
-        ${this.renderAgentStructuredOutputConfig(agentConfig, promptConfig)}
+        <div class="section">
+          <div class="section-title">Prompt settings</div>
+          ${this.renderAgentPrompt(agentConfig, promptConfig)}
+          ${this.renderAgentStructuredOutputConfig(agentConfig, promptConfig)}
+        </div>
         <div class="divider"></div>
         ${this.renderAgentWordsPerMinute(agentConfig, promptConfig)}
+        <div class="divider"></div>
         ${this.renderAgentSamplingParameters(agentConfig, promptConfig)}
+        <div class="divider"></div>
         ${this.renderAgentCustomRequestBodyFields(agentConfig, promptConfig)}
         <div class="divider"></div>
         <pr-button
@@ -382,32 +386,6 @@ export class AgentEditorComponent extends MobxLitElement {
       );
     };
 
-    const renderStructuredOutputPrompt = () => {
-      const config = agentPromptConfig.structuredOutputConfig;
-      if (!structuredOutputEnabled(config)) {
-        return nothing;
-      }
-      if (!config.appendToPrompt) {
-        return nothing;
-      }
-      return html`
-        <div class="description">
-          Structured output formatting instructions: configure under structured
-          output settings
-        </div>
-        <pr-textarea
-          placeholder="Structured output formatting instructions"
-          variant="outlined"
-          .value=${makeStructuredOutputPrompt(
-            agentPromptConfig.structuredOutputConfig,
-          )}
-          disabled="true"
-          maxViewportHeight="20"
-        >
-        </pr-textarea>
-      `;
-    };
-
     return html`
       <div class="field">
         <div class="field-title">Prompt</div>
@@ -424,7 +402,22 @@ export class AgentEditorComponent extends MobxLitElement {
           @input=${updatePrompt}
         >
         </pr-textarea>
-        ${renderStructuredOutputPrompt()}
+      </div>
+    `;
+  }
+
+  private renderAgentStructuredOutputSchema(
+    agentPromptConfig: AgentChatPromptConfig,
+  ) {
+    const config = agentPromptConfig.structuredOutputConfig;
+    if (!structuredOutputEnabled(config) || !config.schema) {
+      return nothing;
+    }
+    return html`
+      <div>
+        <div>Structured output schema (defined by fields above):</div>
+        <div class="description">${printSchema(config.schema)}</div>
+        <div></div>
       </div>
     `;
   }
@@ -488,6 +481,7 @@ export class AgentEditorComponent extends MobxLitElement {
 
     const currentWPM = agentPromptConfig.chatSettings.wordsPerMinute;
     return html`
+      <div class="section-title">Chat settings</div>
       <div class="field">
         <div class="field-title">Words per minute</div>
         <div class="description">
@@ -742,7 +736,6 @@ export class AgentEditorComponent extends MobxLitElement {
   }
 
   // TODO(mkbehr): allow for reordering config fields
-  // TODO(mkbehr): the UI jumps around when you check/uncheck these boxes
   private renderAgentStructuredOutputConfig(
     agent: AgentPersonaConfig,
     agentPromptConfig: AgentChatPromptConfig,
@@ -807,7 +800,13 @@ export class AgentEditorComponent extends MobxLitElement {
             @click=${updateAppendToPrompt}
           >
           </md-checkbox>
-          <div>Add formatting instructions to prompt</div>
+          <div>
+            Include explanation of structured output format in prompt
+            <span class="small">
+              (e.g., "Return only valid JSON according to the following
+              schema...")
+            </span>
+          </div>
         </div>
         ${this.renderAgentStructuredOutputSchemaFields(
           agent,
@@ -817,21 +816,18 @@ export class AgentEditorComponent extends MobxLitElement {
     };
 
     return html`
-      <div class="section>
-        <div class="title">Structured output settings</div>
-        <div class="checkbox-wrapper">
-          <md-checkbox
-            touch-target="wrapper"
-            ?checked=${config.enabled}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @click=${updateEnabled}
-          >
-          </md-checkbox>
-      <div>Enable structured outputs</div>
+      <div class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${config.enabled}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @click=${updateEnabled}
+        >
+        </md-checkbox>
+        <div>Enable structured outputs</div>
       </div>
       ${mainSettings()}
-      </div>
-      `;
+    `;
   }
 
   private renderAgentStructuredOutputSchemaFields(

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -964,7 +964,6 @@ export class AgentEditorComponent extends MobxLitElement {
       );
     };
 
-    // TODO(mkbehr): type dropdown is too tall
     return html`
       <div class="name-value-input">
         <pr-textarea

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -19,6 +19,7 @@ import {
   StageConfig,
   StageKind,
   StructuredOutputType,
+  StructuredOutputDataType,
 } from '@deliberation-lab/utils';
 import {LLM_AGENT_AVATARS} from '../../shared/constants';
 import {getHashBasedColor} from '../../shared/utils';
@@ -742,36 +743,108 @@ export class AgentEditorComponent extends MobxLitElement {
           </option>
         </select>
       </div>
-      ${!config.isJSON
-        ? nothing
-        : html`
-            <div class="field">
-              <pr-textarea
-                label="JSON field to extract chat message from"
-                placeholder="JSON field to extract chat message from"
-                variant="outlined"
-                .value=${config.messageField}
-                ?disabled=${!this.experimentEditor.isCreator}
-                @input=${updateMessageField}
-              >
-              </pr-textarea>
-            </div>
-          `}
-      ${!config.isJSON
-        ? nothing
-        : html`
-            <div class="field">
-              <pr-textarea
-                label="JSON field to extract debugging explanation from"
-                placeholder="JSON field to extract debugging explanation from"
-                variant="outlined"
-                .value=${config.explanationField}
-                ?disabled=${!this.experimentEditor.isCreator}
-                @input=${updateExplanationField}
-              >
-              </pr-textarea>
-            </div>
-          `}
+      ${this.renderAgentStructuredOutputSchemaFields(agent, agentPromptConfig)}
+    `;
+  }
+
+  private renderAgentStructuredOutputSchemaFields(
+    agent: AgentPersonaConfig,
+    agentPromptConfig: AgentChatPromptConfig,
+  ) {
+    const addField = () => {
+      this.agentEditor.addAgentMediatorStructuredOutputSchemaField(
+        agent.id,
+        agentPromptConfig.id,
+      );
+    };
+
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Structured output schema fields</div>
+          <div class="description">Add fields to the structured output schema.</div>
+        </div>
+        <pr-button @click=${addField}>Add field</pr-button>
+      </div>
+    `;
+  }
+
+  private renderAgentStructuredOutputSchemaField(
+    agent: AgentPersonaConfig,
+    agentPromptConfig: AgentChatPromptConfig,
+    field: {name: string; type: StructuredOutputDataType; description: string},
+    fieldIndex: number,
+  ) {
+    const updateName = (e: InputEvent) => {
+      const name = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorStructuredOutputSchemaField(
+        agent.id,
+        agentPromptConfig.id,
+        fieldIndex,
+        {name},
+      );
+    };
+
+    const updateType = (e: Event) => {
+      const type = (e.target as HTMLSelectElement).value as StructuredOutputDataType;
+      this.agentEditor.updateAgentMediatorStructuredOutputSchemaField(
+        agent.id,
+        agentPromptConfig.id,
+        fieldIndex,
+        {type},
+      );
+    };
+
+    const updateDescription = (e: InputEvent) => {
+      const description = (e.target as HTMLTextAreaElement).value;
+      this.agentEditor.updateAgentMediatorStructuredOutputSchemaField(
+        agent.id,
+        agentPromptConfig.id,
+        fieldIndex,
+        {description},
+      );
+    };
+
+    const deleteField = () => {
+      this.agentEditor.deleteAgentMediatorStructuredOutputSchemaField(
+        agent.id,
+        agentPromptConfig.id,
+        fieldIndex,
+      );
+    };
+
+    return html`
+      <div class="name-value-input">
+        <pr-textarea
+          label="Field name"
+          variant="outlined"
+          .value=${field.name}
+          @input=${updateName}
+        >
+        </pr-textarea>
+        <select .value=${field.type} @change=${updateType}>
+          <option value="${StructuredOutputDataType.STRING}">STRING</option>
+          <option value="${StructuredOutputDataType.NUMBER}">NUMBER</option>
+          <option value="${StructuredOutputDataType.INTEGER}">INTEGER</option>
+          <option value="${StructuredOutputDataType.BOOLEAN}">BOOLEAN</option>
+        </select>
+        <pr-textarea
+          label="Field description"
+          variant="outlined"
+          .value=${field.description}
+          @input=${updateDescription}
+        >
+        </pr-textarea>
+        <pr-icon-button
+          icon="close"
+          color="neutral"
+          padding="small"
+          variant="default"
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @click=${deleteField}
+        >
+        </pr-icon-button>
+      </div>
     `;
   }
 }

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -20,6 +20,7 @@ import {
   StageKind,
   StructuredOutputType,
   StructuredOutputDataType,
+  StructuredOutputSchema,
 } from '@deliberation-lab/utils';
 import {LLM_AGENT_AVATARS} from '../../shared/constants';
 import {getHashBasedColor} from '../../shared/utils';
@@ -758,12 +759,23 @@ export class AgentEditorComponent extends MobxLitElement {
       );
     };
 
+    const structuredOutputConfig = agentPromptConfig.structuredOutputConfig;
+
+    // TODO fix the rendering
     return html`
       <div class="section">
         <div class="section-header">
           <div class="section-title">Structured output schema fields</div>
           <div class="description">Add fields to the structured output schema.</div>
         </div>
+        ${structuredOutputConfig.schema?.properties?.map((field, fieldIndex) =>
+          this.renderAgentStructuredOutputSchemaField(
+            agent,
+            agentPromptConfig,
+            field,
+            fieldIndex,
+          ),
+        )}
         <pr-button @click=${addField}>Add field</pr-button>
       </div>
     `;
@@ -772,7 +784,7 @@ export class AgentEditorComponent extends MobxLitElement {
   private renderAgentStructuredOutputSchemaField(
     agent: AgentPersonaConfig,
     agentPromptConfig: AgentChatPromptConfig,
-    field: {name: string; type: StructuredOutputDataType; description: string},
+    field: {name: string; schema: StructuredOutputSchema},
     fieldIndex: number,
   ) {
     const updateName = (e: InputEvent) => {
@@ -781,7 +793,7 @@ export class AgentEditorComponent extends MobxLitElement {
         agent.id,
         agentPromptConfig.id,
         fieldIndex,
-        {name},
+        {name: name},
       );
     };
 
@@ -791,7 +803,7 @@ export class AgentEditorComponent extends MobxLitElement {
         agent.id,
         agentPromptConfig.id,
         fieldIndex,
-        {type},
+        {schema: {type: type}},
       );
     };
 
@@ -801,7 +813,7 @@ export class AgentEditorComponent extends MobxLitElement {
         agent.id,
         agentPromptConfig.id,
         fieldIndex,
-        {description},
+        {schema: {description: description}},
       );
     };
 
@@ -822,7 +834,7 @@ export class AgentEditorComponent extends MobxLitElement {
           @input=${updateName}
         >
         </pr-textarea>
-        <select .value=${field.type} @change=${updateType}>
+        <select .value=${field.schema.type} @change=${updateType}>
           <option value="${StructuredOutputDataType.STRING}">STRING</option>
           <option value="${StructuredOutputDataType.NUMBER}">NUMBER</option>
           <option value="${StructuredOutputDataType.INTEGER}">INTEGER</option>
@@ -831,7 +843,7 @@ export class AgentEditorComponent extends MobxLitElement {
         <pr-textarea
           label="Field description"
           variant="outlined"
-          .value=${field.description}
+          .value=${field.schema.description}
           @input=${updateDescription}
         >
         </pr-textarea>

--- a/frontend/src/components/experiment_builder/agent_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_editor.ts
@@ -731,9 +731,15 @@ export class AgentEditorComponent extends MobxLitElement {
           @change=${updateType}
           ?disabled=${!this.experimentEditor.canEditStages}
         >
-          ${Object.values(StructuredOutputType).map((type) => {
-            return html`<option value="${type}">${type}</option>`;
-          })}
+          <option value="${StructuredOutputType.NONE}">
+            No structured output
+          </option>
+          <option value="${StructuredOutputType.JSON_FORMAT}">
+            Force JSON output
+          </option>
+          <option value="${StructuredOutputType.JSON_SCHEMA}">
+            Force JSON output with schema
+          </option>
         </select>
       </div>
       ${!config.isJSON

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -31,9 +31,6 @@ import {
 } from '@deliberation-lab/utils';
 
 import {styles} from './experimenter_panel.scss';
-import {DEFAULT_STRING_FORMATTING_INSTRUCTIONS} from '@deliberation-lab/utils';
-import {DEFAULT_JSON_FORMATTING_INSTRUCTIONS} from '@deliberation-lab/utils';
-
 import {convertUnifiedTimestampToDate} from '../../shared/utils';
 
 enum PanelView {

--- a/frontend/src/sass/_common.scss
+++ b/frontend/src/sass/_common.scss
@@ -85,6 +85,18 @@
   }
 }
 
+@mixin select {
+  @include typescale.body-small;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: $spacing-small;
+  color: var(--md-sys-color-on-surface);
+  height: max-content;
+  outline: none;
+  padding: $spacing-small;
+  width: max-content;
+}
+
 @mixin chip {
   background: var(--md-sys-color-surface-container);
   border-radius: $spacing-medium;

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -19,6 +19,7 @@ import {
   ParticipantProfileBase,
   StageConfig,
   StageKind,
+  StructuredOutputConfig,
   ModelGenerationConfig,
   createAgentChatPromptConfig,
   createAgentPersonaConfig,
@@ -208,10 +209,26 @@ export class AgentEditor extends Service {
   ) {
     const agent = this.getAgentMediator(id);
     const config = this.agentChatPromptMap[id][stageId];
+    // TODO(mkbehr): fix or remove
+    // if (agent && config) {
+    //   this.agentChatPromptMap[id][stageId] = {
+    //     ...config,
+    //     responseConfig: {...config.responseConfig, ...newResponseConfig},
+    //   };
+    // }
+  }
+
+  updateAgentMediatorStructuredOutputConfig(
+    id: string,
+    stageId: string,
+    newStructuredOutputConfig: Partial<StructuredOutputConfig>,
+  ) {
+    const agent = this.getAgentMediator(id);
+    const config = this.agentChatPromptMap[id][stageId];
     if (agent && config) {
       this.agentChatPromptMap[id][stageId] = {
         ...config,
-        responseConfig: {...config.responseConfig, ...newResponseConfig},
+        structuredOutputConfig: {...config.structuredOutputConfig, ...newStructuredOutputConfig},
       };
     }
   }

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -290,9 +290,6 @@ export class AgentEditor extends Service {
           properties: [newField]
         };
       }
-      console.log(promptConfig.structuredOutputConfig.type);
-      console.log(promptConfig.structuredOutputConfig.schema);
-      console.log(promptConfig.structuredOutputConfig.schema?.properties ?? 'no properties');
       this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
         schema: promptConfig.structuredOutputConfig.schema,
       });

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -204,22 +204,6 @@ export class AgentEditor extends Service {
     }
   }
 
-  updateAgentMediatorResponseConfig(
-    id: string,
-    stageId: string,
-    newResponseConfig: Partial<AgentResponseConfig>,
-  ) {
-    const agent = this.getAgentMediator(id);
-    const config = this.agentChatPromptMap[id][stageId];
-    // TODO(mkbehr): fix or remove
-    // if (agent && config) {
-    //   this.agentChatPromptMap[id][stageId] = {
-    //     ...config,
-    //     responseConfig: {...config.responseConfig, ...newResponseConfig},
-    //   };
-    // }
-  }
-
   updateAgentMediatorStructuredOutputConfig(
     id: string,
     stageId: string,

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -350,11 +350,10 @@ export class AgentEditor extends Service {
     if (agent && promptConfig) {
       const schema = promptConfig.structuredOutputConfig.schema;
       if (schema && schema.properties) {
-        // TODO: Figure out how to update the map
-        // schema.properties = [
-        //   ...schema.properties.slice(0, fieldIndex),
-        //   ...schema.properties.slice(fieldIndex + 1),
-        // ];
+        schema.properties = [
+          ...schema.properties.slice(0, fieldIndex),
+          ...schema.properties.slice(fieldIndex + 1),
+        ];
         this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
           schema,
         });

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -20,6 +20,7 @@ import {
   StageConfig,
   StageKind,
   StructuredOutputConfig,
+  StructuredOutputDataType,
   ModelGenerationConfig,
   createAgentChatPromptConfig,
   createAgentPersonaConfig,
@@ -286,6 +287,72 @@ export class AgentEditor extends Service {
         ...promptConfig.generationConfig,
         customRequestBodyFields,
       };
+    }
+  }
+
+  addAgentMediatorStructuredOutputSchemaField(agentId: string, stageId: string) {
+    const agent = this.getAgentMediator(agentId);
+    const promptConfig = this.agentChatPromptMap[agentId][stageId];
+    if (agent && promptConfig) {
+      const schema = promptConfig.structuredOutputConfig.schema;
+      const newField = {name: '', type: StructuredOutputDataType.STRING, description: ''};
+      if (schema) {
+        schema.properties = schema.properties ?? new Map();
+        schema.properties.set(newField.name, newField);
+      } else {
+        promptConfig.structuredOutputConfig.schema = {
+          type: StructuredOutputDataType.OBJECT,
+          properties: new Map([[newField.name, newField]]),
+        };
+      }
+      this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
+        schema: promptConfig.structuredOutputConfig.schema,
+      });
+    }
+  }
+
+  updateAgentMediatorStructuredOutputSchemaField(
+    agentId: string,
+    stageId: string,
+    fieldIndex: number,
+    field: Partial<{name: string; type: string; description: string}>,
+  ) {
+    const agent = this.getAgentMediator(agentId);
+    const promptConfig = this.agentChatPromptMap[agentId][stageId];
+    if (agent && promptConfig) {
+      const schema = promptConfig.structuredOutputConfig.schema;
+      if (schema && schema.properties) {
+        // TODO: Figure out how to update the map
+        // schema.properties[fieldIndex] = {
+        //   ...schema.properties[fieldIndex],
+        //   ...field,
+        // };
+        this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
+          schema,
+        });
+      }
+    }
+  }
+
+  deleteAgentMediatorStructuredOutputSchemaField(
+    agentId: string,
+    stageId: string,
+    fieldIndex: number,
+  ) {
+    const agent = this.getAgentMediator(agentId);
+    const promptConfig = this.agentChatPromptMap[agentId][stageId];
+    if (agent && promptConfig) {
+      const schema = promptConfig.structuredOutputConfig.schema;
+      if (schema && schema.properties) {
+        // TODO: Figure out how to update the map
+        // schema.properties = [
+        //   ...schema.properties.slice(0, fieldIndex),
+        //   ...schema.properties.slice(fieldIndex + 1),
+        // ];
+        this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
+          schema,
+        });
+      }
     }
   }
 

--- a/frontend/src/services/agent.editor.ts
+++ b/frontend/src/services/agent.editor.ts
@@ -214,7 +214,10 @@ export class AgentEditor extends Service {
     if (agent && config) {
       this.agentChatPromptMap[id][stageId] = {
         ...config,
-        structuredOutputConfig: {...config.structuredOutputConfig, ...newStructuredOutputConfig},
+        structuredOutputConfig: {
+          ...config.structuredOutputConfig,
+          ...newStructuredOutputConfig,
+        },
       };
     }
   }
@@ -275,19 +278,25 @@ export class AgentEditor extends Service {
     }
   }
 
-  addAgentMediatorStructuredOutputSchemaField(agentId: string, stageId: string) {
+  addAgentMediatorStructuredOutputSchemaField(
+    agentId: string,
+    stageId: string,
+  ) {
     const agent = this.getAgentMediator(agentId);
     const promptConfig = this.agentChatPromptMap[agentId][stageId];
     if (agent && promptConfig) {
       const schema = promptConfig.structuredOutputConfig.schema;
-      const newField = {name: '', schema: {type: StructuredOutputDataType.STRING, description: ''}};
+      const newField = {
+        name: '',
+        schema: {type: StructuredOutputDataType.STRING, description: ''},
+      };
       if (schema) {
         schema.properties = schema.properties ?? [];
         schema.properties = [...schema.properties, newField];
       } else {
         promptConfig.structuredOutputConfig.schema = {
           type: StructuredOutputDataType.OBJECT,
-          properties: [newField]
+          properties: [newField],
         };
       }
       this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
@@ -310,9 +319,9 @@ export class AgentEditor extends Service {
         schema.properties[fieldIndex] = {
           name: field.name ?? schema.properties[fieldIndex].name,
           schema: {
-              ...schema.properties[fieldIndex].schema,
-              ...field.schema,
-          }
+            ...schema.properties[fieldIndex].schema,
+            ...field.schema,
+          },
         };
         this.updateAgentMediatorStructuredOutputConfig(agentId, stageId, {
           schema,

--- a/frontend/src/shared/games/reality_tv_chat.ts
+++ b/frontend/src/shared/games/reality_tv_chat.ts
@@ -1,5 +1,3 @@
-import {createProfileStage} from '@deliberation-lab/utils';
-import {createAgentResponseConfig} from '@deliberation-lab/utils';
 import {
   createAgentChatPromptConfig,
   createAgentChatSettings,
@@ -7,6 +5,7 @@ import {
   createChatStage,
   createMetadataConfig,
   createParticipantProfileBase,
+  createProfileStage,
   AgentChatPromptConfig,
   AgentDataObject,
   ProfileType,
@@ -78,11 +77,6 @@ function createLennyAgent(): AgentDataObject {
         canSelfTriggerCalls: false,
         maxResponses: 10,
       }),
-      responseConfig: createAgentResponseConfig({
-        isJSON: true,
-        messageField: 'response',
-        explanationField: 'explanation',
-      }),
     },
   );
 
@@ -111,11 +105,6 @@ function createBobAgent(): AgentDataObject {
         canSelfTriggerCalls: false,
         maxResponses: 10,
       }),
-      responseConfig: createAgentResponseConfig({
-        isJSON: true,
-        messageField: 'response',
-        explanationField: 'explanation',
-      }),
     },
   );
 
@@ -142,11 +131,6 @@ function createRhondaAgent(): AgentDataObject {
         wordsPerMinute: 100,
         canSelfTriggerCalls: false,
         maxResponses: 10,
-      }),
-      responseConfig: createAgentResponseConfig({
-        isJSON: true,
-        messageField: 'response',
-        explanationField: 'explanation',
       }),
     },
   );
@@ -175,11 +159,6 @@ function createModeratorAgent(): AgentDataObject {
         wordsPerMinute: 300,
         canSelfTriggerCalls: false,
         maxResponses: 10,
-      }),
-      responseConfig: createAgentResponseConfig({
-        isJSON: true,
-        messageField: 'response',
-        explanationField: 'explanation',
       }),
     },
   );

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -23,9 +23,9 @@ export async function getAgentResponse(
 ): Promise<ModelResponse> {
   let response;
 
-  const structuredOutputPrompt = (structuredOutputConfig
-                                  ? makeStructuredOutputPrompt(structuredOutputConfig)
-                                  : '');
+  const structuredOutputPrompt = structuredOutputConfig
+    ? makeStructuredOutputPrompt(structuredOutputConfig)
+    : '';
   if (structuredOutputPrompt) {
     prompt = `${prompt}\n${structuredOutputPrompt}`;
   }

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -4,6 +4,7 @@ import {
   ApiKeyType,
   ExperimenterData,
   ModelGenerationConfig,
+  StructuredOutputConfig,
 } from '@deliberation-lab/utils';
 
 import {getGeminiAPIResponse} from './api/gemini.api';
@@ -17,6 +18,7 @@ export async function getAgentResponse(
   prompt: string,
   modelSettings: AgentModelSettings,
   generationConfig: ModelGenerationConfig,
+  structuredOutputConfig?: StructuredOutputConfig,
 ): Promise<ModelResponse> {
   let response;
 
@@ -26,6 +28,7 @@ export async function getAgentResponse(
       modelSettings.model,
       prompt,
       generationConfig,
+      structuredOutputConfig,
     );
   } else if (modelSettings.apiType === ApiKeyType.OPENAI_API_KEY) {
     response = getOpenAIAPIResponse(

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -5,6 +5,7 @@ import {
   ExperimenterData,
   ModelGenerationConfig,
   StructuredOutputConfig,
+  makeStructuredOutputPrompt,
 } from '@deliberation-lab/utils';
 
 import {getGeminiAPIResponse} from './api/gemini.api';
@@ -21,6 +22,13 @@ export async function getAgentResponse(
   structuredOutputConfig?: StructuredOutputConfig,
 ): Promise<ModelResponse> {
   let response;
+
+  const structuredOutputPrompt = (structuredOutputConfig
+                                  ? makeStructuredOutputPrompt(structuredOutputConfig)
+                                  : '');
+  if (structuredOutputPrompt) {
+    prompt = `${prompt}\n${structuredOutputPrompt}`;
+  }
 
   if (modelSettings.apiType === ApiKeyType.GEMINI_API_KEY) {
     response = getGeminiResponse(

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -58,12 +58,14 @@ export async function getGeminiResponse(
   modelName: string,
   prompt: string,
   generationConfig: ModelGenerationConfig,
+  structuredOutputConfig?: StructuredOutputConfig,
 ): Promise<ModelResponse> {
   return await getGeminiAPIResponse(
     data.apiKeys.geminiApiKey,
     modelName,
     prompt,
     generationConfig,
+    structuredOutputConfig,
   );
 }
 

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -75,12 +75,24 @@ describe('Gemini API', () => {
     };
 
     const structuredOutputConfig = {
-      type: StructuredOutputType.JSON_FORMAT,
+      type: StructuredOutputType.JSON_SCHEMA,
       schema: {
         type: StructuredOutputDataType.OBJECT,
         properties: [
-          { name: 'stringProperty', schema: { type: StructuredOutputDataType.STRING } },
-          { name: 'integerProperty', schema: { type: StructuredOutputDataType.INTEGER } },
+          {
+            name: 'stringProperty',
+            schema: {
+              type: StructuredOutputDataType.STRING,
+              description: "A string-valued property",
+            }
+          },
+          {
+            name: 'integerProperty',
+            schema: {
+              type: StructuredOutputDataType.INTEGER,
+              description: "An integer-valued property",
+            }
+          },
         ],
       },
     };
@@ -100,13 +112,21 @@ describe('Gemini API', () => {
         responseMimeType: 'application/json',
         responseSchema: {
           type: 'OBJECT',
-          properties: [
-            { name: 'stringProperty', schema: { type: 'STRING' } },
-            { name: 'integerProperty', schema: { type: 'INTEGER' } },
-          ],
+          properties: {
+            stringProperty:  {
+              type: 'STRING',
+              description: 'A string-valued property',
+            },
+            integerProperty: {
+              type: 'INTEGER',
+              description: 'An integer-valued property',
+            },
+          },
+          propertyOrdering: ['stringProperty', 'integerProperty'],
+          required: ['stringProperty', 'integerProperty'],
         },
       },
     };
-    expect(parsedResponse).toEqual(expect.objectContaining(expectedResponse));
+    expect(parsedResponse).toMatchObject(expectedResponse);
   });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -94,12 +94,19 @@ describe('Gemini API', () => {
     );
 
     const parsedResponse = JSON.parse(response.text);
-    expect(parsedResponse.output).toBe('test output');
-    expect(parsedResponse.generationConfig.responseMimeType).toBe('application/json');
-    expect(parsedResponse.generationConfig.responseSchema?.type).toBe('OBJECT');
-    expect(parsedResponse.generationConfig.responseSchema?.properties[0]?.name).toBe('stringProperty');
-    expect(parsedResponse.generationConfig.responseSchema?.properties[0]?.schema.type).toBe('STRING');
-    expect(parsedResponse.generationConfig.responseSchema?.properties[1]?.name).toBe('integerProperty');
-    expect(parsedResponse.generationConfig.responseSchema?.properties[1]?.schema.type).toBe('INTEGER');
+    const expectedResponse = {
+      output: 'test output',
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: 'OBJECT',
+          properties: [
+            { name: 'stringProperty', schema: { type: 'STRING' } },
+            { name: 'integerProperty', schema: { type: 'INTEGER' } },
+          ],
+        },
+      },
+    };
+    expect(parsedResponse).toEqual(expectedResponse);
   });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -4,7 +4,7 @@ import nock = require('nock');
 import {
   AgentGenerationConfig,
   StructuredOutputType,
-  StructuredOutputDataType
+  StructuredOutputDataType,
 } from '@deliberation-lab/utils';
 import {getGeminiAPIResponse} from './gemini.api';
 import {ModelResponse} from './model.response';
@@ -18,24 +18,25 @@ describe('Gemini API', () => {
     scope = nock('https://generativelanguage.googleapis.com')
       .post(`/v1beta/models/${MODEL_NAME}:generateContent`)
       .reply(200, (uri, requestBody) => {
-        return { candidates: [
-          {
-            content: {
-              parts: [
-                {
-                  text: JSON.stringify({
-                    output: 'test output',
-                    generationConfig: requestBody.generationConfig,
-                  }),
-                }
-              ],
+        return {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: JSON.stringify({
+                      output: 'test output',
+                      generationConfig: requestBody.generationConfig,
+                    }),
+                  },
+                ],
+              },
+              index: 0,
+              finish_reason: 'STOP',
+              avgLogprobs: -0.1,
             },
-            index: 0,
-            finish_reason: 'STOP',
-            avgLogprobs: -0.1
-          },
-        ],
-        modelVersion: MODEL_NAME
+          ],
+          modelVersion: MODEL_NAME,
         };
       });
   });
@@ -83,15 +84,15 @@ describe('Gemini API', () => {
             name: 'stringProperty',
             schema: {
               type: StructuredOutputDataType.STRING,
-              description: "A string-valued property",
-            }
+              description: 'A string-valued property',
+            },
           },
           {
             name: 'integerProperty',
             schema: {
               type: StructuredOutputDataType.INTEGER,
-              description: "An integer-valued property",
-            }
+              description: 'An integer-valued property',
+            },
           },
         ],
       },
@@ -113,7 +114,7 @@ describe('Gemini API', () => {
         responseSchema: {
           type: 'OBJECT',
           properties: {
-            stringProperty:  {
+            stringProperty: {
               type: 'STRING',
               description: 'A string-valued property',
             },

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -89,7 +89,13 @@ describe('Gemini API', () => {
       structuredOutputConfig,
     );
 
-    expect(response.text).toContain('test output');
-    expect(response.text).toContain('"generationConfig":{"temperature":0.4');
+    const parsedResponse = JSON.parse(response.text);
+    expect(parsedResponse.output).toBe('test output');
+    expect(parsedResponse.generationConfig.responseMimeType).toBe('application/json');
+    expect(parsedResponse.generationConfig.responseSchema.type).toBe('OBJECT');
+    expect(parsedResponse.generationConfig.responseSchema.properties[0].name).toBe('stringProperty');
+    expect(parsedResponse.generationConfig.responseSchema.properties[0].schema.type).toBe('STRING');
+    expect(parsedResponse.generationConfig.responseSchema.properties[1].name).toBe('integerProperty');
+    expect(parsedResponse.generationConfig.responseSchema.properties[1].schema.type).toBe('INTEGER');
   });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -107,6 +107,6 @@ describe('Gemini API', () => {
         },
       },
     };
-    expect(parsedResponse).toEqual(expectedResponse);
+    expect(parsedResponse).toEqual(expect.objectContaining(expectedResponse));
   });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -60,4 +60,36 @@ describe('Gemini API', () => {
     expect(response.text).toContain('"temperature":0.4');
     expect(response.text).toContain('"topP":0.9');
   });
+
+  it('handles structured output config', async () => {
+    const generationConfig: AgentGenerationConfig = {
+      temperature: 0.4,
+      topP: 0.9,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      customRequestBodyFields: [{name: 'seed', value: 123}],
+    };
+
+    const structuredOutputConfig = {
+      type: StructuredOutputType.JSON_FORMAT,
+      schema: {
+        type: StructuredOutputDataType.OBJECT,
+        properties: [
+          { name: 'stringProperty', schema: { type: StructuredOutputDataType.STRING } },
+          { name: 'integerProperty', schema: { type: StructuredOutputDataType.INTEGER } },
+        ],
+      },
+    };
+
+    const response: ModelResponse = await getGeminiAPIResponse(
+      'testapikey',
+      MODEL_NAME,
+      'This is a test prompt.',
+      generationConfig,
+      structuredOutputConfig,
+    );
+
+    expect(response.text).toContain('test output');
+    expect(response.text).toContain('"generationConfig":{"temperature":0.4');
+  });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -19,7 +19,10 @@ describe('Gemini API', () => {
             content: {
               parts: [
                 {
-                  text: `test output, generation config: ${JSON.stringify(requestBody.generationConfig)}`,
+                  text: JSON.stringify({
+                    output: 'test output',
+                    generationConfig: requestBody.generationConfig,
+                  }),
                 }
               ],
             },

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -8,8 +8,10 @@ import {ModelResponse} from './model.response';
 const MODEL_NAME = 'gemini-1.5-flash';
 
 describe('Gemini API', () => {
-  it('handles text completion request', async () => {
-    nock('https://generativelanguage.googleapis.com')
+  let scope: nock.Scope;
+
+  beforeEach(() => {
+    scope = nock('https://generativelanguage.googleapis.com')
       .post(`/v1beta/models/${MODEL_NAME}:generateContent`)
       .reply(200, (uri, requestBody) => {
         return { candidates: [
@@ -27,8 +29,15 @@ describe('Gemini API', () => {
           },
         ],
         modelVersion: MODEL_NAME
-               };});
+        };
+      });
+  });
 
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('handles text completion request', async () => {
     const generationConfig: AgentGenerationConfig = {
       temperature: 0.4,
       topP: 0.9,
@@ -47,7 +56,5 @@ describe('Gemini API', () => {
     expect(response.text).toContain('test output');
     expect(response.text).toContain('"temperature":0.4');
     expect(response.text).toContain('"topP":0.9');
-
-    nock.cleanAll();
   });
 });

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import nock = require('nock');
 
-import {AgentGenerationConfig} from '@deliberation-lab/utils';
+import {
+  AgentGenerationConfig,
+  StructuredOutputType,
+  StructuredOutputDataType
+} from '@deliberation-lab/utils';
 import {getGeminiAPIResponse} from './gemini.api';
 import {ModelResponse} from './model.response';
 
@@ -92,10 +96,10 @@ describe('Gemini API', () => {
     const parsedResponse = JSON.parse(response.text);
     expect(parsedResponse.output).toBe('test output');
     expect(parsedResponse.generationConfig.responseMimeType).toBe('application/json');
-    expect(parsedResponse.generationConfig.responseSchema.type).toBe('OBJECT');
-    expect(parsedResponse.generationConfig.responseSchema.properties[0].name).toBe('stringProperty');
-    expect(parsedResponse.generationConfig.responseSchema.properties[0].schema.type).toBe('STRING');
-    expect(parsedResponse.generationConfig.responseSchema.properties[1].name).toBe('integerProperty');
-    expect(parsedResponse.generationConfig.responseSchema.properties[1].schema.type).toBe('INTEGER');
+    expect(parsedResponse.generationConfig.responseSchema?.type).toBe('OBJECT');
+    expect(parsedResponse.generationConfig.responseSchema?.properties[0]?.name).toBe('stringProperty');
+    expect(parsedResponse.generationConfig.responseSchema?.properties[0]?.schema.type).toBe('STRING');
+    expect(parsedResponse.generationConfig.responseSchema?.properties[1]?.name).toBe('integerProperty');
+    expect(parsedResponse.generationConfig.responseSchema?.properties[1]?.schema.type).toBe('INTEGER');
   });
 });

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -55,13 +55,14 @@ function makeStructuredOutputSchema(schema: StructuredOutputSchema)
   let properties = null;
   let orderedPropertyNames = null;
 
-  if (schema.properties.length > 0) {
+  if (schema.properties?.length > 0) {
+    console.log(schema.properties)
     properties = {};
-    propertyOrdering = [];
-    for (const [name, property] of schema.properties) {
-      properties.name = makeStructuredOutputSchema(property);
-      orderedPropertyNames.push(name);
-    }
+    orderedPropertyNames = [];
+    schema.properties.forEach((property) => {
+      properties[property.name] = makeStructuredOutputSchema(property.schema);
+      orderedPropertyNames.push(property.name);
+    });
   }
 
   const itemsSchema = schema.arrayItems ? makeStructuredOutputSchema(schema.arrayItems) : null;
@@ -149,7 +150,6 @@ export async function getGeminiAPIResponse(
     ]),
   );
   const structuredOutputGenerationConfig = makeStructuredOutputGenerationConfig(structuredOutputConfig);
-  const structuredOutputType = structuredOutput;
   const geminiConfig: GenerationConfig = {
     stopSequences,
     maxOutputTokens: 300,

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -4,7 +4,13 @@ import {
   HarmCategory,
   HarmBlockThreshold,
 } from '@google/generative-ai';
-import {AgentGenerationConfig} from '@deliberation-lab/utils';
+import {
+  AgentGenerationConfig,
+  StructuredOutputType,
+  StructuredOutputDataType,
+  StructuredOutputConfig,
+  StructuredOutputSchema,
+} from '@deliberation-lab/utils';
 
 const GEMINI_DEFAULT_MODEL = 'gemini-1.5-pro-latest';
 const DEFAULT_FETCH_TIMEOUT = 300 * 1000; // This is the Chrome default
@@ -29,6 +35,71 @@ const SAFETY_SETTINGS = [
     threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
   },
 ];
+
+function makeStructuredOutputSchema(schema: StructuredOutputSchema)
+: Object | null {               // TODO: reference Schema type from google api if possible
+  const typeMap: { [key in StructuredOutputDataType]?: string } = {
+    [StructuredOutputDataType.STRING]: 'STRING',
+    [StructuredOutputDataType.NUMBER]: 'NUMBER',
+    [StructuredOutputDataType.INTEGER]: 'INTEGER',
+    [StructuredOutputDataType.BOOLEAN]: 'BOOLEAN',
+    [StructuredOutputDataType.ARRAY]: 'ARRAY',
+    [StructuredOutputDataType.OBJECT]: 'OBJECT',
+  };
+  const type = typeMap[schema.type];
+  if (!type) {
+    console.error(`Error parsing structured output config: unrecognized data type ${dataType}`);
+    return null;
+  }
+
+  let properties = null;
+  let orderedPropertyNames = null;
+
+  if (schema.properties.length > 0) {
+    properties = {};
+    propertyOrdering = [];
+    for (const [name, property] of schema.properties) {
+      properties.name = makeStructuredOutputSchema(property);
+      orderedPropertyNames.push(name);
+    }
+  }
+
+  const itemsSchema = schema.arrayItems ? makeStructuredOutputSchema(schema.arrayItems) : null;
+  
+  return {
+    type: type,
+    description: schema.description,
+    nullable: false,
+    properties: properties,
+    propertyOrdering: orderedPropertyNames,
+    required: orderedPropertyNames,
+    items: itemsSchema,
+  };
+}
+
+function makeStructuredOutputGenerationConfig(
+  structuredOutputConfig?: StructuredOutputConfig
+): Partial<GenerationConfig> | null {
+  if (!structuredOutputConfig
+      || structuredOutputConfig.type === StructuredOutputType.NONE) {
+    return { responseMimeType: 'text/plain' };
+  }
+  if (structuredOutputConfig.type === StructuredOutputType.JSON_FORMAT) {
+    return { responseMimeType: 'application/json' };
+  }
+  if (!structuredOutputConfig.schema) {
+    console.error(`Expected schema for structured output type ${structuredOutputConfig.type}`);
+    return null;
+  }
+  const schema = makeStructuredOutputSchema(structuredOutputConfig.schema);
+  if (!schema) {
+    return null;
+  }
+  return {
+    responseMimeType: 'application/json',
+    responseSchema: schema,
+  }
+}
 
 /** Makes Gemini API call. */
 export async function callGemini(
@@ -77,9 +148,8 @@ export async function getGeminiAPIResponse(
       field.value,
     ]),
   );
-  const schema = structuredOutputSchema(structuredOutputConfig);
-  // Define mime_type as 'application/json' if structuredOutputConfig exists and has type JSON_FORMAT or JSON_SCHEMA; 'text/plain' otherwise. AI!
-  const mime_type = TODO;
+  const structuredOutputGenerationConfig = makeStructuredOutputGenerationConfig(structuredOutputConfig);
+  const structuredOutputType = structuredOutput;
   const geminiConfig: GenerationConfig = {
     stopSequences,
     maxOutputTokens: 300,
@@ -88,6 +158,7 @@ export async function getGeminiAPIResponse(
     topK: 16,
     presencePenalty: generationConfig.presencePenalty,
     frequencyPenalty: generationConfig.frequencyPenalty,
+    ...structuredOutputGenerationConfig,
     ...customFields
   };
 

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -36,9 +36,10 @@ const SAFETY_SETTINGS = [
   },
 ];
 
-function makeStructuredOutputSchema(schema: StructuredOutputSchema)
-: Object | null {
-  const typeMap: { [key in StructuredOutputDataType]?: string } = {
+function makeStructuredOutputSchema(
+  schema: StructuredOutputSchema,
+): object | null {
+  const typeMap: {[key in StructuredOutputDataType]?: string} = {
     [StructuredOutputDataType.STRING]: 'STRING',
     [StructuredOutputDataType.NUMBER]: 'NUMBER',
     [StructuredOutputDataType.INTEGER]: 'INTEGER',
@@ -48,7 +49,9 @@ function makeStructuredOutputSchema(schema: StructuredOutputSchema)
   };
   const type = typeMap[schema.type];
   if (!type) {
-    console.error(`Error parsing structured output config: unrecognized data type ${dataType}`);
+    console.error(
+      `Error parsing structured output config: unrecognized data type ${dataType}`,
+    );
     return null;
   }
 
@@ -64,8 +67,10 @@ function makeStructuredOutputSchema(schema: StructuredOutputSchema)
     });
   }
 
-  const itemsSchema = schema.arrayItems ? makeStructuredOutputSchema(schema.arrayItems) : null;
-  
+  const itemsSchema = schema.arrayItems
+    ? makeStructuredOutputSchema(schema.arrayItems)
+    : null;
+
   return {
     type: type,
     description: schema.description,
@@ -78,17 +83,21 @@ function makeStructuredOutputSchema(schema: StructuredOutputSchema)
 }
 
 function makeStructuredOutputGenerationConfig(
-  structuredOutputConfig?: StructuredOutputConfig
+  structuredOutputConfig?: StructuredOutputConfig,
 ): Partial<GenerationConfig> | null {
-  if (!structuredOutputConfig
-      || structuredOutputConfig.type === StructuredOutputType.NONE) {
-    return { responseMimeType: 'text/plain' };
+  if (
+    !structuredOutputConfig ||
+    structuredOutputConfig.type === StructuredOutputType.NONE
+  ) {
+    return {responseMimeType: 'text/plain'};
   }
   if (structuredOutputConfig.type === StructuredOutputType.JSON_FORMAT) {
-    return { responseMimeType: 'application/json' };
+    return {responseMimeType: 'application/json'};
   }
   if (!structuredOutputConfig.schema) {
-    console.error(`Expected schema for structured output type ${structuredOutputConfig.type}`);
+    console.error(
+      `Expected schema for structured output type ${structuredOutputConfig.type}`,
+    );
     return null;
   }
   const schema = makeStructuredOutputSchema(structuredOutputConfig.schema);
@@ -98,7 +107,7 @@ function makeStructuredOutputGenerationConfig(
   return {
     responseMimeType: 'application/json',
     responseSchema: schema,
-  }
+  };
 }
 
 /** Makes Gemini API call. */
@@ -148,7 +157,9 @@ export async function getGeminiAPIResponse(
       field.value,
     ]),
   );
-  const structuredOutputGenerationConfig = makeStructuredOutputGenerationConfig(structuredOutputConfig);
+  const structuredOutputGenerationConfig = makeStructuredOutputGenerationConfig(
+    structuredOutputConfig,
+  );
   const geminiConfig: GenerationConfig = {
     stopSequences,
     maxOutputTokens: 300,
@@ -158,17 +169,12 @@ export async function getGeminiAPIResponse(
     presencePenalty: generationConfig.presencePenalty,
     frequencyPenalty: generationConfig.frequencyPenalty,
     ...structuredOutputGenerationConfig,
-    ...customFields
+    ...customFields,
   };
 
   let response = {text: ''};
   try {
-    response = await callGemini(
-      apiKey,
-      promptText,
-      geminiConfig,
-      modelName
-    );
+    response = await callGemini(apiKey, promptText, geminiConfig, modelName);
   } catch (error: any) {
     if (error.message.includes(QUOTA_ERROR_CODE.toString())) {
       console.error('API quota exceeded');

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -56,7 +56,6 @@ function makeStructuredOutputSchema(schema: StructuredOutputSchema)
   let orderedPropertyNames = null;
 
   if (schema.properties?.length > 0) {
-    console.log(schema.properties)
     properties = {};
     orderedPropertyNames = [];
     schema.properties.forEach((property) => {

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -37,7 +37,7 @@ const SAFETY_SETTINGS = [
 ];
 
 function makeStructuredOutputSchema(schema: StructuredOutputSchema)
-: Object | null {               // TODO: reference Schema type from google api if possible
+: Object | null {
   const typeMap: { [key in StructuredOutputDataType]?: string } = {
     [StructuredOutputDataType.STRING]: 'STRING',
     [StructuredOutputDataType.NUMBER]: 'NUMBER',

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -68,6 +68,7 @@ export async function getGeminiAPIResponse(
   modelName: string,
   promptText: string,
   generationConfig: AgentGenerationConfig,
+  structuredOutputConfig?: StructuredOutputConfig = null,
   stopSequences: string[] = [],
 ): Promise<ModelResponse> {
   const customFields = Object.fromEntries(
@@ -76,6 +77,9 @@ export async function getGeminiAPIResponse(
       field.value,
     ]),
   );
+  const schema = structuredOutputSchema(structuredOutputConfig);
+  // Define mime_type as 'application/json' if structuredOutputConfig exists and has type JSON_FORMAT or JSON_SCHEMA; 'text/plain' otherwise. AI!
+  const mime_type = TODO;
   const geminiConfig: GenerationConfig = {
     stopSequences,
     maxOutputTokens: 300,

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -231,7 +231,8 @@ export const createAgentMessage = onDocumentCreated(
         timestamp: Timestamp.now(),
         senderId: mediator.id,
         agentId: mediator.agentConfig.agentId,
-        explanation: agentResponse.promptConfig.responseConfig.isJSON
+        // TODO(mkbehr): move to new config
+        explanation: agentResponse.promptConfig.responseConfig?.isJSON
           ? (agentResponse.parsed[
               agentResponse.promptConfig.responseConfig.explanationField
             ] ?? '')

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -17,6 +17,7 @@ import {
   createMediatorChatMessage,
   getTimeElapsed,
   getTypingDelayInMilliseconds,
+  structuredOutputEnabled,
 } from '@deliberation-lab/utils';
 import {getMediatorsInCohortStage} from '../mediator.utils';
 import {
@@ -224,6 +225,16 @@ export const createAgentMessage = onDocumentCreated(
 
       // Write agent mediator message to conversation
       const mediator = agentResponse.mediator;
+      let explanation = '';
+      if (agentResponse.promptConfig.responseConfig?.isJSON) {
+        explanation = agentResponse.parsed[
+              agentResponse.promptConfig.responseConfig.explanationField
+        ] ?? '';
+      } else if (structuredOutputEnabled(agentResponse.promptConfig.structuredOutputConfig)) {
+        explanation = agentResponse.parsed[
+              agentResponse.promptConfig.structuredOutputConfig.thoughtField
+        ] ?? '';
+      }
       const chatMessage = createMediatorChatMessage({
         profile: {name: mediator.name, avatar: mediator.avatar, pronouns: null},
         discussionId: data.discussionId,
@@ -231,12 +242,7 @@ export const createAgentMessage = onDocumentCreated(
         timestamp: Timestamp.now(),
         senderId: mediator.id,
         agentId: mediator.agentConfig.agentId,
-        // TODO(mkbehr): move to new config
-        explanation: agentResponse.promptConfig.responseConfig?.isJSON
-          ? (agentResponse.parsed[
-              agentResponse.promptConfig.responseConfig.explanationField
-            ] ?? '')
-          : '',
+        explanation: explanation,
       });
       const agentDocument = app
         .firestore()

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -232,7 +232,7 @@ export const createAgentMessage = onDocumentCreated(
         ] ?? '';
       } else if (structuredOutputEnabled(agentResponse.promptConfig.structuredOutputConfig)) {
         explanation = agentResponse.parsed[
-              agentResponse.promptConfig.structuredOutputConfig.thoughtField
+              agentResponse.promptConfig.structuredOutputConfig.explanationField
         ] ?? '';
       }
       const chatMessage = createMediatorChatMessage({

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -227,13 +227,19 @@ export const createAgentMessage = onDocumentCreated(
       const mediator = agentResponse.mediator;
       let explanation = '';
       if (agentResponse.promptConfig.responseConfig?.isJSON) {
-        explanation = agentResponse.parsed[
-              agentResponse.promptConfig.responseConfig.explanationField
-        ] ?? '';
-      } else if (structuredOutputEnabled(agentResponse.promptConfig.structuredOutputConfig)) {
-        explanation = agentResponse.parsed[
-              agentResponse.promptConfig.structuredOutputConfig.explanationField
-        ] ?? '';
+        explanation =
+          agentResponse.parsed[
+            agentResponse.promptConfig.responseConfig.explanationField
+          ] ?? '';
+      } else if (
+        structuredOutputEnabled(
+          agentResponse.promptConfig.structuredOutputConfig,
+        )
+      ) {
+        explanation =
+          agentResponse.parsed[
+            agentResponse.promptConfig.structuredOutputConfig.explanationField
+          ] ?? '';
       }
       const chatMessage = createMediatorChatMessage({
         profile: {name: mediator.name, avatar: mediator.avatar, pronouns: null},

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -301,7 +301,6 @@ export async function getAgentChatResponse(
       if (parsed[promptConfig.structuredOutputConfig.shouldRespondField] ?? true) {
         message = parsed[promptConfig.structuredOutputConfig.messageField] ?? '';
       }
-      console.log(parsed);
     }
 
     // Check if message is empty

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -261,13 +261,14 @@ export async function getAgentChatResponse(
       prompt,
       mediator.agentConfig.modelSettings,
       promptConfig.generationConfig,
+      promptConfig.structuredOutputConfig,
     );
 
     // Add agent message if non-empty
     let message = response.text;
     let parsed = '';
 
-    if (promptConfig.responseConfig.isJSON) {
+    if (promptConfig.responseConfig?.isJSON) { // TODO change config
       // Reset message to empty before trying to fill with JSON response
       message = '';
 

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -299,7 +299,7 @@ export async function getAgentChatResponse(
         return null;
       }
       if (parsed[promptConfig.structuredOutputConfig.shouldRespondField] ?? true) {
-        message = parsed[promptConfig.structuredOutputConfig.responseField] ?? '';
+        message = parsed[promptConfig.structuredOutputConfig.messageField] ?? '';
       }
       console.log(parsed);
     }

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -298,8 +298,12 @@ export async function getAgentChatResponse(
         console.log('Could not parse JSON!');
         return null;
       }
-      if (parsed[promptConfig.structuredOutputConfig.shouldRespondField] ?? true) {
-        message = parsed[promptConfig.structuredOutputConfig.messageField] ?? '';
+      if (
+        parsed[promptConfig.structuredOutputConfig.shouldRespondField] ??
+        true
+      ) {
+        message =
+          parsed[promptConfig.structuredOutputConfig.messageField] ?? '';
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "deliberate-lab",
       "version": "1.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.24.0"
-      },
       "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.29.0",
         "eslint": "^9.20.1",
         "husky": "^9.1.7",
         "lint-staged": "^15.4.3",
@@ -22,6 +20,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
       "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -39,6 +38,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -50,6 +50,7 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -58,6 +59,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
       "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "dev": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
@@ -71,6 +73,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
       "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -82,6 +85,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
       "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -104,6 +108,7 @@
       "version": "9.20.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
       "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -112,6 +117,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -120,6 +126,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
       "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "dev": true,
       "dependencies": {
         "@eslint/core": "^0.10.0",
         "levn": "^0.4.1"
@@ -132,6 +139,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
       "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -143,6 +151,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -151,6 +160,7 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
@@ -163,6 +173,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -175,6 +186,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -187,6 +199,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
       "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "dev": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -199,6 +212,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -211,6 +225,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -219,6 +234,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -230,23 +246,27 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.0.tgz",
-      "integrity": "sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
+      "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/type-utils": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/scope-manager": "8.29.0",
+        "@typescript-eslint/type-utils": "8.29.0",
+        "@typescript-eslint/utils": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -262,13 +282,64 @@
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
+      "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.0.tgz",
       "integrity": "sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.0",
@@ -293,6 +364,8 @@
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.0.tgz",
       "integrity": "sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.24.0",
         "@typescript-eslint/visitor-keys": "8.24.0"
@@ -306,12 +379,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.0.tgz",
-      "integrity": "sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
+      "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
+        "@typescript-eslint/typescript-estree": "8.29.0",
+        "@typescript-eslint/utils": "8.29.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -324,13 +399,100 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
+      "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.0.tgz",
       "integrity": "sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -343,6 +505,8 @@
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.0.tgz",
       "integrity": "sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.24.0",
         "@typescript-eslint/visitor-keys": "8.24.0",
@@ -368,6 +532,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -376,6 +542,8 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -387,14 +555,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.0.tgz",
-      "integrity": "sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
+      "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/typescript-estree": "8.24.0"
+        "@typescript-eslint/scope-manager": "8.29.0",
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/typescript-estree": "8.29.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -405,13 +575,118 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
+      "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
+      "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.29.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.0.tgz",
       "integrity": "sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.24.0",
         "eslint-visitor-keys": "^4.2.0"
@@ -428,6 +703,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -439,6 +715,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -447,6 +724,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -489,6 +767,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -502,17 +781,20 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -522,6 +804,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -533,6 +816,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -541,6 +825,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -587,6 +872,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -597,7 +883,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -617,12 +904,14 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -636,6 +925,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -651,7 +941,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
@@ -675,6 +966,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -686,6 +978,7 @@
       "version": "9.20.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
       "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -744,6 +1037,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
       "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -759,6 +1053,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -770,6 +1065,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
@@ -786,6 +1082,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -797,6 +1094,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -808,6 +1106,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -816,6 +1115,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -852,12 +1152,14 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -873,6 +1175,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -883,17 +1186,20 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
       "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -902,6 +1208,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -913,6 +1220,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -924,6 +1232,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -939,6 +1248,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -950,7 +1260,8 @@
     "node_modules/flatted": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "dev": true
     },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
@@ -980,6 +1291,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -991,6 +1303,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -1001,12 +1314,14 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1039,6 +1354,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -1047,6 +1363,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1062,6 +1379,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -1070,6 +1388,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1090,6 +1409,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1101,6 +1421,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1120,12 +1441,14 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1136,22 +1459,26 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -1160,6 +1487,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -1240,6 +1568,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -1253,7 +1582,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -1327,6 +1657,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1335,6 +1666,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -1371,6 +1703,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1381,12 +1714,14 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -1434,6 +1769,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -1450,6 +1786,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -1464,6 +1801,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -1478,6 +1816,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1489,6 +1828,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1497,6 +1837,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1505,6 +1846,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1528,6 +1870,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -1551,6 +1894,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1559,6 +1903,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1578,6 +1923,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -1617,6 +1963,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -1632,6 +1979,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1654,6 +2002,7 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1665,6 +2014,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -1676,6 +2026,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1777,6 +2128,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -1788,6 +2140,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1799,6 +2152,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1810,6 +2164,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
       "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
       "engines": {
         "node": ">=18.12"
       },
@@ -1821,6 +2176,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -1832,6 +2188,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1845,6 +2202,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -1853,6 +2211,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1867,6 +2226,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1916,6 +2276,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git+https://github.com/PAIR-code/deliberate-lab.git"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.29.0",
     "eslint": "^9.20.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
@@ -22,8 +23,5 @@
   },
   "scripts": {
     "prepare": "husky"
-  },
-  "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.24.0"
   }
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_JSON_FORMATTING_INSTRUCTIONS,
   DEFAULT_STRING_FORMATTING_INSTRUCTIONS,
 } from './stages/chat_stage.prompts';
+import {StructuredOutputConfig} from './structured_output';
 
 /** Agent types and functions. */
 
@@ -112,8 +113,7 @@ export type AgentParticipantPromptConfig = BaseAgentPromptConfig;
  */
 export interface AgentChatPromptConfig extends BaseAgentPromptConfig {
   chatSettings: AgentChatSettings;
-  // TODO(mkbehr): Replace with structured output setup?
-  responseConfig: AgentResponseConfig;
+  structuredOutputConfig: StructuredOutputConfig;
 }
 
 export enum AgentPersonaType {
@@ -229,7 +229,7 @@ export function createAgentChatPromptConfig(
     promptSettings: config.promptSettings ?? createAgentPromptSettings(),
     generationConfig: config.generationConfig ?? createModelGenerationConfig(),
     chatSettings: config.chatSettings ?? createAgentChatSettings(),
-    responseConfig: config.responseConfig ?? createAgentResponseConfig(),
+    structuredOutputConfig: config.structuredOutputConfig ?? createStructuredOutputConfig(),
   };
 }
 

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -83,10 +83,10 @@ export interface AgentChatSettings {
   maxResponses: number | null;
 }
 
-/** Settings for formatting agent response
+/** DEPRECATED: Settings for formatting agent response
  *  (e.g., expect JSON, use specific JSON field for response, use end token)
+ *  New config is StructuredOutputConfig.
  */
-// TODO(mkbehr): Deprecate in favor of new structured output setup?
 export interface AgentResponseConfig {
   isJSON: boolean;
   // JSON field to extract chat message from
@@ -114,7 +114,7 @@ export type AgentParticipantPromptConfig = BaseAgentPromptConfig;
 export interface AgentChatPromptConfig extends BaseAgentPromptConfig {
   chatSettings: AgentChatSettings;
   structuredOutputConfig: StructuredOutputConfig;
-  responseConfig?: AgentResponseConfig;
+  responseConfig?: AgentResponseConfig; // deprecated
 }
 
 export enum AgentPersonaType {

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -4,13 +4,7 @@ import {
 } from './participant';
 import {generateId} from './shared';
 import {StageKind} from './stages/stage';
-import {
-  DEFAULT_AGENT_MEDIATOR_PROMPT,
-  DEFAULT_RESPONSE_FIELD,
-  DEFAULT_EXPLANATION_FIELD,
-  DEFAULT_JSON_FORMATTING_INSTRUCTIONS,
-  DEFAULT_STRING_FORMATTING_INSTRUCTIONS,
-} from './stages/chat_stage.prompts';
+import {DEFAULT_AGENT_MEDIATOR_PROMPT} from './stages/chat_stage.prompts';
 import {
   StructuredOutputConfig,
   createStructuredOutputConfig,

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -11,7 +11,10 @@ import {
   DEFAULT_JSON_FORMATTING_INSTRUCTIONS,
   DEFAULT_STRING_FORMATTING_INSTRUCTIONS,
 } from './stages/chat_stage.prompts';
-import {StructuredOutputConfig, createStructuredOutputConfig} from './structured_output';
+import {
+  StructuredOutputConfig,
+  createStructuredOutputConfig,
+} from './structured_output';
 
 /** Agent types and functions. */
 
@@ -230,7 +233,8 @@ export function createAgentChatPromptConfig(
     promptSettings: config.promptSettings ?? createAgentPromptSettings(),
     generationConfig: config.generationConfig ?? createModelGenerationConfig(),
     chatSettings: config.chatSettings ?? createAgentChatSettings(),
-    structuredOutputConfig: config.structuredOutputConfig ?? createStructuredOutputConfig(),
+    structuredOutputConfig:
+      config.structuredOutputConfig ?? createStructuredOutputConfig(),
   };
 }
 

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -117,7 +117,8 @@ export type AgentParticipantPromptConfig = BaseAgentPromptConfig;
 export interface AgentChatPromptConfig extends BaseAgentPromptConfig {
   chatSettings: AgentChatSettings;
   structuredOutputConfig: StructuredOutputConfig;
-  responseConfig?: AgentResponseConfig; // deprecated
+  // DEPRECATED: Use structuredOutputConfig, not responseConfig
+  responseConfig?: AgentResponseConfig;
 }
 
 export enum AgentPersonaType {
@@ -204,8 +205,7 @@ export function createAgentPromptSettings(
   };
 }
 
-/** Create agent response config. */
-// TODO(mkbehr): Deprecated in favor of new structured output setup?
+/** DEPRECATED: Create agent response config. */
 export function createAgentResponseConfig(
   config: Partial<AgentResponseConfig> = {},
 ): AgentResponseConfig {

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_JSON_FORMATTING_INSTRUCTIONS,
   DEFAULT_STRING_FORMATTING_INSTRUCTIONS,
 } from './stages/chat_stage.prompts';
-import {StructuredOutputConfig} from './structured_output';
+import {StructuredOutputConfig, createStructuredOutputConfig} from './structured_output';
 
 /** Agent types and functions. */
 
@@ -114,6 +114,7 @@ export type AgentParticipantPromptConfig = BaseAgentPromptConfig;
 export interface AgentChatPromptConfig extends BaseAgentPromptConfig {
   chatSettings: AgentChatSettings;
   structuredOutputConfig: StructuredOutputConfig;
+  responseConfig?: AgentResponseConfig;
 }
 
 export enum AgentPersonaType {

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -205,22 +205,6 @@ export function createAgentPromptSettings(
   };
 }
 
-/** DEPRECATED: Create agent response config. */
-export function createAgentResponseConfig(
-  config: Partial<AgentResponseConfig> = {},
-): AgentResponseConfig {
-  const isJSON = config.isJSON ?? false;
-  return {
-    isJSON,
-    messageField: config.messageField ?? DEFAULT_RESPONSE_FIELD,
-    explanationField: config.explanationField ?? DEFAULT_EXPLANATION_FIELD,
-    formattingInstructions:
-      (config.formattingInstructions ?? isJSON)
-        ? DEFAULT_JSON_FORMATTING_INSTRUCTIONS
-        : DEFAULT_STRING_FORMATTING_INSTRUCTIONS,
-  };
-}
-
 export function createAgentChatPromptConfig(
   id: string, // stage ID
   type: StageKind, // stage kind

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -31,8 +31,9 @@ import {StageConfig} from './stages/stage';
  * VERSION 14 - add currentDiscussionId to chat public data (PR #431)
  * VERSION 15 - add stageUnlockMap, readyStages timestamps (PR #442)
  * VERSION 16 - switch to new mediator workflow including updated ChatMessage
+ * VERSION 17 - add structured output config to agent prompt configs
  */
-export const EXPERIMENT_VERSION_ID = 16;
+export const EXPERIMENT_VERSION_ID = 17;
 
 /** Experiment. */
 export interface Experiment {

--- a/utils/src/experimenter.test.ts
+++ b/utils/src/experimenter.test.ts
@@ -49,13 +49,4 @@ describe('checkApiKeyExists', () => {
 
     expect(checkApiKeyExists(experimenterData)).toBe(true);
   });
-
-  test('returns false if active API key type is Ollama and ollamaApiKey is invalid', () => {
-    experimenterData.apiKeys.activeApiKeyType = ApiKeyType.OLLAMA_CUSTOM_URL;
-    experimenterData.apiKeys.ollamaApiKey = {
-      url: 'http://valid-url.com',
-    };
-
-    expect(checkApiKeyExists(experimenterData)).toBe(false);
-  });
 });

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -34,7 +34,7 @@ export * from './profile_sets';
 // Agent
 export * from './agent';
 export * from './agent.validation';
-export * from './structured_output.ts';
+export * from './structured_output';
 
 // Stages
 export * from './stages/stage';

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -34,6 +34,7 @@ export * from './profile_sets';
 // Agent
 export * from './agent';
 export * from './agent.validation';
+export * from './structured_output.ts';
 
 // Stages
 export * from './stages/stage';

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -11,34 +11,6 @@ export const DEFAULT_AGENT_MEDIATOR_PROMPT = `You are a agent for a chat convers
 If you notice that participants are being rude, step in to make sure that everyone is respectful. 
 Otherwise, do not respond.`;
 
-export const DEFAULT_SHOULD_RESPOND_FIELD = 'shouldRespond';
-export const DEFAULT_RESPONSE_FIELD = 'response';
-export const DEFAULT_EXPLANATION_FIELD = 'explanation';
-export const DEFAULT_JSON_FORMATTING_INSTRUCTIONS = `INSTRUCTIONS:
-  Now, you have the opportunity to respond to the conversation. This response will be appended to the end of the transcript.
-  Fill out the following JSON response:
-    1. Do you want to add a message to the chat? ("true" or "false")
-    2. If yes, what would you like to say?
-    3. Why do you want to say that?
-  
-  IMPORTANT: Your output should be in a JSON dictionary exactly like the example output below. Just the JSON! Make sure the JSON is valid. No need to add any delimiters, just begin with a { bracket as in the example below.
-  
-  EXAMPLE OUTPUT:
-  {
-    "shouldRespond": true,
-    "${DEFAULT_RESPONSE_FIELD}": "This is my response.",
-    "${DEFAULT_EXPLANATION_FIELD}": "This is why I chose this response."
-  }
-  
-  EXAMPLE OUTPUT:
-  {
-    "shouldRespond": false,
-    "${DEFAULT_RESPONSE_FIELD}": "",
-    "${DEFAULT_EXPLANATION_FIELD}": "I have spoken recently and want to give others a chance to speak."
-  }`;
-
-export const DEFAULT_STRING_FORMATTING_INSTRUCTIONS = `If you would like to respond, respond with the message you would like to send only (no timestamps or metadata), for example, "Hey everyone, please be respectful." This will be appended to the end of the chat transcript. If you don't wish to respond, respond with an empty string.`;
-
 // ************************************************************************* //
 // PROMPTS                                                                   //
 // ************************************************************************* //

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -11,6 +11,7 @@ export const DEFAULT_AGENT_MEDIATOR_PROMPT = `You are a agent for a chat convers
 If you notice that participants are being rude, step in to make sure that everyone is respectful. 
 Otherwise, do not respond.`;
 
+export const DEFAULT_SHOULD_RESPOND_FIELD = 'shouldRespond';
 export const DEFAULT_RESPONSE_FIELD = 'response';
 export const DEFAULT_EXPLANATION_FIELD = 'explanation';
 export const DEFAULT_JSON_FORMATTING_INSTRUCTIONS = `INSTRUCTIONS:

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -50,7 +50,8 @@ export function getDefaultChatPrompt(
   return [
     getChatPromptPreface(mediator, promptConfig, stageConfig),
     getChatPromptHistory(chatMessages),
-    promptConfig.responseConfig.formattingInstructions,
+    // TODO(mkbehr): add new formatting instructions
+    // promptConfig.responseConfig.formattingInstructions,
     promptConfig.promptContext,
     mediator.agentConfig?.promptContext ?? '',
   ].join('\n');

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -51,8 +51,6 @@ export function getDefaultChatPrompt(
   return [
     getChatPromptPreface(mediator, promptConfig, stageConfig),
     getChatPromptHistory(chatMessages),
-    // TODO(mkbehr): add new formatting instructions
-    // promptConfig.responseConfig.formattingInstructions,
     promptConfig.promptContext,
     mediator.agentConfig?.promptContext ?? '',
   ].join('\n');

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -13,11 +13,7 @@ import {
   ParticipantProfileBase,
   createParticipantProfileBase,
 } from '../participant';
-import {
-  AgentChatPromptConfig,
-  AgentResponseConfig,
-  createAgentResponseConfig,
-} from '../agent';
+import {AgentChatPromptConfig, AgentResponseConfig} from '../agent';
 import {MediatorProfile} from '../mediator';
 import {
   DEFAULT_MODEL,

--- a/utils/src/structured_output.test.ts
+++ b/utils/src/structured_output.test.ts
@@ -1,0 +1,55 @@
+import {
+  StructuredOutputType,
+  StructuredOutputDataType,
+  StructuredOutputSchema,
+  printSchema,
+} from './structured_output';
+
+describe('Structured outputs', () => {
+  it('print schemas in expected format', () => {
+    const structuredOutputSchema = {
+      type: StructuredOutputDataType.OBJECT,
+      properties: [
+        {
+          name: 'stringProperty',
+          schema: {
+            type: StructuredOutputDataType.STRING,
+            description: "A string-valued property",
+          }
+        },
+        {
+          name: 'intArrayProperty',
+          schema: {
+            type: StructuredOutputDataType.ARRAY,
+            description: "An array-valued property",
+            arrayItems: {
+              type: StructuredOutputDataType.INTEGER,
+              description: "An integer-valued property",
+            },
+          },
+        },
+      ],
+    };
+
+    const result = printSchema(structuredOutputSchema);
+    const parsedResult = JSON.parse(result);
+    const expectedResult = {
+      type: "object",
+      properties: {
+        stringProperty: {
+          description: "A string-valued property",
+          type: "string"
+        },
+        intArrayProperty: {
+          description: "An array-valued property",
+          type: "array",
+          items: {
+            description: "An integer-valued property",
+            type: "integer"
+          }
+        }
+      }
+    };
+    expect(parsedResult).toEqual(expectedResult);
+  });
+});

--- a/utils/src/structured_output.test.ts
+++ b/utils/src/structured_output.test.ts
@@ -1,7 +1,5 @@
 import {
-  StructuredOutputType,
   StructuredOutputDataType,
-  StructuredOutputSchema,
   printSchema,
 } from './structured_output';
 
@@ -14,17 +12,17 @@ describe('Structured outputs', () => {
           name: 'stringProperty',
           schema: {
             type: StructuredOutputDataType.STRING,
-            description: "A string-valued property",
-          }
+            description: 'A string-valued property',
+          },
         },
         {
           name: 'intArrayProperty',
           schema: {
             type: StructuredOutputDataType.ARRAY,
-            description: "An array-valued property",
+            description: 'An array-valued property',
             arrayItems: {
               type: StructuredOutputDataType.INTEGER,
-              description: "An integer-valued property",
+              description: 'An integer-valued property',
             },
           },
         },
@@ -34,21 +32,21 @@ describe('Structured outputs', () => {
     const result = printSchema(structuredOutputSchema);
     const parsedResult = JSON.parse(result);
     const expectedResult = {
-      type: "object",
+      type: 'object',
       properties: {
         stringProperty: {
-          description: "A string-valued property",
-          type: "string"
+          description: 'A string-valued property',
+          type: 'string',
         },
         intArrayProperty: {
-          description: "An array-valued property",
-          type: "array",
+          description: 'An array-valued property',
+          type: 'array',
           items: {
-            description: "An integer-valued property",
-            type: "integer"
-          }
-        }
-      }
+            description: 'An integer-valued property',
+            type: 'integer',
+          },
+        },
+      },
     };
     expect(parsedResult).toEqual(expectedResult);
   });

--- a/utils/src/structured_output.test.ts
+++ b/utils/src/structured_output.test.ts
@@ -1,7 +1,4 @@
-import {
-  StructuredOutputDataType,
-  printSchema,
-} from './structured_output';
+import {StructuredOutputDataType, printSchema} from './structured_output';
 
 describe('Structured outputs', () => {
   it('print schemas in expected format', () => {
@@ -47,6 +44,7 @@ describe('Structured outputs', () => {
           },
         },
       },
+      required: ['stringProperty', 'intArrayProperty'],
     };
     expect(parsedResult).toEqual(expectedResult);
   });

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -1,0 +1,26 @@
+export enum StructuredOutputType {
+  NONE = 'NONE',                // No special constraints on the sampler.
+  JSON_FORMAT = 'JSON_FORMAT',  // Constrain the sampler to output JSON.
+  JSON_SCHEMA = 'JSON_SCHEMA',  // Constrain sampler to the configured schema.
+}
+
+export enum StructuredOutputDataType {
+  STRING = 'STRING',
+  NUMBER = 'NUMBER',
+  INTEGER = 'INTEGER',
+  BOOLEAN = 'BOOLEAN',
+  ARRAY = 'ARRAY',
+  OBJECT = 'OBJECT',
+}
+
+export interface StructuredOutputSchema {
+  type: StructuredOutputDataType;
+  description?: string;
+  properties?: Map<string, StructuredOutputSchema>;
+  arrayItems?: StructuredOutputSchema;
+}
+
+export interface StructuredOutputConfig {
+  type: StructuredOutputType;
+  schema?: StructuredOutputSchema;
+}

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -27,6 +27,7 @@ export interface StructuredOutputSchema {
 }
 
 export interface StructuredOutputConfig {
+  enabled: boolean;
   type: StructuredOutputType;
   schema?: StructuredOutputSchema;
   appendToPrompt: boolean;
@@ -38,7 +39,6 @@ export interface StructuredOutputConfig {
 export function createStructuredOutputConfig(
   config: Partial<StructuredOutputConfig> = {},
 ): StructuredOutputConfig {
-  console.log('createStructuredOutputConfig'); // DEBUG
   const schema = config.schema ?? {
     type: StructuredOutputDataType.OBJECT,
     properties: [
@@ -66,6 +66,7 @@ export function createStructuredOutputConfig(
     ],
   }
   return {
+    enabled: config.enabled ?? true,
     type: config.type ?? StructuredOutputType.NONE,
     schema: schema,
     appendToPrompt: true,
@@ -97,7 +98,7 @@ function schemaToObject(schema: StructuredOutputSchema): object {
 }
 
 export function structuredOutputEnabled(config?: StructuredOutputConfig) : boolean {
-  if (!config?.appendToPrompt) {
+  if (config.type == StructuredOutputType.NONE && !config?.appendToPrompt) {
     return false;
   }
   if (!config.schema) {
@@ -106,7 +107,7 @@ export function structuredOutputEnabled(config?: StructuredOutputConfig) : boole
   if (config.schema.properties?.length == 0) {
     return false;
   }
-  return true;
+  return config.enabled;
 }
 
 export function printSchema(
@@ -116,7 +117,7 @@ export function printSchema(
 }
 
 export function makeStructuredOutputPrompt(config?: StructuredOutputConfig): string {
-  if (!structuredOutputEnabled(config) || !config?.schema) {
+  if (!structuredOutputEnabled(config) || !config?.appendToPrompt || !config?.schema) {
     return '';
   }
   return `Return only valid JSON, according to the following schema:

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -24,3 +24,12 @@ export interface StructuredOutputConfig {
   type: StructuredOutputType;
   schema?: StructuredOutputSchema;
 }
+
+export function createStructuredOutputConfig(
+  config: Partial<StructuredOutputConfig> = {},
+): StructuredOutputConfig {
+  return {
+    type: config.type ?? StructuredOutputType.NONE,
+    schema: config.schema,
+  }
+}

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -102,6 +102,9 @@ function schemaToObject(schema: StructuredOutputSchema): object {
 export function structuredOutputEnabled(
   config?: StructuredOutputConfig,
 ): boolean {
+  if (!config) {
+    return false;
+  }
   if (config.type == StructuredOutputType.NONE && !config?.appendToPrompt) {
     return false;
   }

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -62,3 +62,18 @@ export function printSchema(
   indent: number = 2): string {
     return JSON.stringify(schemaToObject(schema), null, indent);
 }
+
+export function makeStructuredOutputPrompt(config?: StructuredOutputConfig): string {
+  if (!config?.appendToPrompt) {
+    return '';
+  }
+  if (!config.schema) {
+    return '';
+  }
+  if (config.schema.properties?.length == 0) {
+    return '';
+  }
+  return `Return only valid JSON, according to the following schema:
+${printSchema(config.schema)}
+`;
+}

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -1,8 +1,7 @@
-import {
-  DEFAULT_SHOULD_RESPOND_FIELD,
-  DEFAULT_RESPONSE_FIELD,
-  DEFAULT_EXPLANATION_FIELD,
-} from './stages/chat_stage.prompts';
+/** Structured output types, constants, and functions. */
+// ****************************************************************************
+// TYPES
+// ****************************************************************************
 
 export enum StructuredOutputType {
   NONE = 'NONE', // No special constraints on the sampler.
@@ -35,6 +34,17 @@ export interface StructuredOutputConfig {
   explanationField: string;
   messageField: string;
 }
+
+// ****************************************************************************
+// CONSTANTS
+// ****************************************************************************
+export const DEFAULT_SHOULD_RESPOND_FIELD = 'shouldRespond';
+export const DEFAULT_RESPONSE_FIELD = 'response';
+export const DEFAULT_EXPLANATION_FIELD = 'explanation';
+
+// ****************************************************************************
+// FUNCTIONS
+// ****************************************************************************
 
 export function createStructuredOutputConfig(
   config: Partial<StructuredOutputConfig> = {},

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -16,7 +16,7 @@ export enum StructuredOutputDataType {
 export interface StructuredOutputSchema {
   type: StructuredOutputDataType;
   description?: string;
-  properties?: Map<string, StructuredOutputSchema>;
+  properties?: {name: string, schema: StructuredOutputSchema}[];
   arrayItems?: StructuredOutputSchema;
 }
 

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -31,8 +31,8 @@ export interface StructuredOutputConfig {
   schema?: StructuredOutputSchema;
   appendToPrompt: boolean;
   shouldRespondField: string;
-  thoughtField: string;
-  responseField: string;
+  explanationField: string;
+  messageField: string;
 }
 
 export function createStructuredOutputConfig(
@@ -70,8 +70,8 @@ export function createStructuredOutputConfig(
     schema: schema,
     appendToPrompt: true,
     shouldRespondField: config.shouldRespondField ?? DEFAULT_SHOULD_RESPOND_FIELD,
-    responseField: config.responseField ?? DEFAULT_RESPONSE_FIELD,
-    thoughtField: config.thoughtField ?? DEFAULT_EXPLANATION_FIELD,
+    messageField: config.messageField ?? DEFAULT_RESPONSE_FIELD,
+    explanationField: config.explanationField ?? DEFAULT_EXPLANATION_FIELD,
   }
 }
 

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -5,9 +5,9 @@ import {
 } from './stages/chat_stage.prompts';
 
 export enum StructuredOutputType {
-  NONE = 'NONE',                // No special constraints on the sampler.
-  JSON_FORMAT = 'JSON_FORMAT',  // Constrain the sampler to output JSON.
-  JSON_SCHEMA = 'JSON_SCHEMA',  // Constrain sampler to the configured schema.
+  NONE = 'NONE', // No special constraints on the sampler.
+  JSON_FORMAT = 'JSON_FORMAT', // Constrain the sampler to output JSON.
+  JSON_SCHEMA = 'JSON_SCHEMA', // Constrain sampler to the configured schema.
 }
 
 export enum StructuredOutputDataType {
@@ -22,7 +22,7 @@ export enum StructuredOutputDataType {
 export interface StructuredOutputSchema {
   type: StructuredOutputDataType;
   description?: string;
-  properties?: {name: string, schema: StructuredOutputSchema}[];
+  properties?: {name: string; schema: StructuredOutputSchema}[];
   arrayItems?: StructuredOutputSchema;
 }
 
@@ -46,34 +46,35 @@ export function createStructuredOutputConfig(
         name: DEFAULT_EXPLANATION_FIELD,
         schema: {
           type: StructuredOutputDataType.STRING,
-          description: 'Your reasoning for your response.'
-        }
+          description: 'Your reasoning for your response.',
+        },
       },
       {
         name: DEFAULT_SHOULD_RESPOND_FIELD,
         schema: {
           type: StructuredOutputDataType.BOOLEAN,
-          description: 'Whether or not to respond.'
-        }
+          description: 'Whether or not to respond.',
+        },
       },
       {
         name: DEFAULT_RESPONSE_FIELD,
         schema: {
           type: StructuredOutputDataType.STRING,
-          description: 'Your response.'
-        }
+          description: 'Your response.',
+        },
       },
     ],
-  }
+  };
   return {
     enabled: config.enabled ?? true,
     type: config.type ?? StructuredOutputType.NONE,
     schema: schema,
     appendToPrompt: true,
-    shouldRespondField: config.shouldRespondField ?? DEFAULT_SHOULD_RESPOND_FIELD,
+    shouldRespondField:
+      config.shouldRespondField ?? DEFAULT_SHOULD_RESPOND_FIELD,
     messageField: config.messageField ?? DEFAULT_RESPONSE_FIELD,
     explanationField: config.explanationField ?? DEFAULT_EXPLANATION_FIELD,
-  }
+  };
 }
 
 function schemaToObject(schema: StructuredOutputSchema): object {
@@ -86,18 +87,21 @@ function schemaToObject(schema: StructuredOutputSchema): object {
     }
     required = schema.properties.map((property) => property.name);
   }
-  const arrayItems = (schema.arrayItems
-                      ? schemaToObject(schema.arrayItems)
-                      : undefined);
+  const arrayItems = schema.arrayItems
+    ? schemaToObject(schema.arrayItems)
+    : undefined;
   return {
     description: schema.description ?? undefined,
     type: schema.type.toLowerCase(),
     properties: properties ?? undefined,
     items: arrayItems ?? undefined,
-  }
+    required: required,
+  };
 }
 
-export function structuredOutputEnabled(config?: StructuredOutputConfig) : boolean {
+export function structuredOutputEnabled(
+  config?: StructuredOutputConfig,
+): boolean {
   if (config.type == StructuredOutputType.NONE && !config?.appendToPrompt) {
     return false;
   }
@@ -112,12 +116,19 @@ export function structuredOutputEnabled(config?: StructuredOutputConfig) : boole
 
 export function printSchema(
   schema: StructuredOutputSchema,
-  indent: number = 2): string {
-    return JSON.stringify(schemaToObject(schema), null, indent);
+  indent: number = 2,
+): string {
+  return JSON.stringify(schemaToObject(schema), null, indent);
 }
 
-export function makeStructuredOutputPrompt(config?: StructuredOutputConfig): string {
-  if (!structuredOutputEnabled(config) || !config?.appendToPrompt || !config?.schema) {
+export function makeStructuredOutputPrompt(
+  config?: StructuredOutputConfig,
+): string {
+  if (
+    !structuredOutputEnabled(config) ||
+    !config?.appendToPrompt ||
+    !config?.schema
+  ) {
     return '';
   }
   return `Return only valid JSON, according to the following schema:


### PR DESCRIPTION
This PR includes changes from PR #494 by @mkbehr, plus a few more.

Fixes #397:
- Experimenters can now configure custom schemas for structured outputs.
- Three special fields are supported: a field for the message, a field for whether or not to respond, and a field for an explanation or chain of thought. Experimenters can configure what these fields are named.
- The prompt will include a description of the output schema. Experimenters can disable this if they'd rather supply their own output examples.
- Experimenters can constrain the sampler to output valid json, or to output valid json in the specified schema. This is only supported for the Gemini API so far.
- Experiments with the old isJSON config should still work, but setting that config in new experiments is disabled.
- New experiments have a default config with structured outputs enabled, a premade schema with the three special fields, schema prompting, and no output constraints.
- All schemas must be flat. Nested objects and arrays are supported in the backend, but don't have UI support.

Changes in addition to PR #494:
- Fix UI styling
- Add quick documentation via new entry in feature log
- Add backwards compatibility for loading agent configs (old configs need a default StructuredOutputConfig included when loading on frontend. If the old config has isJSON enabled, it creates a new enabled StructuredOutputConfig on frontend load so that the experimetner can edit accordingly)
- Fix broken utils/src/experimenter.test.ts test

Checklist:
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Screenshot:
![Screenshot of structured output fields in frontend editor](https://github.com/user-attachments/assets/ef726fad-360d-48a7-a9c5-328c93d1ec31)

![Screenshot of prompt preview in structured output editor](https://github.com/user-attachments/assets/98934a9a-49cc-4e00-ab19-171d1480784a)
