### PR TITLE
Preliminary support for reasoning tokens in Gemini.

### DIFF
--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -146,9 +146,24 @@ export async function callGemini(
     };
   }
 
+  let text = null;
+  let reasoning = null;
+
+  for (const part of response.candidates[0].content.parts) {
+    if (!part.text) {
+      continue;
+    }
+    if (part.thought) {
+      reasoning = part.text;
+    } else {
+      text = part.text;
+    }
+  }
+
   return {
     status: ModelResponseStatus.OK,
-    text: response.text(),
+    text: text,
+    reasoning: reasoning,
   };
 }
 
@@ -177,6 +192,10 @@ export async function getGeminiAPIResponse(
       errorMessage: error.message,
     };
   }
+  const thinkingConfig = {
+    thinkingBudget: generationConfig.reasoningBudget,
+    includeThoughts: generationConfig.includeReasoning,
+  };
   const geminiConfig: GenerationConfig = {
     stopSequences: generationConfig.stopSequences,
     maxOutputTokens: generationConfig.maxTokens,
@@ -185,6 +204,7 @@ export async function getGeminiAPIResponse(
     topK: 16,
     presencePenalty: generationConfig.presencePenalty,
     frequencyPenalty: generationConfig.frequencyPenalty,
+    thinkingConfig: thinkingConfig,
     ...structuredOutputGenerationConfig,
     ...customFields,
   };

--- a/functions/src/api/model.response.ts
+++ b/functions/src/api/model.response.ts
@@ -36,4 +36,7 @@ export interface ModelResponse {
   // TODO(mkbehr): Parse the response during response creation.
   parsedResponse?: object;
   errorMessage?: string;
+  // TODO(mkbehr): Ad-hoc reasoning output for the chip game. This could be
+  // plumbed through to the chat stage's explanation field, but currently isn't.
+  reasoning?: string;
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -48,6 +48,13 @@ export interface ModelGenerationConfig {
   presencePenalty: number;
   // TODO(mkbehr): Add response MIME type and schema
   customRequestBodyFields: CustomRequestBodyField[];
+  // TODO(mkbehr): Ad-hoc reasoning params for the chip game. Gemini-only, not
+  // tested, no UI for setting them. Correspond to thinkingBudget and
+  // includeThinking in Gemini API. Set reasoningBudget to -1 or null for
+  // model-determined reasoning limit, 0 for no reasoning, positive for that
+  // many reasoning tokens in the budget.
+  reasoningBudget?: number;
+  includeReasoning?: boolean;
 }
 
 /** Model settings for a specific agent. */


### PR DESCRIPTION
Add optional params reasoningBudget and includeReasoning to ModelGenerationConfig. reasoningBudget can be set to 0 to disable thinking tokens in Gemini, or a positive integer to set a limit. If includeReasoning is set, the reasoning summary will be returned in a new reasoning field in ModelResponse.

This is a quick fix for latency in the chip game. I've tested it manually by hard-coding values in the chat stage, but it doesn't include unit tests or config UI.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
