### PR TITLE
Add Flipcard stage

### DIFF
--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -5,6 +5,7 @@ import '../../pair-components/tooltip';
 import '../experimenter/experimenter_data_editor';
 import '../stages/base_stage_editor';
 import '../stages/chat_editor';
+import '../stages/flipcard_editor';
 import '../stages/ranking_editor';
 import '../stages/info_editor';
 import '../stages/payout_editor';
@@ -431,6 +432,11 @@ export class ExperimentBuilder extends MobxLitElement {
         return html`
           <base-stage-editor .stage=${stage}></base-stage-editor>
           <chat-editor .stage=${stage}></chat-editor>
+        `;
+      case StageKind.FLIPCARD:
+        return html`
+          <base-stage-editor .stage=${stage}></base-stage-editor>
+          <flipcard-editor .stage=${stage}></flipcard-editor>
         `;
       case StageKind.RANKING:
         return html`

--- a/frontend/src/components/experiment_builder/stage_builder_dialog.ts
+++ b/frontend/src/components/experiment_builder/stage_builder_dialog.ts
@@ -18,6 +18,7 @@ import {
   createChatStage,
   createRankingStage,
   createInfoStage,
+  createFlipCardStage,
   createPayoutStage,
   createProfileStage,
   createRevealStage,
@@ -50,6 +51,10 @@ import {
   getTgStageConfigs,
   TG_AGENTS,
 } from '../../shared/games/test_game';
+import {
+  FLIPCARD_GAME_METADATA,
+  getFlipCardGameStageConfigs,
+} from '../../shared/games/flipcard_game';
 
 import {styles} from './stage_builder_dialog.scss';
 
@@ -132,7 +137,8 @@ export class StageBuilderDialog extends MobxLitElement {
       <div class="card-gallery-wrapper">
         ${this.renderLASCard()} ${this.renderLASCard(true)}
         ${this.renderRealityTVCard()} ${this.renderChipNegotiationCard()}
-        ${this.renderSalespersonGameCard()} ${this.renderTestGameCard()}
+        ${this.renderSalespersonGameCard()} ${this.renderFlipCardGameCard()}
+        ${this.renderTestGameCard()}
       </div>
     `;
   }
@@ -143,8 +149,9 @@ export class StageBuilderDialog extends MobxLitElement {
         ${this.renderTOSCard()} ${this.renderInfoCard()}
         ${this.renderTransferCard()} ${this.renderProfileCard()}
         ${this.renderSurveyCard()} ${this.renderSurveyPerParticipantCard()}
-        ${this.renderChatCard()} ${this.renderRankingCard()}
-        ${this.renderRevealCard()} ${this.renderPayoutCard()}
+        ${this.renderChatCard()} ${this.renderFlipCardCard()}
+        ${this.renderRankingCard()} ${this.renderRevealCard()}
+        ${this.renderPayoutCard()}
       </div>
     `;
   }
@@ -292,6 +299,22 @@ export class StageBuilderDialog extends MobxLitElement {
     `;
   }
 
+  private renderFlipCardCard() {
+    const addStage = () => {
+      this.addStage(createFlipCardStage());
+    };
+
+    return html`
+      <div class="card" @click=${addStage}>
+        <div class="title">🔄 FlipCard</div>
+        <div>
+          Present cards that participants can flip to reveal additional
+          information and make selections.
+        </div>
+      </div>
+    `;
+  }
+
   private renderRankingCard() {
     const addStage = () => {
       this.addStage(createRankingStage());
@@ -395,6 +418,21 @@ export class StageBuilderDialog extends MobxLitElement {
         <div>
           Assign participants to different cohorts while they wait in this
           stage.
+        </div>
+      </div>
+    `;
+  }
+
+  private renderFlipCardGameCard() {
+    const addGame = () => {
+      this.addGame(FLIPCARD_GAME_METADATA, getFlipCardGameStageConfigs(), []);
+    };
+
+    return html`
+      <div class="card" @click=${addGame}>
+        <div class="title">🔄 FlipCard Game</div>
+        <div>
+          A demonstration of the FlipCard stage with adventure selection cards.
         </div>
       </div>
     `;

--- a/frontend/src/components/participant_view/participant_view.ts
+++ b/frontend/src/components/participant_view/participant_view.ts
@@ -6,6 +6,7 @@ import '../stages/chat_interface';
 import '../stages/chat_panel';
 import '../stages/chip_participant_view';
 import '../stages/comprehension_participant_view';
+import '../stages/flipcard_view';
 import '../stages/ranking_participant_view';
 import '../stages/info_view';
 import '../stages/payout_participant_view';
@@ -231,6 +232,8 @@ export class ParticipantView extends MobxLitElement {
           <comprehension-participant-view .stage=${stage}>
           </comprehension-participant-view>
         `;
+      case StageKind.FLIPCARD:
+        return html`<flipcard-view .stage=${stage}></flipcard-view>`;
       case StageKind.RANKING:
         return html`
           <ranking-participant-view .stage=${stage} .answer=${answer}>

--- a/frontend/src/components/stages/flipcard_editor.scss
+++ b/frontend/src/components/stages/flipcard_editor.scss
@@ -1,0 +1,147 @@
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+:host {
+  @include common.flex-column;
+  gap: common.$spacing-xl;
+  height: 100%;
+  overflow: auto;
+}
+
+.section {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+  padding: common.$spacing-medium;
+}
+
+.header {
+  @include common.flex-row;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: common.$spacing-small;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.title {
+  @include typescale.title-medium;
+  color: var(--md-sys-color-on-surface);
+}
+
+.settings {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.setting-row {
+  @include common.flex-row;
+  align-items: center;
+  gap: common.$spacing-small;
+}
+
+.checkbox-label {
+  @include common.flex-row;
+  align-items: center;
+  gap: common.$spacing-small;
+  @include typescale.body-medium;
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+}
+
+.cards-section {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+}
+
+.cards-list {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+}
+
+.card-editor {
+  border: 2px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  background: var(--md-sys-color-surface);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: var(--md-sys-color-outline);
+  }
+}
+
+.card-header {
+  @include common.flex-row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: common.$spacing-medium;
+  padding-bottom: common.$spacing-small;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.card-title-label {
+  @include typescale.title-small;
+  color: var(--md-sys-color-on-surface);
+}
+
+.card-fields {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+}
+
+.field {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
+.field-label {
+  @include typescale.label-medium;
+  color: var(--md-sys-color-on-surface);
+
+  &.required::after {
+    content: ' *';
+    color: var(--md-sys-color-error);
+  }
+}
+
+// Responsive design
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: common.$spacing-small;
+  }
+
+  .settings {
+    padding: common.$spacing-small;
+  }
+
+  .card-editor {
+    padding: common.$spacing-small;
+  }
+}
+
+// Focus styles for accessibility
+.card-editor:focus-within {
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 2px rgba(var(--md-sys-color-primary-rgb), 0.2);
+}
+
+// Animation for adding/removing cards
+.card-editor {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/components/stages/flipcard_editor.ts
+++ b/frontend/src/components/stages/flipcard_editor.ts
@@ -1,0 +1,261 @@
+import '../../pair-components/textarea';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/button/text-button.js';
+import '@material/web/checkbox/checkbox.js';
+import '@material/web/icon/icon.js';
+import '@material/web/iconbutton/icon-button.js';
+
+import {core} from '../../core/core';
+import {ExperimentEditor} from '../../services/experiment.editor';
+
+import {
+  FlipCardStageConfig,
+  FlipCard,
+  createFlipCard,
+} from '@deliberation-lab/utils';
+
+import {styles} from './flipcard_editor.scss';
+
+/** FlipCard stage editor for experiment builder. */
+@customElement('flipcard-editor')
+export class FlipCardEditor extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  @property() stage: FlipCardStageConfig | undefined = undefined;
+
+  override render() {
+    if (this.stage === undefined) {
+      return nothing;
+    }
+
+    return html`
+      <div class="section">
+        <div class="header">
+          <div class="title">FlipCard Settings</div>
+        </div>
+
+        ${this.renderSettings()} ${this.renderCardsSection()}
+      </div>
+    `;
+  }
+
+  private renderSettings() {
+    if (!this.stage) return nothing;
+
+    return html`
+      <div class="settings">
+        <div class="setting-row">
+          <label class="checkbox-label">
+            <md-checkbox
+              ?checked=${this.stage.allowMultipleSelections}
+              @change=${this.updateAllowMultipleSelections}
+            ></md-checkbox>
+            Allow multiple selections
+          </label>
+        </div>
+
+        <div class="setting-row">
+          <label class="checkbox-label">
+            <md-checkbox
+              ?checked=${this.stage.requireConfirmation}
+              @change=${this.updateRequireConfirmation}
+            ></md-checkbox>
+            Require confirmation to complete stage
+          </label>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderCardsSection() {
+    if (!this.stage) return nothing;
+
+    return html`
+      <div class="cards-section">
+        <div class="header">
+          <div class="title">Cards (${this.stage.cards.length})</div>
+          <md-filled-button @click=${this.addCard}>
+            <md-icon slot="icon">add</md-icon>
+            Add Card
+          </md-filled-button>
+        </div>
+
+        <div class="cards-list">
+          ${this.stage.cards.map((card, index) =>
+            this.renderCardEditor(card, index),
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderCardEditor(card: FlipCard, index: number) {
+    return html`
+      <div class="card-editor">
+        <div class="card-header">
+          <div class="card-title-label">Card ${index + 1}</div>
+          <md-icon-button @click=${() => this.removeCard(index)}>
+            <md-icon>delete</md-icon>
+          </md-icon-button>
+        </div>
+
+        <div class="card-fields">
+          <div class="field">
+            <label class="field-label">Title*</label>
+            <pr-textarea
+              .value=${card.title}
+              @input=${(e: InputEvent) =>
+                this.updateCardTitle(
+                  index,
+                  (e.target as HTMLTextAreaElement).value,
+                )}
+              placeholder="Enter card title"
+              size="medium"
+              ?disabled=${!this.experimentEditor.canEditStages}
+            ></pr-textarea>
+          </div>
+
+          <div class="field">
+            <label class="field-label">Front Content*</label>
+            <pr-textarea
+              .value=${card.frontContent}
+              @input=${(e: InputEvent) =>
+                this.updateCardFrontContent(
+                  index,
+                  (e.target as HTMLTextAreaElement).value,
+                )}
+              placeholder="Enter content for the front of the card"
+              size="large"
+              ?disabled=${!this.experimentEditor.canEditStages}
+            ></pr-textarea>
+          </div>
+
+          <div class="field">
+            <label class="field-label">Back Content*</label>
+            <pr-textarea
+              .value=${card.backContent}
+              @input=${(e: InputEvent) =>
+                this.updateCardBackContent(
+                  index,
+                  (e.target as HTMLTextAreaElement).value,
+                )}
+              placeholder="Enter additional content for the back of the card"
+              size="large"
+              ?disabled=${!this.experimentEditor.canEditStages}
+            ></pr-textarea>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private updateAllowMultipleSelections(e: Event) {
+    if (!this.stage) return;
+
+    const target = e.target as HTMLInputElement;
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      allowMultipleSelections: target.checked,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateRequireConfirmation(e: Event) {
+    if (!this.stage) return;
+
+    const target = e.target as HTMLInputElement;
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      requireConfirmation: target.checked,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private addCard() {
+    if (!this.stage) return;
+
+    const newCard = createFlipCard();
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      cards: [...this.stage.cards, newCard],
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private removeCard(index: number) {
+    if (!this.stage) return;
+
+    const updatedCards = [...this.stage.cards];
+    updatedCards.splice(index, 1);
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      cards: updatedCards,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateCardTitle(index: number, title: string) {
+    if (!this.stage) return;
+
+    const updatedCards = [...this.stage.cards];
+    updatedCards[index] = {
+      ...updatedCards[index],
+      title,
+    };
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      cards: updatedCards,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateCardFrontContent(index: number, frontContent: string) {
+    if (!this.stage) return;
+
+    const updatedCards = [...this.stage.cards];
+    updatedCards[index] = {
+      ...updatedCards[index],
+      frontContent,
+    };
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      cards: updatedCards,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateCardBackContent(index: number, backContent: string) {
+    if (!this.stage) return;
+
+    const updatedCards = [...this.stage.cards];
+    updatedCards[index] = {
+      ...updatedCards[index],
+      backContent,
+    };
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      cards: updatedCards,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+}

--- a/frontend/src/components/stages/flipcard_editor.ts
+++ b/frontend/src/components/stages/flipcard_editor.ts
@@ -10,6 +10,7 @@ import '@material/web/button/text-button.js';
 import '@material/web/checkbox/checkbox.js';
 import '@material/web/icon/icon.js';
 import '@material/web/iconbutton/icon-button.js';
+import '@material/web/textfield/filled-text-field.js';
 
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
@@ -60,6 +61,20 @@ export class FlipCardEditor extends MobxLitElement {
             ></md-checkbox>
             Enable card selection
           </label>
+        </div>
+
+        <div class="setting-row">
+          <label class="field-label"
+            >Minimum flips required (0 = disabled)</label
+          >
+          <md-filled-text-field
+            type="number"
+            .value=${this.stage.minFlipsRequired.toString()}
+            @input=${this.updateMinFlipsRequired}
+            min="0"
+            max="${this.stage.cards.length}"
+            ?disabled=${!this.experimentEditor.canEditStages}
+          ></md-filled-text-field>
         </div>
 
         ${this.stage.enableSelection
@@ -178,6 +193,22 @@ export class FlipCardEditor extends MobxLitElement {
     const updatedStage: FlipCardStageConfig = {
       ...this.stage,
       enableSelection: target.checked,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateMinFlipsRequired(e: Event) {
+    if (!this.stage) return;
+
+    const target = e.target as HTMLInputElement;
+    const value = parseInt(target.value, 10) || 0;
+    const maxValue = this.stage.cards.length;
+    const minMaxValue = Math.max(0, Math.min(value, maxValue));
+
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      minFlipsRequired: minMaxValue,
     };
 
     this.experimentEditor.updateStage(updatedStage);

--- a/frontend/src/components/stages/flipcard_editor.ts
+++ b/frontend/src/components/stages/flipcard_editor.ts
@@ -77,6 +77,16 @@ export class FlipCardEditor extends MobxLitElement {
           ></md-filled-text-field>
         </div>
 
+        <div class="setting-row">
+          <label class="checkbox-label">
+            <md-checkbox
+              ?checked=${this.stage.shuffleCards}
+              @change=${this.updateShuffleCards}
+            ></md-checkbox>
+            Shuffle card order for each participant
+          </label>
+        </div>
+
         ${this.stage.enableSelection
           ? html`
               <div class="setting-row">
@@ -209,6 +219,18 @@ export class FlipCardEditor extends MobxLitElement {
     const updatedStage: FlipCardStageConfig = {
       ...this.stage,
       minFlipsRequired: minMaxValue,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
+  }
+
+  private updateShuffleCards(e: Event) {
+    if (!this.stage) return;
+
+    const target = e.target as HTMLInputElement;
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      shuffleCards: target.checked,
     };
 
     this.experimentEditor.updateStage(updatedStage);

--- a/frontend/src/components/stages/flipcard_editor.ts
+++ b/frontend/src/components/stages/flipcard_editor.ts
@@ -55,22 +55,36 @@ export class FlipCardEditor extends MobxLitElement {
         <div class="setting-row">
           <label class="checkbox-label">
             <md-checkbox
-              ?checked=${this.stage.allowMultipleSelections}
-              @change=${this.updateAllowMultipleSelections}
+              ?checked=${this.stage.enableSelection}
+              @change=${this.updateEnableSelection}
             ></md-checkbox>
-            Allow multiple selections
+            Enable card selection
           </label>
         </div>
 
-        <div class="setting-row">
-          <label class="checkbox-label">
-            <md-checkbox
-              ?checked=${this.stage.requireConfirmation}
-              @change=${this.updateRequireConfirmation}
-            ></md-checkbox>
-            Require confirmation to complete stage
-          </label>
-        </div>
+        ${this.stage.enableSelection
+          ? html`
+              <div class="setting-row">
+                <label class="checkbox-label">
+                  <md-checkbox
+                    ?checked=${this.stage.allowMultipleSelections}
+                    @change=${this.updateAllowMultipleSelections}
+                  ></md-checkbox>
+                  Allow multiple selections
+                </label>
+              </div>
+
+              <div class="setting-row">
+                <label class="checkbox-label">
+                  <md-checkbox
+                    ?checked=${this.stage.requireConfirmation}
+                    @change=${this.updateRequireConfirmation}
+                  ></md-checkbox>
+                  Require confirmation to complete stage
+                </label>
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -155,6 +169,18 @@ export class FlipCardEditor extends MobxLitElement {
         </div>
       </div>
     `;
+  }
+
+  private updateEnableSelection(e: Event) {
+    if (!this.stage) return;
+
+    const target = e.target as HTMLInputElement;
+    const updatedStage: FlipCardStageConfig = {
+      ...this.stage,
+      enableSelection: target.checked,
+    };
+
+    this.experimentEditor.updateStage(updatedStage);
   }
 
   private updateAllowMultipleSelections(e: Event) {

--- a/frontend/src/components/stages/flipcard_view.scss
+++ b/frontend/src/components/stages/flipcard_view.scss
@@ -94,6 +94,10 @@
   text-align: left;
 }
 
+.card-front .card-content {
+  text-align: center;
+}
+
 .card-buttons {
   @include common.flex-row;
   gap: common.$spacing-small;

--- a/frontend/src/components/stages/flipcard_view.scss
+++ b/frontend/src/components/stages/flipcard_view.scss
@@ -1,0 +1,179 @@
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+:host {
+  @include common.flex-column;
+  gap: common.$spacing-xl;
+  height: 100%;
+  overflow: auto;
+}
+
+.stage-container {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+  padding: common.$main-content-padding;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: common.$spacing-large;
+  margin: common.$spacing-large 0;
+}
+
+.card-container {
+  perspective: 1000px;
+  height: 280px;
+  position: relative;
+
+  &.disabled {
+    opacity: 0.7;
+    pointer-events: none;
+  }
+}
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+
+  .card-container.flipped & {
+    transform: rotateY(180deg);
+  }
+}
+
+.card-front,
+.card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border: 2px solid var(--md-sys-color-outline);
+  border-radius: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  background: var(--md-sys-color-surface);
+  @include common.flex-column;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+}
+
+.card-front {
+  z-index: 2;
+}
+
+.card-back {
+  transform: rotateY(180deg);
+}
+
+.card-container.selected {
+  .card-front,
+  .card-back {
+    border-color: var(--md-sys-color-primary);
+    border-width: 4px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  }
+}
+
+.card-title {
+  @include typescale.label-large;
+  color: var(--md-sys-color-on-surface);
+  margin: 0 0 common.$spacing-medium 0;
+  padding-bottom: common.$spacing-small;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.card-content {
+  flex: 1;
+  color: var(--md-sys-color-on-surface-variant);
+  line-height: 1.5;
+  margin-bottom: common.$spacing-medium;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.card-buttons {
+  @include common.flex-row;
+  gap: common.$spacing-small;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}
+
+.actions {
+  @include common.flex-column;
+  align-items: center;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-large;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.selection-info {
+  @include typescale.body-large;
+  color: var(--md-sys-color-on-surface);
+  padding: common.$spacing-medium;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.action-buttons {
+  @include common.flex-row;
+  gap: common.$spacing-medium;
+}
+
+// Responsive design for smaller screens
+@media (max-width: 768px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+    gap: common.$spacing-medium;
+  }
+
+  .card-container {
+    height: 240px;
+  }
+
+  .card-buttons {
+    flex-direction: column;
+    gap: common.$spacing-small;
+  }
+}
+
+// Hover effects for non-touch devices
+@media (hover: hover) {
+  .card-container:not(.disabled):not(.flipped) .card-inner:hover {
+    transform: translateY(-4px);
+  }
+
+  .card-container.selected:not(.disabled) .card-inner:hover {
+    transform: translateY(-4px);
+  }
+
+  .card-container.flipped:not(.disabled) .card-inner:hover {
+    transform: rotateY(180deg) translateY(-4px);
+  }
+}
+
+// Animation for selection state
+.card-container.selected {
+  animation: selectPulse 0.5s ease-in-out;
+}
+
+@keyframes selectPulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+// Remove focus outline from card container when buttons are clicked
+.card-container:focus-within {
+  outline: none;
+}

--- a/frontend/src/components/stages/flipcard_view.ts
+++ b/frontend/src/components/stages/flipcard_view.ts
@@ -1,0 +1,242 @@
+import '../progress/progress_stage_completed';
+import './stage_description';
+import './stage_footer';
+
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/button/text-button.js';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
+
+import {
+  FlipCardStageConfig,
+  FlipCard,
+  FlipCardStageParticipantAnswer,
+  createFlipCardStageParticipantAnswer,
+  FlipAction,
+} from '@deliberation-lab/utils';
+
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant.service';
+import {ParticipantAnswerService} from '../../services/participant.answer';
+
+import {styles} from './flipcard_view.scss';
+
+/** FlipCard stage view for participants */
+@customElement('flipcard-view')
+export class FlipCardView extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly participantService = core.getService(ParticipantService);
+  private readonly participantAnswerService = core.getService(
+    ParticipantAnswerService,
+  );
+
+  @property({type: Object}) stage!: FlipCardStageConfig;
+
+  override render() {
+    if (!this.stage || !this.participantService.profile) {
+      return nothing;
+    }
+
+    const answer = this.getParticipantAnswer();
+    const isComplete = answer.confirmed;
+
+    return html`
+      <div class="stage-container">
+        <stage-description .stage=${this.stage}></stage-description>
+
+        <div class="cards-grid">
+          ${this.stage.cards.map((card) => this.renderCard(card, answer))}
+        </div>
+
+        <div class="actions">
+          ${this.renderSelectionInfo(answer)}
+          ${this.renderActionButtons(answer)}
+        </div>
+
+        ${isComplete
+          ? html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
+        <stage-footer .stage=${this.stage}></stage-footer>
+      </div>
+    `;
+  }
+
+  private renderCard(card: FlipCard, answer: FlipCardStageParticipantAnswer) {
+    const isFlipped = answer.flippedCardIds.includes(card.id);
+    const isSelected = answer.selectedCardIds.includes(card.id);
+    const isConfirmed = answer.confirmed;
+
+    const cardClasses = {
+      card: true,
+      flipped: isFlipped,
+      selected: isSelected,
+      disabled: isConfirmed,
+    };
+
+    return html`
+      <div class="card-container ${classMap(cardClasses)}">
+        <div class="card-inner">
+          <!-- Front of card -->
+          <div class="card-front">
+            <h3 class="card-title">${card.title}</h3>
+            <div class="card-content">${card.frontContent}</div>
+            <div class="card-buttons">
+              <md-text-button
+                @click=${() => this.flipCard(card.id, 'flip_to_back')}
+                ?disabled=${isConfirmed}
+              >
+                Learn More
+              </md-text-button>
+              <md-filled-button
+                @click=${() => this.selectCard(card.id)}
+                ?disabled=${isConfirmed}
+              >
+                Select
+              </md-filled-button>
+            </div>
+          </div>
+
+          <!-- Back of card -->
+          <div class="card-back">
+            <h3 class="card-title">${card.title}</h3>
+            <div class="card-content">${card.backContent}</div>
+            <div class="card-buttons">
+              <md-outlined-button
+                @click=${() => this.flipCard(card.id, 'flip_to_front')}
+                ?disabled=${isConfirmed}
+              >
+                Back
+              </md-outlined-button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSelectionInfo(answer: FlipCardStageParticipantAnswer) {
+    if (answer.selectedCardIds.length === 0) {
+      return nothing;
+    }
+
+    const selectedCard = this.stage.cards.find((card) =>
+      answer.selectedCardIds.includes(card.id),
+    );
+    if (!selectedCard) return nothing;
+
+    return html`
+      <div class="selection-info">
+        <strong>Selected:</strong> ${selectedCard.title}
+      </div>
+    `;
+  }
+
+  private renderActionButtons(answer: FlipCardStageParticipantAnswer) {
+    if (answer.confirmed) {
+      return html`
+        <div class="action-buttons">
+          <md-filled-button disabled>Selection Confirmed</md-filled-button>
+        </div>
+      `;
+    }
+
+    if (answer.selectedCardIds.length === 0) {
+      return nothing;
+    }
+
+    return html`
+      <div class="action-buttons">
+        <md-filled-button @click=${this.confirmSelection}>
+          Confirm Selection
+        </md-filled-button>
+      </div>
+    `;
+  }
+
+  private flipCard(cardId: string, action: 'flip_to_back' | 'flip_to_front') {
+    const answer = this.getParticipantAnswer();
+    if (answer.confirmed) return;
+
+    const flipAction: FlipAction = {
+      cardId,
+      action,
+      timestamp: new Date().toISOString(),
+    };
+
+    const updatedFlippedIds = [...answer.flippedCardIds];
+    if (action === 'flip_to_back' && !updatedFlippedIds.includes(cardId)) {
+      updatedFlippedIds.push(cardId);
+    } else if (action === 'flip_to_front') {
+      const index = updatedFlippedIds.indexOf(cardId);
+      if (index > -1) {
+        updatedFlippedIds.splice(index, 1);
+      }
+    }
+
+    const updatedAnswer: FlipCardStageParticipantAnswer = {
+      ...answer,
+      flippedCardIds: updatedFlippedIds,
+      flipHistory: [...answer.flipHistory, flipAction],
+    };
+
+    this.participantAnswerService.addAnswer(this.stage.id, updatedAnswer);
+  }
+
+  private selectCard(cardId: string) {
+    const answer = this.getParticipantAnswer();
+    if (answer.confirmed) return;
+
+    let updatedSelectedIds: string[];
+    if (this.stage.allowMultipleSelections) {
+      updatedSelectedIds = answer.selectedCardIds.includes(cardId)
+        ? answer.selectedCardIds.filter((id) => id !== cardId)
+        : [...answer.selectedCardIds, cardId];
+    } else {
+      updatedSelectedIds = [cardId];
+    }
+
+    const updatedAnswer: FlipCardStageParticipantAnswer = {
+      ...answer,
+      selectedCardIds: updatedSelectedIds,
+    };
+
+    this.participantAnswerService.addAnswer(this.stage.id, updatedAnswer);
+  }
+
+  private async confirmSelection() {
+    const answer = this.getParticipantAnswer();
+    if (answer.selectedCardIds.length === 0) return;
+
+    const updatedAnswer: FlipCardStageParticipantAnswer = {
+      ...answer,
+      confirmed: true,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.participantAnswerService.addAnswer(this.stage.id, updatedAnswer);
+
+    // Save to Firebase
+    await this.participantAnswerService.saveFlipCardAnswers(this.stage.id);
+  }
+
+  private getParticipantAnswer(): FlipCardStageParticipantAnswer {
+    const existingAnswer =
+      this.participantAnswerService.answerMap[this.stage.id];
+
+    if (existingAnswer?.kind === 'flipcard') {
+      return existingAnswer as FlipCardStageParticipantAnswer;
+    }
+
+    // Only create and add a new answer if one doesn't exist
+    const newAnswer = createFlipCardStageParticipantAnswer(this.stage.id);
+    this.participantAnswerService.addAnswer(this.stage.id, newAnswer);
+    return this.participantAnswerService.answerMap[
+      this.stage.id
+    ] as FlipCardStageParticipantAnswer;
+  }
+}

--- a/frontend/src/components/stages/flipcard_view.ts
+++ b/frontend/src/components/stages/flipcard_view.ts
@@ -53,11 +53,14 @@ export class FlipCardView extends MobxLitElement {
           ${this.stage.cards.map((card) => this.renderCard(card, answer))}
         </div>
 
-        <div class="actions">
-          ${this.renderSelectionInfo(answer)}
-          ${this.renderActionButtons(answer)}
-        </div>
-
+        ${this.stage.enableSelection
+          ? html`
+              <div class="actions">
+                ${this.renderSelectionInfo(answer)}
+                ${this.renderActionButtons(answer)}
+              </div>
+            `
+          : nothing}
         ${isComplete
           ? html`<progress-stage-completed></progress-stage-completed>`
           : nothing}
@@ -92,12 +95,16 @@ export class FlipCardView extends MobxLitElement {
               >
                 Learn More
               </md-text-button>
-              <md-filled-button
-                @click=${() => this.selectCard(card.id)}
-                ?disabled=${isConfirmed}
-              >
-                Select
-              </md-filled-button>
+              ${this.stage.enableSelection
+                ? html`
+                    <md-filled-button
+                      @click=${() => this.selectCard(card.id)}
+                      ?disabled=${isConfirmed}
+                    >
+                      Select
+                    </md-filled-button>
+                  `
+                : nothing}
             </div>
           </div>
 

--- a/frontend/src/components/stages/flipcard_view.ts
+++ b/frontend/src/components/stages/flipcard_view.ts
@@ -18,6 +18,8 @@ import {
   FlipCardStageParticipantAnswer,
   createFlipCardStageParticipantAnswer,
   FlipAction,
+  seed,
+  choices,
 } from '@deliberation-lab/utils';
 
 import {core} from '../../core/core';
@@ -52,7 +54,9 @@ export class FlipCardView extends MobxLitElement {
         <stage-description .stage=${this.stage}></stage-description>
 
         <div class="cards-grid">
-          ${this.stage.cards.map((card) => this.renderCard(card, answer))}
+          ${this.getDisplayCards().map((card: FlipCard) =>
+            this.renderCard(card, answer),
+          )}
         </div>
 
         ${this.stage.enableSelection
@@ -278,6 +282,22 @@ export class FlipCardView extends MobxLitElement {
     } else {
       return this.canProceedWithMinFlips(answer);
     }
+  }
+
+  private getDisplayCards(): FlipCard[] {
+    if (!this.stage.shuffleCards) {
+      return this.stage.cards;
+    }
+
+    // Use participant ID as seed for consistent shuffling
+    const participantId = this.participantService.profile?.privateId || '';
+    let seedValue = 0;
+    for (let i = 0; i < participantId.length; i++) {
+      seedValue += participantId.charCodeAt(i);
+    }
+
+    seed(seedValue);
+    return choices(this.stage.cards, this.stage.cards.length);
   }
 
   private saveAndProgress = async () => {

--- a/frontend/src/components/stages/flipcard_view.ts
+++ b/frontend/src/components/stages/flipcard_view.ts
@@ -10,6 +10,7 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import {
   FlipCardStageConfig,
@@ -22,6 +23,7 @@ import {
 import {core} from '../../core/core';
 import {ParticipantService} from '../../services/participant.service';
 import {ParticipantAnswerService} from '../../services/participant.answer';
+import {convertMarkdownToHTML} from '../../shared/utils';
 
 import {styles} from './flipcard_view.scss';
 
@@ -92,7 +94,9 @@ export class FlipCardView extends MobxLitElement {
           <!-- Front of card -->
           <div class="card-front">
             <h3 class="card-title">${card.title}</h3>
-            <div class="card-content">${card.frontContent}</div>
+            <div class="card-content">
+              ${unsafeHTML(convertMarkdownToHTML(card.frontContent))}
+            </div>
             <div class="card-buttons">
               <md-text-button
                 @click=${() => this.flipCard(card.id, 'flip_to_back')}
@@ -117,7 +121,9 @@ export class FlipCardView extends MobxLitElement {
           <!-- Back of card -->
           <div class="card-back">
             <h3 class="card-title">${card.title}</h3>
-            <div class="card-content">${card.backContent}</div>
+            <div class="card-content">
+              ${unsafeHTML(convertMarkdownToHTML(card.backContent))}
+            </div>
             <div class="card-buttons">
               <md-outlined-button
                 @click=${() => this.flipCard(card.id, 'flip_to_front')}

--- a/frontend/src/services/participant.answer.ts
+++ b/frontend/src/services/participant.answer.ts
@@ -253,6 +253,15 @@ export class ParticipantAnswerService extends Service {
     );
   }
 
+  async saveFlipCardAnswers(stageId: string) {
+    const answer = this.answerMap[stageId];
+    if (!answer || answer.kind !== StageKind.FLIPCARD) return;
+    await this.sp.participantService.updateFlipCardStageParticipantAnswer(
+      stageId,
+      answer,
+    );
+  }
+
   async saveSurveyPerParticipantAnswers(stageId: string) {
     const answer = this.answerMap[stageId];
     if (!answer || answer.kind !== StageKind.SURVEY_PER_PARTICIPANT) return;

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -3,6 +3,7 @@ import {
   ChatStageParticipantAnswer,
   ChipOffer,
   CreateChatMessageData,
+  FlipCardStageParticipantAnswer,
   RankingItem,
   ParticipantProfileBase,
   ParticipantProfileExtended,
@@ -53,6 +54,7 @@ import {
   updateParticipantToNextStageCallable,
   updateParticipantWaitingCallable,
   updateChatStageParticipantAnswerCallable,
+  updateFlipCardStageParticipantAnswerCallable,
   updateSurveyPerParticipantStageParticipantAnswerCallable,
   updateSurveyStageParticipantAnswerCallable,
   updateRankingStageParticipantAnswerCallable,
@@ -580,6 +582,31 @@ export class ParticipantService extends Service {
   }
 
   /** Update participant survey answerMap. */
+  async updateFlipCardStageParticipantAnswer(
+    id: string, // flipcard stage ID
+    answer: FlipCardStageParticipantAnswer, // flipcard answer
+  ) {
+    let response = {};
+
+    // Update local answer map
+    this.answerMap[id] = answer;
+
+    if (this.experimentId && this.profile) {
+      response = await updateFlipCardStageParticipantAnswerCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          cohortId: this.profile.currentCohortId,
+          participantPrivateId: this.profile.privateId,
+          participantPublicId: this.profile.publicId,
+          flipCardStageParticipantAnswer: answer,
+        },
+      );
+    }
+
+    return response;
+  }
+
   async updateSurveyStageParticipantAnswerMap(
     id: string, // survey stage ID,
     answerMap: Record<string, SurveyAnswer>, // map of question ID to answer

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -27,6 +27,7 @@ import {
   SuccessResponse,
   UpdateChatStageParticipantAnswerData,
   UpdateCohortMetadataData,
+  UpdateFlipCardStageParticipantAnswerData,
   UpdateMediatorStatusData,
   UpdateParticipantAcceptedTOSData,
   UpdateParticipantFailureData,
@@ -301,6 +302,21 @@ export const updateChatStageParticipantAnswerCallable = async (
   >(
     functions,
     'updateChatStageParticipantAnswer',
+  )(config);
+  return data;
+};
+
+/** Generic endpoint to update flipcard stage participant answers */
+export const updateFlipCardStageParticipantAnswerCallable = async (
+  functions: Functions,
+  config: UpdateFlipCardStageParticipantAnswerData,
+) => {
+  const {data} = await httpsCallable<
+    UpdateFlipCardStageParticipantAnswerData,
+    SuccessResponse
+  >(
+    functions,
+    'updateFlipCardStageParticipantAnswer',
   )(config);
   return data;
 };

--- a/frontend/src/shared/games/flipcard_game.ts
+++ b/frontend/src/shared/games/flipcard_game.ts
@@ -1,0 +1,126 @@
+import {
+  createFlipCardStage,
+  createFlipCard,
+  createInfoStage,
+  createMetadataConfig,
+  createProfileStage,
+  createStageTextConfig,
+  createTOSStage,
+  ProfileType,
+  StageConfig,
+  StageGame,
+} from '@deliberation-lab/utils';
+
+export const FLIPCARD_GAME_METADATA = createMetadataConfig({
+  name: 'FlipCard Game',
+  publicName: 'Card Selection Game',
+  description: 'A demonstration game using the FlipCard stage functionality',
+});
+
+export function getFlipCardGameStageConfigs(): StageConfig[] {
+  const stages: StageConfig[] = [];
+
+  stages.push(FLIPCARD_TOS_STAGE);
+  stages.push(FLIPCARD_PROFILE_STAGE);
+  stages.push(FLIPCARD_INTRO_STAGE);
+  stages.push(FLIPCARD_MAIN_STAGE);
+
+  return stages;
+}
+
+const FLIPCARD_CONSENT =
+  'You must agree to participate in this FlipCard demonstration.';
+
+const FLIPCARD_TOS_STAGE = createTOSStage({
+  id: 'flipcard_tos',
+  game: StageGame.NONE,
+  name: 'Consent',
+  tosLines: FLIPCARD_CONSENT.split('\n'),
+});
+
+const FLIPCARD_PROFILE_STAGE = createProfileStage({
+  id: 'flipcard_profile',
+  name: 'Your identity',
+  descriptions: createStageTextConfig({
+    primaryText:
+      "This is how you'll be identified during the card selection game. Click 'Next stage' below to continue.",
+  }),
+  game: StageGame.NONE,
+  profileType: ProfileType.ANONYMOUS_ANIMAL,
+});
+
+const FLIPCARD_INTRO_TEXT = `
+Welcome to the FlipCard demonstration!
+
+In the next stage, you'll see a collection of cards representing different options. Each card has:
+- A title and brief description on the front
+- Additional detailed information on the back (click "Learn More" to flip)
+- A "Select" button to choose that option
+
+Take your time to explore the cards by flipping them over to read more details. Once you've found the option that interests you most, select it and confirm your choice to continue.
+`;
+
+const FLIPCARD_INTRO_STAGE = createInfoStage({
+  id: 'flipcard_intro',
+  name: 'FlipCard Instructions',
+  infoLines: FLIPCARD_INTRO_TEXT.trim().split('\n'),
+});
+
+const FLIPCARD_MAIN_STAGE = createFlipCardStage({
+  id: 'flipcard_main',
+  name: 'Choose Your Adventure',
+  descriptions: createStageTextConfig({
+    primaryText:
+      'Browse the adventure options below and select the one that interests you most.',
+    infoText:
+      'Click "Learn More" to flip a card and see additional details. Click "Select" to choose an option, then "Confirm Selection" to proceed.',
+    helpText:
+      'Use the "Learn More" button to view the back of cards with detailed information. Select the adventure that appeals to you and confirm your choice.',
+  }),
+  cards: [
+    createFlipCard({
+      title: 'Mountain Expedition',
+      frontContent:
+        'Join a thrilling mountain climbing adventure with experienced guides.',
+      backContent:
+        'This 5-day expedition includes professional climbing instruction, all necessary equipment, camping under the stars, and breathtaking summit views. Perfect for those seeking physical challenge and natural beauty. Difficulty level: Intermediate to Advanced.',
+    }),
+    createFlipCard({
+      title: 'Ocean Discovery',
+      frontContent:
+        'Explore the mysteries of the deep sea through scuba diving and marine research.',
+      backContent:
+        "Spend 7 days learning about marine ecosystems while diving in pristine coral reefs. You'll assist marine biologists with research, learn underwater photography, and discover rare sea creatures. All diving certification and equipment provided. Difficulty level: Beginner to Intermediate.",
+    }),
+    createFlipCard({
+      title: 'Cultural Immersion',
+      frontContent:
+        'Experience authentic local culture through traditional crafts, cuisine, and customs.',
+      backContent:
+        'Live with local families for 10 days while learning traditional cooking, handicrafts, and participating in cultural ceremonies. This experience focuses on meaningful connections, language learning, and understanding different ways of life. Perfect for culturally curious travelers. Difficulty level: Easy.',
+    }),
+    createFlipCard({
+      title: 'Space Simulation',
+      frontContent:
+        'Participate in a realistic space mission simulation at a cutting-edge facility.',
+      backContent:
+        "Experience life as an astronaut during this 3-day intensive program. You'll train on simulators, learn about space exploration, work with real NASA equipment, and complete mission scenarios. Includes zero-gravity simulation and space suit fitting. Difficulty level: Intermediate.",
+    }),
+    createFlipCard({
+      title: 'Wildlife Conservation',
+      frontContent:
+        'Contribute to wildlife protection efforts while observing animals in their natural habitat.',
+      backContent:
+        "Work alongside conservationists for 14 days protecting endangered species. Activities include animal tracking, habitat restoration, data collection, and wildlife photography. You'll learn about conservation science while making a real impact. Accommodation in research stations. Difficulty level: Easy to Intermediate.",
+    }),
+    createFlipCard({
+      title: 'Ancient Archaeology',
+      frontContent:
+        'Uncover historical treasures by participating in an active archaeological dig.',
+      backContent:
+        "Join professional archaeologists for 8 days excavating an ancient site. Learn proper excavation techniques, artifact identification, and historical analysis. You'll participate in actual discoveries that contribute to our understanding of past civilizations. Includes lectures on archaeological methods. Difficulty level: Easy to Intermediate.",
+    }),
+  ],
+  allowMultipleSelections: false,
+  requireConfirmation: true,
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,6 +13,7 @@ export * from './participant.endpoints';
 
 export * from './stages/chat.endpoints';
 export * from './stages/chip.endpoints';
+export * from './stages/flipcard.endpoints';
 
 export * from './stages/ranking.endpoints';
 export * from './stages/salesperson.endpoints';

--- a/functions/src/stages/flipcard.endpoints.ts
+++ b/functions/src/stages/flipcard.endpoints.ts
@@ -1,0 +1,156 @@
+import {Value} from '@sinclair/typebox/value';
+import {
+  FlipCardStageParticipantAnswer,
+  FlipCardStagePublicData,
+} from '@deliberation-lab/utils';
+
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {onCall} from 'firebase-functions/v2/https';
+
+import {app} from '../app';
+
+/** Endpoints for FlipCard stage operations. */
+
+// ************************************************************************* //
+// updateFlipCardStageParticipantAnswer endpoint                            //
+//                                                                           //
+// Updates participant's FlipCard answer and public data                    //
+// ************************************************************************* //
+
+export const updateFlipCardStageParticipantAnswer = onCall(async (request) => {
+  const {data} = request;
+
+  try {
+    // Extract required fields
+    const {
+      experimentId,
+      cohortId,
+      participantPrivateId,
+      participantPublicId,
+      flipCardStageParticipantAnswer,
+    } = data;
+
+    if (
+      !experimentId ||
+      !cohortId ||
+      !participantPrivateId ||
+      !participantPublicId ||
+      !flipCardStageParticipantAnswer
+    ) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'Missing required fields',
+      );
+    }
+
+    // Define participant answer document reference
+    const participantDocument = app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('participants')
+      .doc(participantPrivateId)
+      .collection('stageData')
+      .doc(flipCardStageParticipantAnswer.id);
+
+    // Define public stage document reference
+    const publicDocument = app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('cohorts')
+      .doc(cohortId)
+      .collection('publicStageData')
+      .doc(flipCardStageParticipantAnswer.id);
+
+    // Update participant answer and public data in a transaction
+    await app.firestore().runTransaction(async (transaction) => {
+      // Read current public data first (all reads must come before writes)
+      const publicDoc = await transaction.get(publicDocument);
+      const publicData = publicDoc.data() as
+        | FlipCardStagePublicData
+        | undefined;
+
+      // Update participant's answer
+      transaction.set(participantDocument, {
+        ...flipCardStageParticipantAnswer,
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      if (publicData) {
+        // Update public data with participant's flip history and selections
+        const updatedPublicData: FlipCardStagePublicData = {
+          ...publicData,
+          participantFlipHistory: {
+            ...publicData.participantFlipHistory,
+            [participantPublicId]: flipCardStageParticipantAnswer.flipHistory,
+          },
+          participantSelections: {
+            ...publicData.participantSelections,
+            [participantPublicId]:
+              flipCardStageParticipantAnswer.selectedCardIds,
+          },
+        };
+
+        transaction.set(publicDocument, updatedPublicData);
+      }
+    });
+
+    return {success: true};
+  } catch (error) {
+    console.error('Error updating FlipCard stage participant answer:', error);
+    throw new functions.https.HttpsError(
+      'internal',
+      'Failed to update FlipCard stage participant answer',
+    );
+  }
+});
+
+// ************************************************************************* //
+// getFlipCardStagePublicData endpoint                                      //
+//                                                                           //
+// Retrieves public FlipCard stage data for a cohort                       //
+// ************************************************************************* //
+
+export const getFlipCardStagePublicData = onCall(async (request) => {
+  const {data} = request;
+
+  try {
+    const {experimentId, cohortId, stageId} = data;
+
+    if (!experimentId || !cohortId || !stageId) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'Missing required fields: experimentId, cohortId, stageId',
+      );
+    }
+
+    // Define public stage document reference
+    const publicDocument = app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('cohorts')
+      .doc(cohortId)
+      .collection('publicStageData')
+      .doc(stageId);
+
+    const doc = await publicDocument.get();
+
+    if (!doc.exists) {
+      throw new functions.https.HttpsError(
+        'not-found',
+        'FlipCard stage public data not found',
+      );
+    }
+
+    return doc.data() as FlipCardStagePublicData;
+  } catch (error) {
+    console.error('Error getting FlipCard stage public data:', error);
+    throw new functions.https.HttpsError(
+      'internal',
+      'Failed to get FlipCard stage public data',
+    );
+  }
+});

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -51,6 +51,8 @@ export * from './stages/chip_stage';
 export * from './stages/chip_stage.validation';
 export * from './stages/comprehension_stage';
 export * from './stages/comprehension_stage.validation';
+export * from './stages/flipcard_stage';
+export * from './stages/flipcard_stage.validation';
 export * from './stages/ranking_stage';
 export * from './stages/ranking_stage.prompts';
 export * from './stages/ranking_stage.validation';

--- a/utils/src/stages/flipcard_stage.ts
+++ b/utils/src/stages/flipcard_stage.ts
@@ -25,6 +25,7 @@ export interface FlipCard {
 export interface FlipCardStageConfig extends BaseStageConfig {
   kind: StageKind.FLIPCARD;
   cards: FlipCard[];
+  enableSelection: boolean;
   allowMultipleSelections: boolean;
   requireConfirmation: boolean;
 }
@@ -94,6 +95,7 @@ export function createFlipCardStage(
         showParticipantProgress: true,
       }),
     cards: config.cards ?? [createFlipCard()],
+    enableSelection: config.enableSelection ?? true,
     allowMultipleSelections: config.allowMultipleSelections ?? false,
     requireConfirmation: config.requireConfirmation ?? true,
   };

--- a/utils/src/stages/flipcard_stage.ts
+++ b/utils/src/stages/flipcard_stage.ts
@@ -1,0 +1,129 @@
+import {generateId} from '../shared';
+import {
+  BaseStageConfig,
+  BaseStageParticipantAnswer,
+  BaseStagePublicData,
+  StageKind,
+  StageGame,
+  createStageTextConfig,
+  createStageProgressConfig,
+} from './stage';
+
+// ************************************************************************* //
+// TYPES                                                                     //
+// ************************************************************************* //
+
+/** FlipCard item configuration. */
+export interface FlipCard {
+  id: string;
+  title: string;
+  frontContent: string;
+  backContent: string;
+}
+
+/** FlipCard stage config. */
+export interface FlipCardStageConfig extends BaseStageConfig {
+  kind: StageKind.FLIPCARD;
+  cards: FlipCard[];
+  allowMultipleSelections: boolean;
+  requireConfirmation: boolean;
+}
+
+/** FlipCard participant answer. */
+export interface FlipCardStageParticipantAnswer
+  extends BaseStageParticipantAnswer {
+  kind: StageKind.FLIPCARD;
+  selectedCardIds: string[];
+  flippedCardIds: string[];
+  flipHistory: FlipAction[];
+  confirmed: boolean;
+  timestamp: string;
+}
+
+/** FlipCard public data. */
+export interface FlipCardStagePublicData extends BaseStagePublicData {
+  kind: StageKind.FLIPCARD;
+  participantFlipHistory: Record<string, FlipAction[]>;
+  participantSelections: Record<string, string[]>;
+}
+
+/** Flip action tracking. */
+export interface FlipAction {
+  cardId: string;
+  action: 'flip_to_back' | 'flip_to_front';
+  timestamp: string;
+}
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+
+/** Create FlipCard item. */
+export function createFlipCard(config: Partial<FlipCard> = {}): FlipCard {
+  return {
+    id: config.id ?? generateId(),
+    title: config.title ?? '',
+    frontContent: config.frontContent ?? '',
+    backContent: config.backContent ?? '',
+  };
+}
+
+/** Create FlipCard stage. */
+export function createFlipCardStage(
+  config: Partial<FlipCardStageConfig> = {},
+): FlipCardStageConfig {
+  return {
+    id: config.id ?? generateId(),
+    kind: StageKind.FLIPCARD,
+    game: config.game ?? StageGame.NONE,
+    name: config.name ?? 'FlipCard',
+    descriptions:
+      config.descriptions ??
+      createStageTextConfig({
+        primaryText: 'Browse the cards and select one that interests you.',
+        infoText:
+          'Click "Learn More" to flip a card and see additional information. Select a card and confirm your choice to proceed.',
+        helpText:
+          'Use the "Learn More" button to view the back of cards. Once you find a card you like, click "Select" and then "Confirm Selection" to continue.',
+      }),
+    progress:
+      config.progress ??
+      createStageProgressConfig({
+        minParticipants: 1,
+        waitForAllParticipants: false,
+        showParticipantProgress: true,
+      }),
+    cards: config.cards ?? [createFlipCard()],
+    allowMultipleSelections: config.allowMultipleSelections ?? false,
+    requireConfirmation: config.requireConfirmation ?? true,
+  };
+}
+
+/** Create FlipCard stage participant answer. */
+export function createFlipCardStageParticipantAnswer(
+  stageId: string,
+  config: Partial<FlipCardStageParticipantAnswer> = {},
+): FlipCardStageParticipantAnswer {
+  return {
+    id: stageId,
+    kind: StageKind.FLIPCARD,
+    selectedCardIds: config.selectedCardIds ?? [],
+    flippedCardIds: config.flippedCardIds ?? [],
+    flipHistory: config.flipHistory ?? [],
+    confirmed: config.confirmed ?? false,
+    timestamp: config.timestamp ?? new Date().toISOString(),
+  };
+}
+
+/** Create FlipCard stage public data. */
+export function createFlipCardStagePublicData(
+  stageId: string,
+  config: Partial<FlipCardStagePublicData> = {},
+): FlipCardStagePublicData {
+  return {
+    id: stageId,
+    kind: StageKind.FLIPCARD,
+    participantFlipHistory: config.participantFlipHistory ?? {},
+    participantSelections: config.participantSelections ?? {},
+  };
+}

--- a/utils/src/stages/flipcard_stage.ts
+++ b/utils/src/stages/flipcard_stage.ts
@@ -29,6 +29,7 @@ export interface FlipCardStageConfig extends BaseStageConfig {
   allowMultipleSelections: boolean;
   requireConfirmation: boolean;
   minFlipsRequired: number;
+  shuffleCards: boolean;
 }
 
 /** FlipCard participant answer. */
@@ -100,6 +101,7 @@ export function createFlipCardStage(
     allowMultipleSelections: config.allowMultipleSelections ?? false,
     requireConfirmation: config.requireConfirmation ?? true,
     minFlipsRequired: config.minFlipsRequired ?? 0,
+    shuffleCards: config.shuffleCards ?? false,
   };
 }
 

--- a/utils/src/stages/flipcard_stage.ts
+++ b/utils/src/stages/flipcard_stage.ts
@@ -28,6 +28,7 @@ export interface FlipCardStageConfig extends BaseStageConfig {
   enableSelection: boolean;
   allowMultipleSelections: boolean;
   requireConfirmation: boolean;
+  minFlipsRequired: number;
 }
 
 /** FlipCard participant answer. */
@@ -98,6 +99,7 @@ export function createFlipCardStage(
     enableSelection: config.enableSelection ?? true,
     allowMultipleSelections: config.allowMultipleSelections ?? false,
     requireConfirmation: config.requireConfirmation ?? true,
+    minFlipsRequired: config.minFlipsRequired ?? 0,
   };
 }
 

--- a/utils/src/stages/flipcard_stage.validation.ts
+++ b/utils/src/stages/flipcard_stage.validation.ts
@@ -1,0 +1,87 @@
+import {Type, type Static} from '@sinclair/typebox';
+import {StageKind} from './stage';
+import {
+  StageGameSchema,
+  StageProgressConfigSchema,
+  StageTextConfigSchema,
+} from './stage.validation';
+
+/** Shorthand for strict TypeBox object validation */
+const strict = {additionalProperties: false} as const;
+
+// ************************************************************************* //
+// FlipCard stage validation                                                //
+// ************************************************************************* //
+
+/** FlipCard item validation. */
+export const FlipCardData = Type.Object(
+  {
+    id: Type.String({minLength: 1}),
+    title: Type.String({minLength: 1}),
+    frontContent: Type.String({minLength: 1}),
+    backContent: Type.String({minLength: 1}),
+  },
+  strict,
+);
+
+/** FlipCard stage config validation. */
+export const FlipCardStageConfigData = Type.Object(
+  {
+    id: Type.String({minLength: 1}),
+    kind: Type.Literal(StageKind.FLIPCARD),
+    game: StageGameSchema,
+    name: Type.String({minLength: 1}),
+    descriptions: StageTextConfigSchema,
+    progress: StageProgressConfigSchema,
+    cards: Type.Array(FlipCardData),
+    allowMultipleSelections: Type.Boolean(),
+    requireConfirmation: Type.Boolean(),
+  },
+  strict,
+);
+
+/** FlipCard stage participant answer validation. */
+export const FlipCardStageParticipantAnswerData = Type.Object(
+  {
+    id: Type.String({minLength: 1}),
+    kind: Type.Literal(StageKind.FLIPCARD),
+    selectedCardIds: Type.Array(Type.String()),
+    flippedCardIds: Type.Array(Type.String()),
+    flipHistory: Type.Array(
+      Type.Object(
+        {
+          cardId: Type.String({minLength: 1}),
+          action: Type.Union([
+            Type.Literal('flip_to_back'),
+            Type.Literal('flip_to_front'),
+          ]),
+          timestamp: Type.String({minLength: 1}),
+        },
+        strict,
+      ),
+    ),
+    confirmed: Type.Boolean(),
+    timestamp: Type.String({minLength: 1}),
+  },
+  strict,
+);
+
+// ************************************************************************* //
+// updateFlipCardStageParticipantAnswer endpoint                            //
+// ************************************************************************* //
+
+/** FlipCard stage participant answer update data validation. */
+export const UpdateFlipCardStageParticipantAnswerData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    cohortId: Type.String({minLength: 1}),
+    participantPrivateId: Type.String({minLength: 1}),
+    participantPublicId: Type.String({minLength: 1}),
+    flipCardStageParticipantAnswer: FlipCardStageParticipantAnswerData,
+  },
+  strict,
+);
+
+export type UpdateFlipCardStageParticipantAnswerData = Static<
+  typeof UpdateFlipCardStageParticipantAnswerData
+>;

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -15,6 +15,12 @@ import {
   ComprehensionStageParticipantAnswer,
 } from './comprehension_stage';
 import {
+  FlipCardStageConfig,
+  FlipCardStageParticipantAnswer,
+  FlipCardStagePublicData,
+  createFlipCardStagePublicData,
+} from './flipcard_stage';
+import {
   RankingStageConfig,
   RankingStageParticipantAnswer,
   RankingStagePublicData,
@@ -55,6 +61,7 @@ export enum StageKind {
   CHAT = 'chat', // group chat
   CHIP = 'chip', // "chip" negotiation
   COMPREHENSION = 'comprehension',
+  FLIPCARD = 'flipcard', // flip card selection
   RANKING = 'ranking',
   PAYOUT = 'payout',
   REVEAL = 'reveal',
@@ -105,6 +112,7 @@ export type StageConfig =
   | ChatStageConfig
   | ChipStageConfig
   | ComprehensionStageConfig
+  | FlipCardStageConfig
   | RankingStageConfig
   | InfoStageConfig
   | PayoutStageConfig
@@ -132,6 +140,7 @@ export type StageParticipantAnswer =
   | ChatStageParticipantAnswer
   | ChipStageParticipantAnswer
   | ComprehensionStageParticipantAnswer
+  | FlipCardStageParticipantAnswer
   | PayoutStageParticipantAnswer
   | RankingStageParticipantAnswer
   | SurveyStageParticipantAnswer
@@ -153,6 +162,7 @@ export interface BaseStagePublicData {
 export type StagePublicData =
   | ChatStagePublicData
   | ChipStagePublicData
+  | FlipCardStagePublicData
   | RankingStagePublicData
   | SalespersonStagePublicData
   | SurveyStagePublicData;
@@ -198,6 +208,9 @@ export function createPublicDataFromStageConfigs(stages: StageConfig[]) {
         break;
       case StageKind.CHIP:
         publicData.push(createChipStagePublicData(stage.id));
+        break;
+      case StageKind.FLIPCARD:
+        publicData.push(createFlipCardStagePublicData(stage.id));
         break;
       case StageKind.RANKING:
         publicData.push(createRankingStagePublicData(stage.id));

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -3,6 +3,7 @@ import {StageGame} from './stage';
 import {ChatStageConfigData} from './chat_stage.validation';
 import {ChipStageConfigData} from './chip_stage.validation';
 import {ComprehensionStageConfigData} from './comprehension_stage.validation';
+import {FlipCardStageConfigData} from './flipcard_stage.validation';
 import {RankingStageConfigData} from './ranking_stage.validation';
 import {InfoStageConfigData} from './info_stage.validation';
 import {PayoutStageConfigData} from './payout_stage.validation';
@@ -25,6 +26,7 @@ export const StageConfigData = Type.Union([
   ChatStageConfigData,
   ChipStageConfigData,
   ComprehensionStageConfigData,
+  FlipCardStageConfigData,
   InfoStageConfigData,
   PayoutStageConfigData,
   ProfileStageConfigData,


### PR DESCRIPTION
New Flipcard stage that supports:

- Displaying a set of cards with a title, front content, and back content (in Markdown).
- Logging of card flip actions with timestamps.
- Optionally:
  - Enabling "Selection" of cards that can be submitted as an answer.
  - Enabling shuffling of cards (using participant ID as a seed)
  - Require flipping a minimum number of cards to proceed.
 