### PR TITLE
Return detailed error output from Gemini API calls.

### DIFF
--- a/functions/src/agent.endpoints.ts
+++ b/functions/src/agent.endpoints.ts
@@ -15,10 +15,7 @@ import {
   getOpenAIAPIResponse,
   getOllamaResponse,
 } from './agent.utils';
-import {
-  ModelResponseStatus,
-  ModelResponse,
-} from './api/model.response';
+import {ModelResponseStatus, ModelResponse} from './api/model.response';
 import {getAgentParticipantRankingStageResponse} from './stages/ranking.utils';
 import {
   getExperimenterData,

--- a/functions/src/agent.endpoints.ts
+++ b/functions/src/agent.endpoints.ts
@@ -15,6 +15,10 @@ import {
   getOpenAIAPIResponse,
   getOllamaResponse,
 } from './agent.utils';
+import {
+  ModelResponseStatus,
+  ModelResponse,
+} from './api/model.response';
 import {getAgentParticipantRankingStageResponse} from './stages/ranking.utils';
 import {
   getExperimenterData,
@@ -103,6 +107,10 @@ export const testAgentParticipantPrompt = onCall(async (request) => {
     response,
   );
 
+  if (response.status !== ModelResponseStatus.OK) {
+    return {data: `Error: ${response.status}: ${response.errorMessage}`};
+  }
+
   return {data: response};
 });
 
@@ -142,6 +150,10 @@ export const testAgentConfig = onCall(async (request) => {
     JSON.stringify(promptConfig),
     response,
   );
+
+  if (response.status !== ModelResponseStatus.OK) {
+    return {data: `Error: ${response.status}: ${response.errorMessage}`};
+  }
 
   return {data: response.text};
 });

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -18,10 +18,7 @@ import {initiateChatDiscussion} from './stages/chat.utils';
 import {getAgentParticipantRankingStageResponse} from './stages/ranking.utils';
 import {getAgentParticipantSurveyStageResponse} from './stages/survey.utils';
 
-import {
-  ModelResponse,
-  ModelResponseStatus,
-} from './api/model.response';
+import {ModelResponseStatus} from './api/model.response';
 import {getGeminiAPIResponse} from './api/gemini.api';
 import {getOpenAIAPIChatCompletionResponse} from './api/openai.api';
 import {ollamaChat} from './api/ollama.api';
@@ -51,7 +48,7 @@ export async function getAgentResponse(
   }
 
   if (modelSettings.apiType === ApiKeyType.GEMINI_API_KEY) {
-    response = getGeminiResponse(
+    response = await getGeminiResponse(
       data,
       modelSettings.modelName,
       prompt,
@@ -59,7 +56,7 @@ export async function getAgentResponse(
       structuredOutputConfig,
     );
   } else if (modelSettings.apiType === ApiKeyType.OPENAI_API_KEY) {
-    response = getOpenAIAPIResponse(
+    response = await getOpenAIAPIResponse(
       data,
       modelSettings.modelName,
       prompt,

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -18,6 +18,10 @@ import {initiateChatDiscussion} from './stages/chat.utils';
 import {getAgentParticipantRankingStageResponse} from './stages/ranking.utils';
 import {getAgentParticipantSurveyStageResponse} from './stages/survey.utils';
 
+import {
+  ModelResponse,
+  ModelResponseStatus,
+} from './api/model.response';
 import {getGeminiAPIResponse} from './api/gemini.api';
 import {getOpenAIAPIChatCompletionResponse} from './api/openai.api';
 import {ollamaChat} from './api/ollama.api';
@@ -65,11 +69,14 @@ export async function getAgentResponse(
   } else if (modelSettings.apiType === ApiKeyType.OLLAMA_CUSTOM_URL) {
     response = await getOllamaResponse(data, modelSettings.modelName, prompt);
   } else {
-    console.error(
-      'Error: invalid apiKey type: ',
-      data.apiKeys.ollamaApiKey.apiKey,
-    );
-    response = {text: ''};
+    response = {
+      status: ModelResponseStatus.CONFIG_ERROR,
+      errorMessage: `Error: invalid apiKey type: ${data.apiKeys.ollamaApiKey.apiKey}`,
+    };
+  }
+
+  if (response.status !== ModelResponseStatus.OK) {
+    console.error(`GetAgentResponse: response error status: ${response.status}; message: ${response.errorMessage}`);
   }
 
   return response;

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -73,7 +73,9 @@ export async function getAgentResponse(
   }
 
   if (response.status !== ModelResponseStatus.OK) {
-    console.error(`GetAgentResponse: response error status: ${response.status}; message: ${response.errorMessage}`);
+    console.error(
+      `GetAgentResponse: response error status: ${response.status}; message: ${response.errorMessage}`,
+    );
   }
 
   return response;

--- a/functions/src/api/gemini.api.test.ts
+++ b/functions/src/api/gemini.api.test.ts
@@ -134,4 +134,6 @@ describe('Gemini API', () => {
     };
     expect(parsedResponse).toMatchObject(expectedResponse);
   });
+
+  // TODO(mkbehr): Add tests for error responses.
 });

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -134,7 +134,7 @@ export async function callGemini(
   if (!response.candidates) {
     return {
       status: ModelResponseStatus.UNKNOWN_ERROR,
-      errorMessage: `Response unexpectedly had no candidates: ${response}`,
+      errorMessage: `Model provider returned an unexpected response (no response candidates): ${response}`,
     };
   }
 

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -201,7 +201,7 @@ export async function getGeminiAPIResponse(
     if (statusMatch) {
       const statusCode = parseInt(statusMatch[1]);
       if (statusCode == AUTHENTICATION_FAILURE_ERROR_CODE) {
-        returnStatus = ModelResponseStatus.QUOTA_ERROR;
+        returnStatus = ModelResponseStatus.AUTHENTICATION_ERROR;
       } else if (statusCode == QUOTA_ERROR_CODE) {
         returnStatus = ModelResponseStatus.QUOTA_ERROR;
       } else if (statusCode >= 500 && statusCode < 600) {

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -11,10 +11,7 @@ import {
   StructuredOutputConfig,
   StructuredOutputSchema,
 } from '@deliberation-lab/utils';
-import {
-  ModelResponseStatus,
-  ModelResponse,
-} from './model.response';
+import {ModelResponseStatus, ModelResponse} from './model.response';
 
 const GEMINI_DEFAULT_MODEL = 'gemini-1.5-pro-latest';
 const DEFAULT_FETCH_TIMEOUT = 300 * 1000; // This is the Chrome default
@@ -41,9 +38,7 @@ const SAFETY_SETTINGS = [
   },
 ];
 
-function makeStructuredOutputSchema(
-  schema: StructuredOutputSchema,
-): object {
+function makeStructuredOutputSchema(schema: StructuredOutputSchema): object {
   const typeMap: {[key in StructuredOutputDataType]?: string} = {
     [StructuredOutputDataType.STRING]: 'STRING',
     [StructuredOutputDataType.NUMBER]: 'NUMBER',
@@ -130,7 +125,9 @@ export async function callGemini(
   if (response.promptFeedback) {
     return {
       status: ModelResponseStatus.REFUSAL_ERROR,
-      errorMessage: response.promptFeedback.blockReasonMessage ?? JSON.stringify(response.promptFeedback),
+      errorMessage:
+        response.promptFeedback.blockReasonMessage ??
+        JSON.stringify(response.promptFeedback),
     };
   }
 
@@ -178,7 +175,7 @@ export async function getGeminiAPIResponse(
     return {
       status: ModelResponseStatus.INTERNAL_ERROR,
       errorMessage: error.message,
-    }
+    };
   }
   const geminiConfig: GenerationConfig = {
     stopSequences: generationConfig.stopSequences,
@@ -200,7 +197,7 @@ export async function getGeminiAPIResponse(
     // so try to parse the output string looking for the HTTP status code.
     let returnStatus = ModelResponseStatus.UNKNOWN_ERROR;
     // Match a status code and message between brackets, e.g. "[403 Forbidden]".
-    const statusMatch = error.message.match(/\[(\d{3})[\s\w]*\]/)
+    const statusMatch = error.message.match(/\[(\d{3})[\s\w]*\]/);
     if (statusMatch) {
       const statusCode = parseInt(statusMatch[1]);
       if (statusCode == AUTHENTICATION_FAILURE_ERROR_CODE) {

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -193,7 +193,7 @@ export async function getGeminiAPIResponse(
   };
 
   try {
-    return callGemini(apiKey, promptText, geminiConfig, modelName);
+    return await callGemini(apiKey, promptText, geminiConfig, modelName);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     // The GenerativeAI client doesn't return responses in a parseable format,
@@ -214,6 +214,6 @@ export async function getGeminiAPIResponse(
     return {
       status: returnStatus,
       errorMessage: error.message,
-    }
+    };
   }
 }

--- a/functions/src/api/model.response.ts
+++ b/functions/src/api/model.response.ts
@@ -18,6 +18,10 @@ export enum ModelResponseStatus {
   // The response reached the configured output token limit and was terminated
   // early. The partial response will be present in the text field.
   LENGTH_ERROR = 'length_error',
+  // The agent's config is invalid.
+  CONFIG_ERROR = 'config_error',
+  // Deliberate Lab encountered an internal error.
+  INTERNAL_ERROR = 'internal_error',
   // Catchall category for errors not covered above.
   UNKNOWN_ERROR = 'unknown_error',
 }

--- a/functions/src/api/model.response.ts
+++ b/functions/src/api/model.response.ts
@@ -33,6 +33,7 @@ export interface ModelResponse {
   status: ModelResponseStatus;
   // The model's response, in plaintext. Null if the provider didn't return a response.
   text?: string;
+  // TODO(mkbehr): Parse the response during response creation.
   parsedResponse?: object;
   errorMessage?: string;
 }

--- a/functions/src/api/model.response.ts
+++ b/functions/src/api/model.response.ts
@@ -1,7 +1,34 @@
+export enum ModelResponseStatus {
+  // A successful response.
+  OK = 'ok',
+  // The provider returned an otherwise-valid response, but Deliberate Lab
+  // couldn't parse it in the expected structured output format. The plaintext
+  // response will be present in the text field.
+  STRUCTURED_OUTPUT_PARSE_ERROR = 'structured_output_parse_error',
+  // The provider didn't accept the authentication for this request, e.g.
+  // because of a missing or invalid API key.
+  AUTHENTICATION_ERROR = 'authentication_error',
+  // The provider denied the request because the account ran out of quota or funds.
+  QUOTA_ERROR = 'quota_error',
+  // Deliberate Lab couldn't reach the provider, or received a server error
+  // response. This error may be transient.
+  PROVIDER_UNAVAILABLE_ERROR = 'provider_unavailable_error',
+  // The provider refused the request for policy or safety reasons.
+  REFUSAL_ERROR = 'refusal_error',
+  // The response reached the configured output token limit and was terminated
+  // early. The partial response will be present in the text field.
+  LENGTH_ERROR = 'length_error',
+  // Catchall category for errors not covered above.
+  UNKNOWN_ERROR = 'unknown_error',
+}
+
 /**
  * Common interface for all model responses.
  */
 export interface ModelResponse {
-  score?: number;
-  text: string;
+  status: ModelResponseStatus;
+  // The model's response, in plaintext. Null if the provider didn't return a response.
+  text?: string;
+  parsedResponse?: object;
+  errorMessage?: string;
 }

--- a/functions/src/api/ollama.api.ts
+++ b/functions/src/api/ollama.api.ts
@@ -12,10 +12,7 @@ import {
   OllamaServerConfig,
   ModelGenerationConfig,
 } from '@deliberation-lab/utils';
-import {
-  ModelResponse,
-  ModelResponseStatus,
-} from './model.response';
+import {ModelResponse, ModelResponseStatus} from './model.response';
 
 /**
  * The JSON schema for LLM input understood by Ollama.

--- a/functions/src/api/ollama.api.ts
+++ b/functions/src/api/ollama.api.ts
@@ -12,7 +12,10 @@ import {
   OllamaServerConfig,
   ModelGenerationConfig,
 } from '@deliberation-lab/utils';
-import {ModelResponse} from './model.response';
+import {
+  ModelResponse,
+  ModelResponseStatus,
+} from './model.response';
 
 /**
  * The JSON schema for LLM input understood by Ollama.
@@ -50,7 +53,11 @@ export async function ollamaChat(
     body: JSON.stringify(messageObjects),
   });
   const responseMessage = await decodeResponse(response);
-  return {text: responseMessage};
+  return {
+    // TODO(mkbehr): handle errors from this API
+    status: ModelResponseStatus.OK,
+    text: responseMessage,
+  };
 }
 
 /**

--- a/functions/src/api/openai.api.ts
+++ b/functions/src/api/openai.api.ts
@@ -6,7 +6,10 @@ import {
   StructuredOutputConfig,
   StructuredOutputSchema,
 } from '@deliberation-lab/utils';
-import {ModelResponse} from './model.response';
+import {
+  ModelResponse,
+  ModelResponseStatus,
+} from './model.response';
 
 const MAX_TOKENS_FINISH_REASON = 'length';
 
@@ -131,7 +134,11 @@ export async function callOpenAIChatCompletion(
     console.error(`Error: Token limit exceeded`);
   }
 
-  return {text: response.choices[0].message.content};
+  return {
+    // TODO(mkbehr): handle errors from this API
+    status: ModelResponseStatus.OK,
+    text: response.choices[0].message.content
+  };
 }
 
 export async function getOpenAIAPIChatCompletionResponse(
@@ -161,7 +168,11 @@ export async function getOpenAIAPIChatCompletionResponse(
     structuredOutputConfig,
   );
 
-  let response = {text: ''};
+  let response = {
+    // TODO(mkbehr): handle errors from this API
+    status: ModelResponseStatus.UNKNOWN_ERROR,
+    errorMessage: ''
+  };
   try {
     response = await callOpenAIChatCompletion(
       apiKey,
@@ -173,10 +184,12 @@ export async function getOpenAIAPIChatCompletionResponse(
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    console.error('API error:', error);
+    response = {
+      // TODO(mkbehr): handle errors from this API
+      status: ModelResponseStatus.UNKNOWN_ERROR,
+      errorMessage: error.message,
+    };
   }
 
-  // Log the response
-  console.log(response);
   return response;
 }

--- a/functions/src/api/openai.api.ts
+++ b/functions/src/api/openai.api.ts
@@ -6,10 +6,7 @@ import {
   StructuredOutputConfig,
   StructuredOutputSchema,
 } from '@deliberation-lab/utils';
-import {
-  ModelResponse,
-  ModelResponseStatus,
-} from './model.response';
+import {ModelResponse, ModelResponseStatus} from './model.response';
 
 const MAX_TOKENS_FINISH_REASON = 'length';
 
@@ -48,8 +45,8 @@ function makeStructuredOutputSchema(
     ? makeStructuredOutputSchema(schema.arrayItems)
     : undefined;
 
-  const additionalProperties = (schema.type == StructuredOutputDataType.OBJECT)
-    ? false : undefined;
+  const additionalProperties =
+    schema.type == StructuredOutputDataType.OBJECT ? false : undefined;
 
   return {
     type: type,
@@ -64,7 +61,7 @@ function makeStructuredOutputSchema(
 function makeStructuredOutputParameters(
   structuredOutputConfig?: StructuredOutputConfig,
 ): object | null {
-    if (
+  if (
     !structuredOutputConfig ||
     structuredOutputConfig.type === StructuredOutputType.NONE
   ) {
@@ -103,9 +100,7 @@ export async function callOpenAIChatCompletion(
     baseURL: baseUrl,
   });
 
-  const responseFormat = makeStructuredOutputParameters(
-    structuredOutputConfig
-  );
+  const responseFormat = makeStructuredOutputParameters(structuredOutputConfig);
   const customFields = Object.fromEntries(
     generationConfig.customRequestBodyFields.map((field) => [
       field.name,
@@ -114,13 +109,13 @@ export async function callOpenAIChatCompletion(
   );
   const response = await client.chat.completions.create({
     model: modelName,
-    messages: [{ role: 'user', content: prompt }],
+    messages: [{role: 'user', content: prompt}],
     temperature: generationConfig.temperature,
     top_p: generationConfig.topP,
     frequency_penalty: generationConfig.frequencyPenalty,
     presence_penalty: generationConfig.presencePenalty,
     response_format: responseFormat,
-      ...customFields,
+    ...customFields,
   });
 
   if (!response || !response.choices) {
@@ -137,7 +132,7 @@ export async function callOpenAIChatCompletion(
   return {
     // TODO(mkbehr): handle errors from this API
     status: ModelResponseStatus.OK,
-    text: response.choices[0].message.content
+    text: response.choices[0].message.content,
   };
 }
 
@@ -171,7 +166,7 @@ export async function getOpenAIAPIChatCompletionResponse(
   let response = {
     // TODO(mkbehr): handle errors from this API
     status: ModelResponseStatus.UNKNOWN_ERROR,
-    errorMessage: ''
+    errorMessage: '',
   };
   try {
     response = await callOpenAIChatCompletion(

--- a/functions/src/stages/chat.triggers.ts
+++ b/functions/src/stages/chat.triggers.ts
@@ -26,7 +26,6 @@ import {
   getTypingDelayInMilliseconds,
   structuredOutputEnabled,
 } from '@deliberation-lab/utils';
-import {getAgentResponse} from '../agent.utils';
 import {updateCurrentDiscussionIndex} from './chat.utils';
 import {getPastStagesPromptContext} from './stage.utils';
 import {getMediatorsInCohortStage} from '../mediator.utils';

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -24,6 +24,7 @@ import * as functions from 'firebase-functions';
 import {Timestamp} from 'firebase-admin/firestore';
 import {onCall} from 'firebase-functions/v2/https';
 
+import {ModelResponseStatus} from '../api/model.response';
 import {app} from '../app';
 import {getAgentResponse} from '../agent.utils';
 import {
@@ -310,7 +311,7 @@ export async function getAgentChatAPIResponse(
     promptConfig.structuredOutputConfig,
   );
 
-  if (message.status !== ModelResponseStatus.OK) {
+  if (response.status !== ModelResponseStatus.OK) {
     // TODO: Surface the error to the experimenter.
     return null;
   }

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -310,8 +310,13 @@ export async function getAgentChatAPIResponse(
     promptConfig.structuredOutputConfig,
   );
 
+  if (message.status !== ModelResponseStatus.OK) {
+    // TODO: Surface the error to the experimenter.
+    return null;
+  }
+
   // Add agent message if non-empty
-  let message = response.text;
+  let message = response.text!;
   let parsed = '';
 
   if (promptConfig.responseConfig?.isJSON) {
@@ -319,7 +324,7 @@ export async function getAgentChatAPIResponse(
     message = '';
 
     try {
-      const cleanedText = response.text
+      const cleanedText = response.text!
         .replace(/```json\s*|\s*```/g, '')
         .trim();
       parsed = JSON.parse(cleanedText);
@@ -334,7 +339,7 @@ export async function getAgentChatAPIResponse(
     message = '';
 
     try {
-      const cleanedText = response.text
+      const cleanedText = response.text!
         .replace(/```json\s*|\s*```/g, '')
         .trim();
       parsed = JSON.parse(cleanedText);

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -325,8 +325,8 @@ export async function getAgentChatAPIResponse(
     message = '';
 
     try {
-      const cleanedText = response.text!
-        .replace(/```json\s*|\s*```/g, '')
+      const cleanedText = response
+        .text!.replace(/```json\s*|\s*```/g, '')
         .trim();
       parsed = JSON.parse(cleanedText);
     } catch {
@@ -340,8 +340,8 @@ export async function getAgentChatAPIResponse(
     message = '';
 
     try {
-      const cleanedText = response.text!
-        .replace(/```json\s*|\s*```/g, '')
+      const cleanedText = response
+        .text!.replace(/```json\s*|\s*```/g, '')
         .trim();
       parsed = JSON.parse(cleanedText);
     } catch {

--- a/functions/src/stages/ranking.utils.ts
+++ b/functions/src/stages/ranking.utils.ts
@@ -84,7 +84,7 @@ export async function getAgentParticipantRankingStageResponse(
     participant.agentConfig.modelSettings,
     generationConfig,
   );
-  const response = rawResponse.text;
+  const response = rawResponse.text ?? '';
 
   // Check console log for response
   console.log(

--- a/functions/src/stages/survey.utils.ts
+++ b/functions/src/stages/survey.utils.ts
@@ -97,7 +97,7 @@ async function getAgentParticipantSurveyQuestionResponse(
     participant.agentConfig.modelSettings,
     generationConfig,
   );
-  const response = rawResponse.text;
+  const response = rawResponse.text ?? '';
 
   // Check console log for response
   console.log(


### PR DESCRIPTION
Restructure the ModelResponse interface to return error information.
- A new `status` field contains an enum to indicate whether the response was OK.
- `text` is populated only if the model returned a text response. (It will be empty for most error cases, but some errors will leave some text populated, like running out of output tokens.)
- A new `errorMessage` field contains the error message.
- A new `parsedResponse` field isn't populated yet, but it'll let us move structured output parsing closer to the model call, and return a parsing error if the model returns badly-formatted data.

Errors are reported through the prompt testing endpoint, but otherwise not used yet.

Only the Gemini API is fully supported so far. The OpenAI/compatible API will report UNKNOWN_ERROR for some errors, and the Ollama API will always report OK.

- [x] Tests pass