### PR TITLE
Add presence detection using the firebase realtime database websocket

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -22,9 +22,15 @@
   "storage": {
     "rules": "firestore/storage.rules"
   },
+  "database": {
+    "rules": "firestore/database.rules.json"
+  },
   "emulators": {
     "auth": {
       "port": 9099
+    },
+    "database": {
+      "port": 9000
     },
     "functions": {
       "port": 5001

--- a/firestore/database.rules.json
+++ b/firestore/database.rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "status": {
+      "$experimentId": {
+        "$publicId": {
+          ".read": "true",
+          ".write": "true"
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -21,6 +21,7 @@ import {AuthService} from './services/auth.service';
 import {HomeService} from './services/home.service';
 import {Pages, RouterService} from './services/router.service';
 import {SettingsService} from './services/settings.service';
+import {PresenceService} from './services/presence.service';
 
 import {ColorMode} from './shared/types';
 
@@ -36,6 +37,7 @@ export class App extends MobxLitElement {
   private readonly homeService = core.getService(HomeService);
   private readonly routerService = core.getService(RouterService);
   private readonly settingsService = core.getService(SettingsService);
+  private readonly presenceService = core.getService(PresenceService);
 
   override connectedCallback() {
     super.connectedCallback();
@@ -87,6 +89,11 @@ export class App extends MobxLitElement {
           <experiment-builder></experiment-builder>
         `;
       case Pages.PARTICIPANT:
+        this.presenceService.setupPresence(
+          this.routerService.activeRoute.params['experiment'],
+          this.routerService.activeRoute.params['participant'],
+        );
+
         return html`
           <page-header></page-header>
           <participant-view></participant-view>

--- a/frontend/src/components/experiment_dashboard/participant_stats.ts
+++ b/frontend/src/components/experiment_dashboard/participant_stats.ts
@@ -88,7 +88,7 @@ export class Preview extends MobxLitElement {
   private renderChips() {
     return html`
       <div class="chip-container">
-        ${this.renderStatusChip()} ${this.renderStageChip()}
+        ${this.renderStatusChip()} ${this.renderConnectedChip()} ${this.renderStageChip()}
         ${this.renderTOSChip()}
       </div>
     `;
@@ -163,6 +163,17 @@ export class Preview extends MobxLitElement {
     }
   }
 
+  private getConnectedChipStyle(connected: boolean): {
+    emoji: string;
+    className: string;
+  } {
+    if (connected) {
+      return {emoji: '🔗', className: 'success'};
+    } else {
+      return {emoji: '📵', className: 'error'};
+    }
+  }
+
   private renderTOSChip() {
     if (!this.profile) {
       return nothing;
@@ -188,6 +199,20 @@ export class Preview extends MobxLitElement {
     return html`
       <div class="chip ${className}">
         <b>${emoji} Status:</b> ${currentStatus}
+      </div>
+    `;
+  }
+
+  private renderConnectedChip() {
+    if (!this.profile) {
+      return nothing;
+    }
+    const {connected} = this.profile;
+    const {emoji, className} = this.getConnectedChipStyle(connected);
+
+    return html`
+      <div class="chip ${className}">
+        <b>${emoji} Connected:</b> ${connected}
       </div>
     `;
   }

--- a/frontend/src/components/experiment_dashboard/participant_summary.ts
+++ b/frontend/src/components/experiment_dashboard/participant_summary.ts
@@ -144,6 +144,12 @@ export class ParticipantSummary extends MobxLitElement {
   private renderStatus() {
     if (!this.participant) return nothing;
 
+    const {connected} = this.participant;
+
+    if(!connected && !isParticipantEndedExperiment(this.participant)) {
+      return html`<div class="chip error">disconnected</div>`;
+    }
+
     if (isPendingParticipant(this.participant)) {
       return html`<div class="chip secondary">transfer pending</div>`;
     } else if (isObsoleteParticipant(this.participant)) {

--- a/frontend/src/service_provider.ts
+++ b/frontend/src/service_provider.ts
@@ -15,6 +15,7 @@ import {RouterService} from './services/router.service';
 import {SettingsService} from './services/settings.service';
 import {ExperimentEditor} from './services/experiment.editor';
 import {ExperimentManager} from './services/experiment.manager';
+import {PresenceService} from './services/presence.service';
 
 /**
  * Defines a map of services to their identifier
@@ -62,6 +63,9 @@ export function makeServiceProvider(self: Core) {
     },
     get settingsService() {
       return self.getService(SettingsService);
+    },
+    get presenceService() {
+      return self.getService(PresenceService);
     },
     // Editors
     get experimentEditor() {

--- a/frontend/src/services/firebase.service.ts
+++ b/frontend/src/services/firebase.service.ts
@@ -6,6 +6,11 @@ import {
   getAuth,
 } from 'firebase/auth';
 import {
+  Database,
+  getDatabase,
+  connectDatabaseEmulator,
+} from 'firebase/database';
+import {
   Firestore,
   Unsubscribe,
   connectFirestoreEmulator,
@@ -28,6 +33,7 @@ import {
   FIREBASE_LOCAL_HOST_PORT_FIRESTORE,
   FIREBASE_LOCAL_HOST_PORT_FUNCTIONS,
   FIREBASE_LOCAL_HOST_PORT_STORAGE,
+  FIREBASE_LOCAL_HOST_PORT_RTDB,
 } from '../shared/constants';
 import {FIREBASE_CONFIG} from '../../firebase_config';
 
@@ -44,6 +50,7 @@ export class FirebaseService extends Service {
     this.auth = getAuth(this.app);
     this.functions = getFunctions(this.app);
     this.storage = getStorage(this.app);
+    this.rtdb = getDatabase(this.app);
 
     // Only register emulators if in dev mode
     if (process.env.NODE_ENV === 'development') {
@@ -61,6 +68,7 @@ export class FirebaseService extends Service {
   provider: GoogleAuthProvider;
   storage: FirebaseStorage;
   unsubscribe: Unsubscribe[] = [];
+  rtdb: Database;
 
   registerEmulators() {
     connectFirestoreEmulator(
@@ -81,6 +89,11 @@ export class FirebaseService extends Service {
       this.functions,
       'localhost',
       FIREBASE_LOCAL_HOST_PORT_FUNCTIONS,
+    );
+    connectDatabaseEmulator(
+      this.rtdb,
+      'localhost',
+      FIREBASE_LOCAL_HOST_PORT_RTDB,
     );
   }
 }

--- a/frontend/src/services/presence.service.ts
+++ b/frontend/src/services/presence.service.ts
@@ -1,0 +1,51 @@
+import {
+  ref,
+  onValue,
+  onDisconnect,
+  set,
+  serverTimestamp,
+} from 'firebase/database';
+
+import {makeObservable} from 'mobx';
+
+import {Service} from './service';
+import {FirebaseService} from './firebase.service';
+
+interface ServiceProvider {
+  firebaseService: FirebaseService;
+}
+
+/** Tracks whether a participant is connected, using the firebase realtime database's websocket */
+export class PresenceService extends Service {
+  constructor(private readonly sp: ServiceProvider) {
+    super();
+    makeObservable(this);
+  }
+
+  setupPresence(experimentId: string, participantPrivateId: string) {
+    const statusRef = ref(this.sp.firebaseService.rtdb, `/status/${experimentId}/${participantPrivateId}`);
+
+    const isOffline = {
+      connected: false,
+      last_changed: serverTimestamp(),
+    };
+
+    const isOnline = {
+      connected: true,
+      last_changed: serverTimestamp(),
+    };
+
+    onValue(ref(this.sp.firebaseService.rtdb, '.info/connected'), (snapshot) => {
+      const isConnected = snapshot.val();
+      if (!isConnected) {
+        return;
+      }
+
+      // Set the user's status in rtdb. The callback will reset it to online
+      // if the user reconnects.
+      onDisconnect(statusRef).set(isOffline).then(() => {
+        set(statusRef, isOnline);
+      });
+    });
+  }
+}

--- a/frontend/src/shared/constants.ts
+++ b/frontend/src/shared/constants.ts
@@ -10,6 +10,7 @@ export const FIREBASE_LOCAL_HOST_PORT_FIRESTORE = 8080;
 export const FIREBASE_LOCAL_HOST_PORT_STORAGE = 9199;
 export const FIREBASE_LOCAL_HOST_PORT_AUTH = 9099;
 export const FIREBASE_LOCAL_HOST_PORT_FUNCTIONS = 5001;
+export const FIREBASE_LOCAL_HOST_PORT_RTDB = 9000;
 
 /** App name. */
 export const APP_NAME = 'Deliberate Lab';

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -12,4 +12,8 @@ import * as admin from 'firebase-admin';
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript
 
-export const app = admin.initializeApp();
+// By default, cloud functions use a legacy db name (just the project id), whereas the rest of
+// firebase uses the new db name (project id + -default-rtdb).
+export const app = admin.initializeApp({
+  databaseURL: `https://${process.env.GCLOUD_PROJECT}-default-rtdb.firebaseio.com`,
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,6 +11,8 @@ export * from './participant.endpoints';
 export * from './participant.triggers';
 export * from './participant.utils';
 
+export * from './presence.triggers';
+
 export * from './alert.endpoints';
 
 export * from './agent.endpoints';

--- a/functions/src/participant.triggers.ts
+++ b/functions/src/participant.triggers.ts
@@ -1,4 +1,5 @@
 import {onDocumentCreated} from 'firebase-functions/v2/firestore';
+
 import {
   ChipPublicStageData,
   ParticipantProfileExtended,

--- a/functions/src/presence.triggers.test.ts
+++ b/functions/src/presence.triggers.test.ts
@@ -1,0 +1,59 @@
+import firebaseFunctionsTest from 'firebase-functions-test';
+
+// Mock './app' before importing function under test
+jest.mock('./app', () => {
+  const setMock = jest.fn();
+  const getMock = jest.fn().mockResolvedValue({ exists: true });
+  const docMock = jest.fn().mockReturnValue({ get: getMock, set: setMock });
+  const firestoreMock = jest.fn().mockReturnValue({ doc: docMock });
+
+  // Expose mocks via module-scoped object for assertions
+  return {
+    __esModule: true,
+    app: {
+      firestore: firestoreMock,
+    },
+    __mocks__: {
+      firestoreMock,
+      docMock,
+      setMock,
+      getMock,
+    },
+  };
+});
+
+import { mirrorPresenceToFirestore } from './presence.triggers';
+// @ts-ignore
+import { __mocks__ } from './app';
+
+const testEnv = firebaseFunctionsTest({ projectId: 'deliberate-lab-test' });
+
+describe('mirrorPresenceToFirestore', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates firestore with the connected status from rtdb', async () => {
+    const wrapped = testEnv.wrap(mirrorPresenceToFirestore);
+
+    const beforeSnap = testEnv.database.makeDataSnapshot(null, '/status/exp123/user456');
+    const afterSnap = testEnv.database.makeDataSnapshot(
+      { connected: true, last_changed: 1234567890 },
+      '/status/exp123/user456'
+    );
+
+    const change = { before: beforeSnap, after: afterSnap };
+
+    await wrapped(change, {
+      params: {
+        experimentId: 'exp123',
+        participantPrivateId: 'user456',
+      },
+    });
+
+    const { docMock, setMock } = __mocks__;
+
+    expect(docMock).toHaveBeenCalledWith('experiments/exp123/participants/user456');
+    expect(setMock).toHaveBeenCalledWith({ connected: true }, { merge: true });
+  });
+});

--- a/functions/src/presence.triggers.ts
+++ b/functions/src/presence.triggers.ts
@@ -1,0 +1,35 @@
+import {database} from 'firebase-functions';
+import {app} from './app';
+
+/**
+ * Mirror the presence status from RTDB to Firestore.
+ *
+ * This function is triggered when the presence status of a participant changes in the RTDB.
+ * It updates the corresponding participant document in Firestore with the new status.
+ *
+ * Currently, rtdb is only used in Deliberate Lab for presence tracking (using the rtdb websocket).
+ */
+export const mirrorPresenceToFirestore = database
+  .instance(`${process.env.GCLOUD_PROJECT}-default-rtdb`) // other parts of firebase use the -default-rtdb suffix, so stay consistent
+  .ref('/status/{experimentId}/{participantPrivateId}')  // rtdb path, not firestore path
+  .onWrite(async (change, context) => {
+    const { experimentId, participantPrivateId } = context.params;
+    console.log(`mirrorPresenceToFirestore triggered for experimentId=${experimentId} participantPrivateId=${participantPrivateId}`);
+    const status = change.after.val();
+
+    if (!status) return null; // status was deleted
+
+    // Find the matching participant doc
+    const participantRef = app.firestore().doc(`experiments/${experimentId}/participants/${participantPrivateId}`);
+    const participantSnapshot = await participantRef.get();
+
+    if (! participantSnapshot.exists) {
+      console.warn(`No participant found with id=${participantPrivateId} in experiment=${experimentId}`);
+      return null;
+    }
+
+    return participantRef.set(
+      { connected: status.connected },
+      { merge: true }
+    );
+  });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es2017",
     "paths": {
       "@deliberation-lab/utils": ["../utils/dist"] // Makes `tsc --watch` also watch changes in the utils package
-    }
+    },
+    "esModuleInterop": true
   },
   "compileOnSave": true,
   "include": ["src"],

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -35,6 +35,7 @@ export interface ParticipantProfile extends ParticipantProfileBase {
   currentStatus: ParticipantStatus;
   timestamps: ProgressTimestamps;
   anonymousProfiles: Record<string, AnonymousProfileMetadata>;
+  connected: boolean;
 }
 
 /** Anonymous profile data generated from profile set. */
@@ -148,6 +149,7 @@ export function createParticipantProfileExtended(
     currentStatus: config.currentStatus ?? ParticipantStatus.IN_PROGRESS,
     timestamps: config.timestamps ?? createProgressTimestamps(),
     anonymousProfiles: {},
+    connected: false,
   };
 }
 


### PR DESCRIPTION
Fixes #506

With this PR, whether a user has their browser window open and connected is reflected in the UI, and the `connected` property on their participant record. It allows the experimenter to know if the participant is still present, which is important for experiments that involve participants interacting with one another.

This works by using the firebase rtdb's existing presence functionality, and a cloud function that mirrors the user's state into firestore.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
