### PR TITLE
Responsive participant view

### DIFF
--- a/frontend/src/components/participant_view/participant_nav.scss
+++ b/frontend/src/components/participant_view/participant_nav.scss
@@ -1,6 +1,6 @@
-@use "../../sass/colors";
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -47,7 +47,7 @@
   border-radius: common.$spacing-medium;
 
   &.experimenter-only {
-    opacity: .25;
+    opacity: 0.25;
   }
 }
 
@@ -60,4 +60,29 @@
   @include common.chip;
   @include typescale.label-small;
   border-radius: common.$spacing-small;
+}
+
+@include common.viewport-small {
+  :host {
+    width: 0;
+    min-width: 0;
+    flex-basis: 0;
+    overflow: hidden;
+  }
+  .nav {
+    width: 0;
+    min-width: 0;
+    flex-basis: 0;
+    overflow: hidden;
+    border-right: none;
+    padding: 0;
+  }
+  .title,
+  .stages,
+  .nav-item-wrapper,
+  .nav-item,
+  .primary,
+  .chip {
+    display: none;
+  }
 }

--- a/frontend/src/components/popup/popup.scss
+++ b/frontend/src/components/popup/popup.scss
@@ -1,6 +1,6 @@
-@use "../../sass/common";
-@use "../../sass/colors";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/colors';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -26,6 +26,21 @@
   justify-content: space-between;
   width: 100%;
   gap: common.$spacing-xl;
+}
+
+@include common.viewport-small {
+  .button-row {
+    flex-direction: column;
+    gap: common.$spacing-medium;
+    align-items: stretch;
+  }
+  .button-container {
+    width: 100%;
+    padding-bottom: common.$spacing-xl; // Added extra padding below buttons on mobile
+  }
+  pr-button {
+    width: 100%;
+  }
 }
 
 .button-container {

--- a/frontend/src/components/stages/chat_interface.scss
+++ b/frontend/src/components/stages/chat_interface.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -135,4 +135,51 @@ stage-footer {
     height: auto;
     width: 100%;
   }
+}
+
+.chat-participants-top {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+  margin-bottom: common.$spacing-large;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.chat-participants-title {
+  @include typescale.title-small;
+  margin-bottom: common.$spacing-small;
+}
+
+.chat-participants-title-row {
+  display: flex;
+  align-items: center;
+}
+
+.chat-timer-mobile {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.chat-info-message {
+  @include common.flex-row;
+  background: var(--md-sys-color-surface);
+  border-radius: common.$spacing-medium;
+  margin-bottom: common.$spacing-medium;
+  padding: common.$spacing-medium common.$spacing-large;
+  color: var(--md-sys-color-on-surface-variant);
+  :host .description-wrapper {
+    border-bottom: none;
+  }
+}
+
+.countdown {
+  @include typescale.label-medium;
+  font-style: italic;
+  color: var(--md-sys-color-secondary);
+}
+
+.ended {
+  color: var(--md-sys-color-tertiary);
 }

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -436,22 +436,6 @@ export class ChatInterface extends MobxLitElement {
     `;
   }
 
-  private formatTime(seconds: number | null): string {
-    if (seconds === null) return '';
-    const hours = Math.floor(seconds / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    if (hours > 0) {
-      return `${hours.toString().padStart(2, '0')}:${mins
-        .toString()
-        .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-    } else {
-      return `${mins.toString().padStart(2, '0')}:${secs
-        .toString()
-        .padStart(2, '0')}`;
-    }
-  }
-
   private renderStageDescription() {
     if (!this.stage) return nothing;
     // Pass noBorder=true when rendering in chat-info-message

--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -456,7 +456,7 @@ export class ChatInterface extends MobxLitElement {
     const requireFullTime = this.stage.requireFullTime === true;
     if (requireFullTime && this.stage.timeLimitInMinutes !== null) {
       if (
-        this.timeRemainingInSeconds !== null &&
+        this.timeRemainingInSeconds == null || // chat hasn't begun yet
         this.timeRemainingInSeconds > 0
       ) {
         disableNext = true;

--- a/frontend/src/components/stages/chat_panel.scss
+++ b/frontend/src/components/stages/chat_panel.scss
@@ -7,6 +7,10 @@
   gap: common.$spacing-large;
   overflow: auto;
   width: 240px;
+
+  @include common.viewport-medium {
+    display: none;
+  }
 }
 
 .panel-item {

--- a/frontend/src/components/stages/chat_panel.ts
+++ b/frontend/src/components/stages/chat_panel.ts
@@ -12,7 +12,6 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {AgentManager} from '../../services/agent.manager';
 import {AuthService} from '../../services/auth.service';
-import {ExperimentManager} from '../../services/experiment.manager';
 import {CohortService} from '../../services/cohort.service';
 import {ParticipantService} from '../../services/participant.service';
 
@@ -25,7 +24,6 @@ import {
   checkApiKeyExists,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
-import {isActiveParticipant} from '../../shared/participant.utils';
 import {
   convertUnifiedTimestampToDate,
   getHashBasedColor,
@@ -40,7 +38,6 @@ export class ChatPanel extends MobxLitElement {
   private readonly agentManager = core.getService(AgentManager);
   private readonly authService = core.getService(AuthService);
   private readonly cohortService = core.getService(CohortService);
-  private readonly experimentManager = core.getService(ExperimentManager);
   private readonly participantService = core.getService(ParticipantService);
 
   @property() stage: ChatStageConfig | null = null;
@@ -175,6 +172,9 @@ export class ChatPanel extends MobxLitElement {
 
   private renderParticipantList() {
     const activeParticipants = this.cohortService.activeParticipants;
+    const mediators = this.cohortService.getMediatorsForStage(
+      this.stage?.id ?? '',
+    );
 
     if (!this.stage) {
       return nothing;
@@ -183,14 +183,12 @@ export class ChatPanel extends MobxLitElement {
     return html`
       <div class="panel-item">
         <div class="panel-item-title">
-          Participants (${activeParticipants.length})
+          Participants (${activeParticipants.length + mediators.length})
         </div>
         ${activeParticipants.map((participant) =>
           this.renderProfile(participant),
         )}
-        ${this.cohortService
-          .getMediatorsForStage(this.stage.id)
-          .map((mediator) => this.renderMediator(mediator))}
+        ${mediators.map((mediator) => this.renderMediator(mediator))}
       </div>
     `;
   }

--- a/frontend/src/components/stages/stage_description.scss
+++ b/frontend/src/components/stages/stage_description.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -9,6 +9,10 @@
   @include common.flex-column;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   padding: common.$main-content-padding;
+
+  &.no-border {
+    border-bottom: none;
+  }
 }
 
 .description {

--- a/frontend/src/components/stages/stage_description.ts
+++ b/frontend/src/components/stages/stage_description.ts
@@ -14,14 +14,14 @@ export class StageDescription extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   @property() stage: StageConfig | null = null;
+  @property({type: Boolean}) noBorder = false;
 
   override render() {
     if (!this.stage || this.stage.descriptions.primaryText.length === 0) {
       return nothing;
     }
-
     return html`
-      <div class="description-wrapper">
+      <div class="description-wrapper${this.noBorder ? ' no-border' : ''}">
         <div class="description html-wrapper">
           ${unsafeHTML(
             convertMarkdownToHTML(this.stage.descriptions.primaryText),

--- a/frontend/src/sass/_common.scss
+++ b/frontend/src/sass/_common.scss
@@ -302,6 +302,12 @@
   }
 }
 
+@mixin viewport-medium {
+  @media screen and (max-width: 1024px) {
+    @content;
+  }
+}
+
 @mixin viewport-small {
   @media screen and (max-width: 720px) {
     @content;


### PR DESCRIPTION
Fixes #529

Adds some simple responsive layout to the participant view. On smaller screens:

- Hides the left sidebar showing the current stage
- Hides the left sidebar in the chat stage
- Shows chat participants and time remaining at the top of the window
- Puts the chat info inside the chat, so it scrolls off with new messages
- Reformats the buttons in the transfer popup

This code is a bit messy since I'm trying to get it out the door asap for an experiment we are running. But it does make participation possible on a phone. Especially, there is some duplicated code between `chat_panel` and `chat_interface` that could be refactored into a set of common components.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
