### PR TITLE
Add slider scale option to survey questions

### DIFF
--- a/frontend/src/components/stages/survey_editor.scss
+++ b/frontend/src/components/stages/survey_editor.scss
@@ -1,6 +1,6 @@
-@use "../../sass/colors";
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -81,4 +81,26 @@ pr-textarea {
 
 .required {
   color: var(--md-sys-color-error);
+}
+
+.scale-value-editors,
+.scale-text-editors {
+  @include common.flex-row;
+  gap: common.$spacing-medium;
+}
+
+.scale-value-editor,
+.scale-text-editor {
+  @include common.flex-column;
+  flex: 1;
+  gap: common.$spacing-small;
+
+  label {
+    @include typescale.label-small;
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  input {
+    @include common.number-input;
+  }
 }

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -390,6 +390,11 @@ export class SurveyEditor extends MobxLitElement {
       this.updateQuestion({...question, upperText}, index);
     };
 
+    const updateMiddleText = (e: InputEvent) => {
+      const middleText = (e.target as HTMLTextAreaElement).value;
+      this.updateQuestion({...question, middleText}, index);
+    };
+
     const updateLowerValue = (e: InputEvent) => {
       const lowerValue =
         parseInt((e.target as HTMLInputElement).value, 10) || 0;
@@ -487,6 +492,17 @@ export class SurveyEditor extends MobxLitElement {
             .value=${question.upperText ?? ''}
             ?disabled=${!this.experimentEditor.canEditStages}
             @input=${updateUpperText}
+          >
+          </pr-textarea>
+        </div>
+        <div class="scale-text-editor">
+          <label>Middle text (optional)</label>
+          <pr-textarea
+            placeholder="e.g., Neutral"
+            size="small"
+            .value=${question.middleText ?? ''}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateMiddleText}
           >
           </pr-textarea>
         </div>

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -380,6 +380,28 @@ export class SurveyEditor extends MobxLitElement {
   }
 
   private renderScaleQuestion(question: ScaleSurveyQuestion, index: number) {
+    const updateLowerText = (e: InputEvent) => {
+      const lowerText = (e.target as HTMLTextAreaElement).value;
+      this.updateQuestion({...question, lowerText}, index);
+    };
+
+    const updateUpperText = (e: InputEvent) => {
+      const upperText = (e.target as HTMLTextAreaElement).value;
+      this.updateQuestion({...question, upperText}, index);
+    };
+
+    const updateLowerValue = (e: InputEvent) => {
+      const lowerValue =
+        parseInt((e.target as HTMLInputElement).value, 10) || 0;
+      this.updateQuestion({...question, lowerValue}, index);
+    };
+
+    const updateUpperValue = (e: InputEvent) => {
+      const upperValue =
+        parseInt((e.target as HTMLInputElement).value, 10) || 10;
+      this.updateQuestion({...question, upperValue}, index);
+    };
+
     const toggleUseSlider = () => {
       const updatedQuestion = {...question, useSlider: !question.useSlider};
       this.updateQuestion(updatedQuestion, index);
@@ -391,6 +413,61 @@ export class SurveyEditor extends MobxLitElement {
           ${this.renderQuestionTitleEditor(question, index)}
         </div>
         ${this.renderQuestionNav(question, index)}
+      </div>
+      <div class="description">
+        <b>Scale range:</b> Set the numeric range for the scale.
+      </div>
+      <div class="scale-value-editors">
+        <div class="scale-value-editor">
+          <label>Lower value</label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            .value=${question.lowerValue.toString()}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateLowerValue}
+          />
+        </div>
+        <div class="scale-value-editor">
+          <label>Upper value</label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            .value=${question.upperValue.toString()}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateUpperValue}
+          />
+        </div>
+      </div>
+      <div class="description">
+        <b>Scale labels:</b> Add text labels for the lower and upper ends of the
+        scale.
+      </div>
+      <div class="scale-text-editors">
+        <div class="scale-text-editor">
+          <label>Lower text (${question.lowerValue})</label>
+          <pr-textarea
+            placeholder="e.g., Strongly disagree"
+            size="small"
+            .value=${question.lowerText ?? ''}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateLowerText}
+          >
+          </pr-textarea>
+        </div>
+        <div class="scale-text-editor">
+          <label>Upper text (${question.upperValue})</label>
+          <pr-textarea
+            placeholder="e.g., Strongly agree"
+            size="small"
+            .value=${question.upperText ?? ''}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateUpperText}
+          >
+          </pr-textarea>
+        </div>
       </div>
       <div class="description">
         <b>Optional:</b> Display the scale as a slider instead of radio buttons.

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -402,6 +402,11 @@ export class SurveyEditor extends MobxLitElement {
       this.updateQuestion({...question, upperValue}, index);
     };
 
+    const updateStepSize = (e: InputEvent) => {
+      const stepSize = parseInt((e.target as HTMLInputElement).value, 10) || 1;
+      this.updateQuestion({...question, stepSize}, index);
+    };
+
     const toggleUseSlider = () => {
       const updatedQuestion = {...question, useSlider: !question.useSlider};
       this.updateQuestion(updatedQuestion, index);
@@ -424,6 +429,8 @@ export class SurveyEditor extends MobxLitElement {
             type="number"
             min="0"
             max="100"
+            step="1"
+            required
             .value=${question.lowerValue.toString()}
             ?disabled=${!this.experimentEditor.canEditStages}
             @input=${updateLowerValue}
@@ -433,11 +440,26 @@ export class SurveyEditor extends MobxLitElement {
           <label>Upper value</label>
           <input
             type="number"
-            min="0"
+            min=${(question.lowerValue + 1).toString()}
             max="100"
+            step="1"
+            required
             .value=${question.upperValue.toString()}
             ?disabled=${!this.experimentEditor.canEditStages}
             @input=${updateUpperValue}
+          />
+        </div>
+        <div class="scale-value-editor">
+          <label>Step size</label>
+          <input
+            type="number"
+            min="1"
+            max="10"
+            step="1"
+            required
+            .value=${(question.stepSize ?? 1).toString()}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateStepSize}
           />
         </div>
       </div>

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -380,6 +380,11 @@ export class SurveyEditor extends MobxLitElement {
   }
 
   private renderScaleQuestion(question: ScaleSurveyQuestion, index: number) {
+    const toggleUseSlider = () => {
+      const updatedQuestion = {...question, useSlider: !question.useSlider};
+      this.updateQuestion(updatedQuestion, index);
+    };
+
     return html`
       <div class="header">
         <div class="left">
@@ -387,6 +392,19 @@ export class SurveyEditor extends MobxLitElement {
         </div>
         ${this.renderQuestionNav(question, index)}
       </div>
+      <div class="description">
+        <b>Optional:</b> Display the scale as a slider instead of radio buttons.
+      </div>
+      <label class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${question.useSlider ?? false}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @click=${toggleUseSlider}
+        >
+        </md-checkbox>
+        <span class="checkbox-label">Use slider</span>
+      </label>
     `;
   }
 

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -513,7 +513,7 @@ export class SurveyEditor extends MobxLitElement {
       <label class="checkbox-wrapper">
         <md-checkbox
           touch-target="wrapper"
-          ?checked=${question.useSlider ?? false}
+          ?checked=${question.useSlider}
           ?disabled=${!this.experimentEditor.canEditStages}
           @click=${toggleUseSlider}
         >

--- a/frontend/src/components/stages/survey_per_participant_view.ts
+++ b/frontend/src/components/stages/survey_per_participant_view.ts
@@ -404,9 +404,7 @@ export class SurveyView extends MobxLitElement {
         ${this.renderParticipant(participant)}
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
@@ -459,9 +457,7 @@ export class SurveyView extends MobxLitElement {
         ${this.renderParticipant(participant)}
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale slider">

--- a/frontend/src/components/stages/survey_per_participant_view.ts
+++ b/frontend/src/components/stages/survey_per_participant_view.ts
@@ -6,6 +6,7 @@ import './stage_description';
 import './stage_footer';
 
 import '@material/web/radio/radio.js';
+import '@material/web/slider/slider.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -387,21 +388,104 @@ export class SurveyView extends MobxLitElement {
     question: ScaleSurveyQuestion,
     participant: ParticipantProfile,
   ) {
-    const scale = [...Array(question.upperValue + 1).keys()].slice(
-      question.lowerValue,
-    );
+    const stepSize = question.stepSize ?? 1;
+    const scale = [];
+    for (let i = question.lowerValue; i <= question.upperValue; i += stepSize) {
+      scale.push(i);
+    }
+
+    if (question.useSlider) {
+      return this.renderScaleSlider(question, participant);
+    }
+
     return html`
       <div class="question">
         <div class="question-title">${question.questionTitle}</div>
         ${this.renderParticipant(participant)}
-        <div class="scale labels">
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
           <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
           ${scale.map((num) =>
             this.renderScaleRadioButton(question, num, participant.publicId),
           )}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderScaleSlider(
+    question: ScaleSurveyQuestion,
+    participant: ParticipantProfile,
+  ) {
+    const getCurrentValue = () => {
+      if (!this.stage) return question.lowerValue;
+      const answer =
+        this.participantAnswerService.getSurveyPerParticipantAnswer(
+          this.stage.id,
+          question.id,
+          participant.publicId,
+        );
+      if (answer && answer.kind === SurveyQuestionKind.SCALE) {
+        return answer.value;
+      }
+      return question.lowerValue;
+    };
+
+    const handleSliderChange = (e: Event) => {
+      const value = Number((e.target as HTMLInputElement).value);
+      const answer: ScaleSurveyAnswer = {
+        id: question.id,
+        kind: SurveyQuestionKind.SCALE,
+        value,
+      };
+
+      // Update per participant answer
+      if (!this.stage) return;
+      this.participantAnswerService.updateSurveyPerParticipantAnswer(
+        this.stage.id,
+        answer,
+        participant.publicId,
+      );
+    };
+
+    return html`
+      <div class="question">
+        <div class="question-title">${question.questionTitle}</div>
+        ${this.renderParticipant(participant)}
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
+          <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
+          <div>${question.upperText}</div>
+        </div>
+        <div class="scale slider">
+          <md-slider
+            min=${question.lowerValue}
+            max=${question.upperValue}
+            step=${question.stepSize ?? 1}
+            value=${getCurrentValue()}
+            ticks
+            labeled
+            ?disabled=${this.participantService.disableStage}
+            @input=${handleSliderChange}
+          >
+          </md-slider>
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/survey_per_participant_view.ts
+++ b/frontend/src/components/stages/survey_per_participant_view.ts
@@ -402,12 +402,7 @@ export class SurveyView extends MobxLitElement {
       <div class="question">
         <div class="question-title">${question.questionTitle}</div>
         ${this.renderParticipant(participant)}
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`
@@ -462,12 +457,7 @@ export class SurveyView extends MobxLitElement {
       <div class="question">
         <div class="question-title">${question.questionTitle}</div>
         ${this.renderParticipant(participant)}
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`

--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -223,9 +223,7 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
@@ -264,9 +262,7 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale slider">

--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -1,4 +1,5 @@
 import '@material/web/radio/radio.js';
+import '@material/web/slider/slider.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -102,7 +103,7 @@ export class SurveyView extends MobxLitElement {
           >
           </md-checkbox>
           <div class=${titleClasses}>
-            ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+            ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
           </div>
         </label>
       </div>
@@ -126,7 +127,7 @@ export class SurveyView extends MobxLitElement {
     return html`
       <div class="question">
         <div class=${titleClasses}>
-          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
         ${textAnswer.trim().length > 0
           ? html`<div>${textAnswer}</div>`
@@ -153,7 +154,7 @@ export class SurveyView extends MobxLitElement {
     return html`
       <div class="radio-question">
         <div class=${titleClasses}>
-          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
         <div class=${questionWrapperClasses}>
           ${question.options.map((option) =>
@@ -196,9 +197,11 @@ export class SurveyView extends MobxLitElement {
   }
 
   private renderScaleQuestion(question: ScaleSurveyQuestion) {
-    const scale = [...Array(question.upperValue + 1).keys()].slice(
-      question.lowerValue,
-    );
+    const stepSize = question.stepSize ?? 1;
+    const scale = [];
+    for (let i = question.lowerValue; i <= question.upperValue; i += stepSize) {
+      scale.push(i);
+    }
 
     const titleClasses = classMap({
       required: !isSurveyAnswerComplete(
@@ -209,10 +212,14 @@ export class SurveyView extends MobxLitElement {
       ),
     });
 
+    if (question.useSlider) {
+      return this.renderScaleSlider(question);
+    }
+
     return html`
       <div class="question">
         <div class=${titleClasses}>
-          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
@@ -220,6 +227,56 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale values">
           ${scale.map((num) => this.renderScaleRadioButton(question, num))}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderScaleSlider(question: ScaleSurveyQuestion) {
+    const titleClasses = classMap({
+      required: !isSurveyAnswerComplete(
+        this.participantAnswerService.getSurveyAnswer(
+          this.stage?.id ?? '',
+          question.id,
+        ),
+      ),
+    });
+
+    const getCurrentValue = () => {
+      if (!this.stage) return question.lowerValue;
+      const answer = this.participantAnswerService.getSurveyAnswer(
+        this.stage.id,
+        question.id,
+      );
+      if (answer && answer.kind === SurveyQuestionKind.SCALE) {
+        return answer.value;
+      }
+      return question.lowerValue;
+    };
+
+    return html`
+      <div class="question">
+        <div class=${titleClasses}>
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
+        </div>
+        <div class="scale labels">
+          <div>${question.lowerText}</div>
+          <div>${question.upperText}</div>
+        </div>
+        <div class="scale slider">
+          <md-slider
+            min=${question.lowerValue}
+            max=${question.upperValue}
+            step=${question.stepSize ?? 1}
+            value=${getCurrentValue()}
+            ticks
+            labeled
+            disabled
+          >
+          </md-slider>
+        </div>
+        <div class="slider-selected-value">
+          Selected value: ${getCurrentValue()}
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -221,12 +221,7 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`
@@ -267,12 +262,7 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`

--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -221,8 +221,16 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div class="scale labels">
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
           <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
@@ -259,8 +267,16 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div class="scale labels">
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
           <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
           <div>${question.upperText}</div>
         </div>
         <div class="scale slider">

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -112,6 +112,14 @@
   &.labels {
     @include typescale.label-small;
     justify-content: space-between;
+
+    &.include-middle-label {
+      justify-content: space-between;
+
+      .middle-label {
+        text-align: center;
+      }
+    }
   }
 
   &.slider {

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -123,6 +123,15 @@
   }
 }
 
+.slider-selected-value {
+  @include common.flex-row-align-center;
+  @include typescale.label-medium;
+  color: var(--md-sys-color-primary);
+  font-weight: 500;
+  justify-content: center;
+  margin-top: common.$spacing-small;
+}
+
 .scale-button {
   @include common.flex-column-align-center;
   gap: common.$spacing-small;

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -113,12 +113,8 @@
     @include typescale.label-small;
     justify-content: space-between;
 
-    &.include-middle-label {
-      justify-content: space-between;
-
-      .middle-label {
-        text-align: center;
-      }
+    .middle-label {
+      text-align: center;
     }
   }
 

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -36,7 +36,7 @@
 
 .question {
   @include common.flex-column;
-  gap: common.$spacing-medium; 
+  gap: common.$spacing-medium;
 }
 
 .slider-wrapper {
@@ -112,6 +112,14 @@
   &.labels {
     @include typescale.label-small;
     justify-content: space-between;
+  }
+
+  &.slider {
+    width: 100%;
+
+    md-slider {
+      width: 100%;
+    }
   }
 }
 

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -112,10 +112,6 @@
   &.labels {
     @include typescale.label-small;
     justify-content: space-between;
-
-    .middle-label {
-      text-align: center;
-    }
   }
 
   &.slider {

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -321,8 +321,16 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div class="scale labels">
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
           <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
@@ -371,8 +379,16 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div class="scale labels">
+        <div
+          class="scale labels ${question.middleText &&
+          question.middleText.trim().length > 0
+            ? 'include-middle-label'
+            : ''}"
+        >
           <div>${question.lowerText}</div>
+          ${question.middleText && question.middleText.trim().length > 0
+            ? html`<div class="middle-label">${question.middleText}</div>`
+            : nothing}
           <div>${question.upperText}</div>
         </div>
         <div class="scale slider">

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -5,6 +5,7 @@ import './stage_description';
 import './stage_footer';
 
 import '@material/web/radio/radio.js';
+import '@material/web/slider/slider.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -145,7 +146,7 @@ export class SurveyView extends MobxLitElement {
           >
           </md-checkbox>
           <div class=${titleClasses}>
-            ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+            ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
           </div>
         </label>
       </div>
@@ -183,7 +184,7 @@ export class SurveyView extends MobxLitElement {
     return html`
       <div class="question">
         <div class=${titleClasses}>
-          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
         <pr-textarea
           variant="outlined"
@@ -309,10 +310,14 @@ export class SurveyView extends MobxLitElement {
       ),
     });
 
+    if (question.useSlider) {
+      return this.renderScaleSlider(question);
+    }
+
     return html`
       <div class="question">
         <div class=${titleClasses}>
-          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + "*"))}
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
@@ -320,6 +325,66 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale values">
           ${scale.map((num) => this.renderScaleRadioButton(question, num))}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderScaleSlider(question: ScaleSurveyQuestion) {
+    const titleClasses = classMap({
+      required: !isSurveyAnswerComplete(
+        this.participantAnswerService.getSurveyAnswer(
+          this.stage?.id ?? '',
+          question.id,
+        ),
+      ),
+    });
+    const getCurrentValue = () => {
+      if (!this.stage) return question.lowerValue;
+      const answer = this.participantAnswerService.getSurveyAnswer(
+        this.stage.id,
+        question.id,
+      );
+      if (answer && answer.kind === SurveyQuestionKind.SCALE) {
+        return answer.value;
+      }
+      return question.lowerValue;
+    };
+
+    const handleSliderChange = (e: Event) => {
+      const value = Number((e.target as HTMLInputElement).value);
+      const answer: ScaleSurveyAnswer = {
+        id: question.id,
+        kind: SurveyQuestionKind.SCALE,
+        value,
+      };
+
+      // Update stage answer
+      if (!this.stage) return;
+      this.participantAnswerService.updateSurveyAnswer(this.stage.id, answer);
+    };
+
+    return html`
+      <div class="question">
+        <div class=${titleClasses}>
+          ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
+        </div>
+        <div class="scale labels">
+          <div>${question.lowerText}</div>
+          <div>${question.upperText}</div>
+        </div>
+        <div class="scale slider">
+          <md-slider
+            min=${question.lowerValue}
+            max=${question.upperValue}
+            step="1"
+            value=${getCurrentValue()}
+            ticks
+            labeled
+            ?disabled=${this.participantService.disableStage}
+            @input=${handleSliderChange}
+          >
+          </md-slider>
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -323,9 +323,7 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale values">
@@ -376,9 +374,7 @@ export class SurveyView extends MobxLitElement {
         </div>
         <div class="scale labels">
           <div>${question.lowerText}</div>
-          ${question.middleText && question.middleText.trim().length > 0
-            ? html`<div class="middle-label">${question.middleText}</div>`
-            : nothing}
+          <div>${question.middleText}</div>
           <div>${question.upperText}</div>
         </div>
         <div class="scale slider">

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -297,9 +297,11 @@ export class SurveyView extends MobxLitElement {
   }
 
   private renderScaleQuestion(question: ScaleSurveyQuestion) {
-    const scale = [...Array(question.upperValue + 1).keys()].slice(
-      question.lowerValue,
-    );
+    const stepSize = question.stepSize ?? 1;
+    const scale = [];
+    for (let i = question.lowerValue; i <= question.upperValue; i += stepSize) {
+      scale.push(i);
+    }
 
     const titleClasses = classMap({
       required: !isSurveyAnswerComplete(
@@ -377,7 +379,7 @@ export class SurveyView extends MobxLitElement {
           <md-slider
             min=${question.lowerValue}
             max=${question.upperValue}
-            step="1"
+            step=${question.stepSize ?? 1}
             value=${getCurrentValue()}
             ticks
             labeled

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -321,12 +321,7 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`
@@ -379,12 +374,7 @@ export class SurveyView extends MobxLitElement {
         <div class=${titleClasses}>
           ${unsafeHTML(convertMarkdownToHTML(question.questionTitle + '*'))}
         </div>
-        <div
-          class="scale labels ${question.middleText &&
-          question.middleText.trim().length > 0
-            ? 'include-middle-label'
-            : ''}"
-        >
+        <div class="scale labels">
           <div>${question.lowerText}</div>
           ${question.middleText && question.middleText.trim().length > 0
             ? html`<div class="middle-label">${question.middleText}</div>`

--- a/frontend/src/shared/games/lost_at_sea.ts
+++ b/frontend/src/shared/games/lost_at_sea.ts
@@ -530,7 +530,7 @@ export const COMPREHENSION_CHECK = createComprehensionStage({
           }),
           createMultipleChoiceItem({
             id: 'c',
-            text: "One randomly drawn question from either Part 2 (where your own answers determine your payoff) or Part 3 (where the leaders’ answers determine your payoff).",
+            text: 'One randomly drawn question from either Part 2 (where your own answers determine your payoff) or Part 3 (where the leaders’ answers determine your payoff).',
           }),
         ],
       },
@@ -563,7 +563,6 @@ const LAS_PART_2_INSTRUCTIONS_STAGE = createInfoStage({
   game: StageGame.LAS,
   name: 'Overview of part 2 and 3',
   infoLines: LAS_PART_2_INSTRUCTIONS_INFO_LINES,
-
 });
 
 // ****************************************************************************
@@ -618,7 +617,7 @@ const LAS_PART_2_GROUP_INSTRUCTIONS_INFO_LINES = [
   'After the chat ends, you will have the chance to revise the individual answers you provided in Part 1 of the experiment. You can choose to update your previous answers or to keep them the same.',
   'Please note that Part 1 and Part 2 of the experiment are independent. Changing answers here will not impact the answers you provided in Part 1.',
   '## Election of a group leader for Part 3',
-  'After the chat, and after you’ve had the chance to update your individual answers, you will be asked to elect a group leader who will play a crucial role in Part 3 of the experiment. In Part 3, your group will repeat the same task as in Part 1, but with different pairs of items. The leader’s answers regarding the most important items for survival will determine the team\'s final payoff.',
+  "After the chat, and after you’ve had the chance to update your individual answers, you will be asked to elect a group leader who will play a crucial role in Part 3 of the experiment. In Part 3, your group will repeat the same task as in Part 1, but with different pairs of items. The leader’s answers regarding the most important items for survival will determine the team's final payoff.",
   '## Payment for Parts 2 and 3',
   'Your payment for Parts 2 and 3 includes a fixed fee of £6 and a bonus. The bonus is determined by randomly selecting either Part 2 or Part 3.',
   '* If Part 2 is selected: One question is randomly chosen from Part 2. You earn £2 if your answer is correct, and £0 otherwise.',
@@ -997,7 +996,7 @@ const LAS_PAYOUT_STAGE = createPayoutStage({
 const LAS_FINAL_DESCRIPTION_PRIMARY = `Thank you for participating in this experiment. After completing the final survey, clicking 'End experiment' will redirect you to Prolific.`;
 
 export const LAS_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
-   {
+  {
     id: '0',
     kind: SurveyQuestionKind.TEXT,
     questionTitle:
@@ -1012,8 +1011,11 @@ export const LAS_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
     lowerValue: 0,
     upperText: 'Very satisfied',
     upperValue: 10,
+    middleText: '',
+    useSlider: false,
+    stepSize: 1,
   },
- {
+  {
     id: '2',
     kind: SurveyQuestionKind.TEXT,
     questionTitle:
@@ -1035,6 +1037,9 @@ export const LAS_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
     lowerValue: 0,
     upperText: 'Very willing to take risks',
     upperValue: 10,
+    middleText: '',
+    useSlider: false,
+    stepSize: 1,
   },
   {
     id: '5',
@@ -1045,6 +1050,9 @@ export const LAS_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
     lowerValue: 0,
     upperText: 'Women are better',
     upperValue: 10,
+    middleText: '',
+    useSlider: false,
+    stepSize: 1,
   },
   {
     id: '6',
@@ -1055,6 +1063,9 @@ export const LAS_FINAL_SURVEY_QUESTIONS: SurveyQuestion[] = [
     lowerValue: 0,
     upperText: 'Women are better',
     upperValue: 10,
+    middleText: '',
+    useSlider: false,
+    stepSize: 1,
   },
   {
     id: '7',

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -75,6 +75,7 @@ export interface ScaleSurveyQuestion extends BaseSurveyQuestion {
   lowerValue: number; // min 0
   lowerText: string;
   useSlider?: boolean; // Whether to display as slider instead of radio buttons
+  stepSize?: number; // Step size for the scale (defaults to 1)
 }
 
 export type SurveyQuestion =
@@ -243,6 +244,7 @@ export function createScaleSurveyQuestion(
     lowerValue: config.lowerValue ?? 0,
     lowerText: config.lowerText ?? '',
     useSlider: config.useSlider ?? false,
+    stepSize: config.stepSize ?? 1,
   };
 }
 

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -74,9 +74,9 @@ export interface ScaleSurveyQuestion extends BaseSurveyQuestion {
   upperText: string;
   lowerValue: number; // min 0
   lowerText: string;
-  middleText?: string; // Optional text to display in the center of the scale
-  useSlider?: boolean; // Whether to display as slider instead of radio buttons
-  stepSize?: number; // Step size for the scale (defaults to 1)
+  middleText: string; // Optional text to display in the center of the scale
+  useSlider: boolean; // Whether to display as slider instead of radio buttons
+  stepSize: number; // Step size for the scale (defaults to 1)
 }
 
 export type SurveyQuestion =

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -74,6 +74,7 @@ export interface ScaleSurveyQuestion extends BaseSurveyQuestion {
   upperText: string;
   lowerValue: number; // min 0
   lowerText: string;
+  middleText?: string; // Optional text to display in the center of the scale
   useSlider?: boolean; // Whether to display as slider instead of radio buttons
   stepSize?: number; // Step size for the scale (defaults to 1)
 }
@@ -243,6 +244,7 @@ export function createScaleSurveyQuestion(
     upperText: config.upperText ?? '',
     lowerValue: config.lowerValue ?? 0,
     lowerText: config.lowerText ?? '',
+    middleText: config.middleText ?? '',
     useSlider: config.useSlider ?? false,
     stepSize: config.stepSize ?? 1,
   };

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -74,6 +74,7 @@ export interface ScaleSurveyQuestion extends BaseSurveyQuestion {
   upperText: string;
   lowerValue: number; // min 0
   lowerText: string;
+  useSlider?: boolean; // Whether to display as slider instead of radio buttons
 }
 
 export type SurveyQuestion =
@@ -241,6 +242,7 @@ export function createScaleSurveyQuestion(
     upperText: config.upperText ?? '',
     lowerValue: config.lowerValue ?? 0,
     lowerText: config.lowerText ?? '',
+    useSlider: config.useSlider ?? false,
   };
 }
 


### PR DESCRIPTION
Fixes #545.

* Extends `ScaleSurveyQuestion` to add a slider view. 
    * This renders differently in the UI, otherwise uses the same base features and functions as the scale question. 
* Adds `middleText` option to `ScaleSurveyQuestion`.
* Adds `stepSize` option to `ScaleSurveyQuestion`.
* Adds visual editing of these properties to `survey_editor`.
* Updates `survey_summary_view` and `survey_per_participant_view` to account for slider.
