### PR TITLE
Move the openai-compatible API to the chat completions API.

### DIFF
--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -9,7 +9,7 @@ import {
 } from '@deliberation-lab/utils';
 
 import {getGeminiAPIResponse} from './api/gemini.api';
-import {getOpenAIAPITextCompletionResponse} from './api/openai.api';
+import {getOpenAIAPIChatCompletionResponse} from './api/openai.api';
 import {ollamaChat} from './api/ollama.api';
 
 import {app} from './app';
@@ -83,7 +83,7 @@ export async function getOpenAIAPIResponse(
   prompt: string,
   generationConfig: ModelGenerationConfig,
 ): Promise<ModelResponse> {
-  return await getOpenAIAPITextCompletionResponse(
+  return await getOpenAIAPIChatCompletionResponse(
     data.apiKeys.openAIApiKey?.apiKey || '',
     data.apiKeys.openAIApiKey?.baseUrl || null,
     model,

--- a/functions/src/api/openai.api.test.ts
+++ b/functions/src/api/openai.api.test.ts
@@ -2,13 +2,13 @@
 import nock = require('nock');
 
 import {AgentGenerationConfig} from '@deliberation-lab/utils';
-import {getOpenAIAPITextCompletionResponse} from './openai.api';
+import {getOpenAIAPIChatCompletionResponse} from './openai.api';
 import {ModelResponse} from './model.response';
 
 describe('OpenAI-compatible API', () => {
-  it('handles text completion request', async () => {
+  it('handles chat completion request', async () => {
     nock('https://test.uri')
-      .post('/v1/completions', body => body.model == 'test-model')
+      .post('/v1/chat/completions', body => body.model == 'test-model')
       .reply(200, {
         id: 'test-id',
         object: 'text_completion',
@@ -32,7 +32,7 @@ describe('OpenAI-compatible API', () => {
       customRequestBodyFields: [{name: 'foo', value: 'bar'}],
     };
 
-    const response: ModelResponse = await getOpenAIAPITextCompletionResponse(
+    const response: ModelResponse = await getOpenAIAPIChatCompletionResponse(
       'testapikey',
       'https://test.uri/v1/',
       'test-model',

--- a/functions/src/api/openai.api.ts
+++ b/functions/src/api/openai.api.ts
@@ -4,7 +4,7 @@ import {ModelResponse} from './model.response';
 
 const MAX_TOKENS_FINISH_REASON = 'length';
 
-export async function callOpenAITextCompletion(
+export async function callOpenAIChatCompletion(
   apiKey: string,
   baseUrl: string | null,
   modelName: string,
@@ -22,9 +22,9 @@ export async function callOpenAITextCompletion(
       field.value,
     ]),
   );
-  const response = await client.completions.create({
+  const response = await client.chat.completions.create({
     model: modelName,
-    prompt: prompt,
+    messages: [{ role: 'user', content: prompt }],
     temperature: generationConfig.temperature,
     top_p: generationConfig.topP,
     frequency_penalty: generationConfig.frequencyPenalty,
@@ -46,7 +46,7 @@ export async function callOpenAITextCompletion(
   return {text: response.choices[0].text};
 }
 
-export async function getOpenAIAPITextCompletionResponse(
+export async function getOpenAIAPIChatCompletionResponse(
   apiKey: string,
   baseUrl: string | null,
   modelName: string,
@@ -72,7 +72,7 @@ export async function getOpenAIAPITextCompletionResponse(
 
   let response = {text: ''};
   try {
-    response = await callOpenAITextCompletion(
+    response = await callOpenAIChatCompletion(
       apiKey,
       baseUrl,
       modelName,


### PR DESCRIPTION
Previously it was using the legacy text completions API. The chat completions API is needed to support structured output.

This doesn't segment the prompt into separate messages, it just sends the entire prompt as one user message, which should match the Gemini API behavior.

- [x] Tests pass