### PR TITLE
Temporarily hardcode all participants to connected

### DIFF
--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -53,6 +53,9 @@ export const createParticipant = onCall(async (request) => {
     prolificId: data.prolificId,
   });
 
+  // Temporarily always mark participants as connected (PR #537)
+  participantConfig.connected = true; // TODO: Remove this line
+
   // If agent config is specified, add to participant config
   if (data.agentConfig) {
     participantConfig.agentConfig = data.agentConfig;

--- a/functions/src/presence.triggers.ts
+++ b/functions/src/presence.triggers.ts
@@ -11,30 +11,40 @@ import {app} from './app';
  */
 export const mirrorPresenceToFirestore = database
   .instance(`${process.env.GCLOUD_PROJECT}-default-rtdb`) // other parts of firebase use the -default-rtdb suffix, so stay consistent
-  .ref('/status/{experimentId}/{participantPrivateId}')  // rtdb path, not firestore path
+  .ref('/status/{experimentId}/{participantPrivateId}') // rtdb path, not firestore path
   .onWrite(async (change, context) => {
-    const { experimentId, participantPrivateId } = context.params;
-    console.log(`mirrorPresenceToFirestore triggered for experimentId=${experimentId} participantPrivateId=${participantPrivateId}`);
+    const {experimentId, participantPrivateId} = context.params;
+    console.log(
+      `mirrorPresenceToFirestore triggered for experimentId=${experimentId} participantPrivateId=${participantPrivateId}`,
+    );
     const status = change.after.val();
 
     if (!status) return null; // status was deleted
 
     // Find the matching participant doc
-    const participantRef = app.firestore().doc(`experiments/${experimentId}/participants/${participantPrivateId}`);
+    const participantRef = app
+      .firestore()
+      .doc(`experiments/${experimentId}/participants/${participantPrivateId}`);
     const participantSnapshot = await participantRef.get();
 
-    if (! participantSnapshot.exists) {
-      console.warn(`No participant found with id=${participantPrivateId} in experiment=${experimentId}`);
+    if (!participantSnapshot.exists) {
+      console.warn(
+        `No participant found with id=${participantPrivateId} in experiment=${experimentId}`,
+      );
       return null;
     }
     const participant = participantSnapshot.data();
 
-    if(participant && participant.agentConfig) {
-      return null;  // Don't update presence for agent participants
+    if (participant && participant.agentConfig) {
+      return null; // Don't update presence for agent participants
     }
 
-    return participantRef.set(
-      { connected: status.connected },
-      { merge: true }
-    );
+    // Temporarily prevent participants from switching from connected
+    // to disconnected (PR #537)
+    // TODO: Remove this logic to resume actual presence detection
+    if (!status.connected) {
+      return null;
+    }
+
+    return participantRef.set({connected: status.connected}, {merge: true});
   });


### PR DESCRIPTION
This defines all new participants as connected and prevents existing participant profiles from switching to disconnected.

We've received reports of some participants showing up as disconnected even when they are actively participating (e.g., sending chat messages), so we're disabling the "disconnected" status while we investigate.

Note that in the future, we may also want to show disconnected participants as "inactive" in the chat stage if they have already sent a message (so that the participant list in chat reflects everyone who has contributed at some time).