### PR TITLE
Add private chat stage that enables 1:1 turn-based chat with participant and mediator

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -208,6 +208,11 @@ service cloud.firestore {
 
           // Participants can use cloud function endpoints
           allow write: if false;
+
+          match /privateChats/{chatId} {
+            allow read: if true;
+            allow write: if false; // Use Cloud functions
+          }
         }
 
         match /alerts/{alertId} {

--- a/frontend/src/components/chat/chat_interface.scss
+++ b/frontend/src/components/chat/chat_interface.scss
@@ -8,10 +8,13 @@
   width: 100%;
 }
 
+$chat-window-max-width: 1000px;
+
 .interface-wrapper {
   @include common.flex-row;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   flex-grow: 1;
+  justify-content: center;
   overflow: hidden;
 
   &.vertical {
@@ -21,6 +24,7 @@
 
 .main-content {
   @include common.flex-column;
+  align-items: center;
   background: var(--md-sys-color-surface-variant);
   flex-grow: 1;
   overflow: hidden;
@@ -31,6 +35,8 @@
   flex-direction: column-reverse;
   flex-grow: 1;
   overflow: hidden;
+  max-width: $chat-window-max-width;
+  width: 100%;
 }
 
 .chat-scroll {
@@ -49,6 +55,7 @@
 chat-input {
   background: var(--md-sys-color-surface-variant);
   bottom: 0;
+  max-width: $chat-window-max-width;
   padding: common.$main-content-padding;
   padding-top: 0;
   position: sticky;

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -55,17 +55,23 @@ export class ChatInterface extends MobxLitElement {
           <div class="chat-content">
             <div class="chat-scroll">
               <div class="chat-history">
-                ${this.mobileView
-                  ? html`<slot name="mobile-description"></slot>`
-                  : nothing}
+                ${
+                  this.mobileView
+                    ? html`<slot name="mobile-description"></slot>`
+                    : nothing
+                }
                 <slot></slot>
               </div>
             </div>
           </div>
-          <chat-input
-            .stageId=${this.stage?.id ?? ''}
-            .isDisabled=${this.disableInput}
-          >
+          ${
+            !this.showInput
+              ? nothing
+              : html`<chat-input
+                  .stageId=${this.stage?.id ?? ''}
+                  .isDisabled=${this.disableInput}
+                ></chat-input>`
+          }
           </chat-input>
         </div>
       </div>

--- a/frontend/src/components/chat/chat_message.scss
+++ b/frontend/src/components/chat/chat_message.scss
@@ -5,6 +5,7 @@
 $avatar-height: 30px;
 $bubble-radius: 20px;
 $bubble-radius-small: common.$spacing-small;
+$bubble-width: 400px;
 
 :host {
   @include common.flex-column;
@@ -44,7 +45,7 @@ $bubble-radius-small: common.$spacing-small;
   border-radius: $bubble-radius $bubble-radius $bubble-radius
     $bubble-radius-small;
   color: var(--md-sys-color-on-secondary-container);
-  max-width: max-content;
+  max-width: $bubble-width;
   overflow-wrap: anywhere;
 }
 
@@ -108,4 +109,5 @@ $bubble-radius-small: common.$spacing-small;
 .debug {
   @include typescale.label-small;
   color: var(--md-sys-color-tertiary);
+  max-width: $bubble-width;
 }

--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -59,7 +59,10 @@ export class EditorComponent extends MobxLitElement {
     const stageConfig = this.experimentEditor.getStage(this.stageId);
     if (!stageConfig) {
       return nothing;
-    } else if (stageConfig.kind !== StageKind.CHAT) {
+    } else if (
+      stageConfig.kind !== StageKind.CHAT &&
+      stageConfig.kind !== StageKind.PRIVATE_CHAT
+    ) {
       if (this.agent.type === AgentPersonaType.PARTICIPANT) {
         return html`
           <div class="section">

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -443,6 +443,8 @@ export class ExperimentBuilder extends MobxLitElement {
           <base-stage-editor .stage=${stage}></base-stage-editor>
           <group-chat-editor .stage=${stage}></group-chat-editor>
         `;
+      case StageKind.PRIVATE_CHAT:
+        return html` <base-stage-editor .stage=${stage}></base-stage-editor> `;
       case StageKind.FLIPCARD:
         return html`
           <base-stage-editor .stage=${stage}></base-stage-editor>

--- a/frontend/src/components/experiment_builder/stage_builder_dialog.scss
+++ b/frontend/src/components/experiment_builder/stage_builder_dialog.scss
@@ -62,7 +62,7 @@
   @include common.flex-column;
   flex-grow: 1;
   overflow: auto;
-  gap: common.$spacing-medium;
+  gap: common.$spacing-xxl;
   padding: common.$main-content-padding;
 }
 
@@ -97,4 +97,15 @@
   .title {
     @include typescale.title-small;
   }
+}
+
+.gallery-section {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+}
+
+.gallery-title {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  text-transform: uppercase;
 }

--- a/frontend/src/components/experiment_builder/stage_builder_dialog.ts
+++ b/frontend/src/components/experiment_builder/stage_builder_dialog.ts
@@ -142,13 +142,27 @@ export class StageBuilderDialog extends MobxLitElement {
 
   private renderStageCards() {
     return html`
-      <div class="card-gallery-wrapper">
-        ${this.renderTOSCard()} ${this.renderInfoCard()}
-        ${this.renderTransferCard()} ${this.renderProfileCard()}
-        ${this.renderSurveyCard()} ${this.renderSurveyPerParticipantCard()}
-        ${this.renderChatCard()} ${this.renderFlipCardCard()}
-        ${this.renderRankingCard()} ${this.renderRevealCard()}
-        ${this.renderPayoutCard()}
+      <div class="gallery-section">
+        <div class="gallery-title">Basic stages</div>
+        <div class="card-gallery-wrapper">
+          ${this.renderTOSCard()} ${this.renderInfoCard()}
+          ${this.renderProfileCard()}
+        </div>
+      </div>
+
+      <div class="gallery-section">
+        <div class="gallery-title">Chat stages</div>
+        <div class="card-gallery-wrapper">${this.renderGroupChatCard()}</div>
+      </div>
+
+      <div class="gallery-section">
+        <div class="gallery-title">Other stages</div>
+        <div class="card-gallery-wrapper">
+          ${this.renderTransferCard()} ${this.renderSurveyCard()}
+          ${this.renderSurveyPerParticipantCard()} ${this.renderFlipCardCard()}
+          ${this.renderRankingCard()} ${this.renderRevealCard()}
+          ${this.renderPayoutCard()}
+        </div>
       </div>
     `;
   }
@@ -286,15 +300,18 @@ export class StageBuilderDialog extends MobxLitElement {
     `;
   }
 
-  private renderChatCard() {
+  private renderGroupChatCard() {
     const addStage = () => {
       this.addStage(createChatStage());
     };
 
     return html`
       <div class="card" @click=${addStage}>
-        <div class="title">💬 Group chat</div>
-        <div>Host a conversation among participants and optional LLMs.</div>
+        <div class="title">Group chat</div>
+        <div>
+          Host a conversation among all participants in a cohort and optional
+          mediator(s).
+        </div>
       </div>
     `;
   }

--- a/frontend/src/components/experiment_builder/stage_builder_dialog.ts
+++ b/frontend/src/components/experiment_builder/stage_builder_dialog.ts
@@ -20,6 +20,7 @@ import {
   createInfoStage,
   createFlipCardStage,
   createPayoutStage,
+  createPrivateChatStage,
   createProfileStage,
   createRevealStage,
   createSurveyPerParticipantStage,
@@ -152,7 +153,9 @@ export class StageBuilderDialog extends MobxLitElement {
 
       <div class="gallery-section">
         <div class="gallery-title">Chat stages</div>
-        <div class="card-gallery-wrapper">${this.renderGroupChatCard()}</div>
+        <div class="card-gallery-wrapper">
+          ${this.renderGroupChatCard()} ${this.renderPrivateChatCard()}
+        </div>
       </div>
 
       <div class="gallery-section">
@@ -309,7 +312,23 @@ export class StageBuilderDialog extends MobxLitElement {
       <div class="card" @click=${addStage}>
         <div class="title">Group chat</div>
         <div>
-          Host a conversation among all participants in a cohort and optional
+          Host a conversation among <i>all</i> participants in a cohort and
+          optional mediator(s).
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPrivateChatCard() {
+    const addStage = () => {
+      this.addStage(createPrivateChatStage());
+    };
+
+    return html`
+      <div class="card" @click=${addStage}>
+        <div class="title">Private chat</div>
+        <div>
+          Enable each participant to privately chat <i>only</i> with added
           mediator(s).
         </div>
       </div>

--- a/frontend/src/components/participant_view/participant_view.ts
+++ b/frontend/src/components/participant_view/participant_view.ts
@@ -3,6 +3,7 @@ import '../popup/attention_check_popup';
 import '../popup/booted_popup';
 import '../progress/progress_stage_waiting';
 import '../stages/group_chat_participant_view';
+import '../stages/private_chat_participant_view';
 import '../stages/chip_participant_view';
 import '../stages/comprehension_participant_view';
 import '../stages/flipcard_participant_view';
@@ -220,6 +221,11 @@ export class ParticipantView extends MobxLitElement {
         return html`
           <group-chat-participant-view .stage=${stage}>
           </group-chat-particpant-view>
+        `;
+      case StageKind.PRIVATE_CHAT:
+        return html`
+          <private-chat-participant-view .stage=${stage}>
+          </private-chat-participant-view>
         `;
       case StageKind.CHIP:
         return html`

--- a/frontend/src/components/stages/group_chat_participant_view.scss
+++ b/frontend/src/components/stages/group_chat_participant_view.scss
@@ -59,3 +59,15 @@ stage-footer {
     width: 100%;
   }
 }
+
+.description {
+  @include common.flex-row-align-center;
+  color: var(--md-sys-color-outline);
+  font-style: italic;
+  gap: common.$spacing-small;
+  padding: common.$spacing-medium 0;
+
+  &.error {
+    color: var(--md-sys-color-error);
+  }
+}

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -28,11 +28,27 @@ export class PrivateChatView extends MobxLitElement {
     const chatMessages =
       this.participantService.privateChatMap[this.stage.id] ?? [];
 
+    // Disable input if turn-taking is set and latest message
+    // is from participant
+    const isDisabledInput = () => {
+      if (!this.stage?.isTurnBasedChat) {
+        return false;
+      }
+      if (chatMessages.length === 0) {
+        return false;
+      }
+      const publicId = this.participantService.profile?.publicId ?? '';
+      return chatMessages[chatMessages.length - 1].senderId === publicId;
+    };
+
     return html`
-      <chat-interface .stage=${this.stage}>
+      <chat-interface .stage=${this.stage} .disableInput=${isDisabledInput()}>
         ${chatMessages.map(
           (message) => html`<chat-message .chat=${message}></chat-message`,
         )}
+        ${isDisabledInput()
+          ? html`<div>Waiting for a response...</div>`
+          : nothing}
       </chat-interface>
       <stage-footer>
         ${this.stage.progress.showParticipantProgress

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -1,0 +1,40 @@
+import '../progress/progress_stage_completed';
+import '../chat/chat_interface';
+import '../chat/chat_message';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+
+import {PrivateChatStageConfig} from '@deliberation-lab/utils';
+
+import {styles} from './group_chat_participant_view.scss';
+
+/** Private chat interface for participants */
+@customElement('private-chat-participant-view')
+export class PrivateChatView extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  @property() stage: PrivateChatStageConfig | undefined = undefined;
+
+  override render() {
+    if (!this.stage) return nothing;
+
+    return html`
+      <chat-interface .stage=${this.stage} disableInput>
+        <div>Private chat coming soon</div>
+      </chat-interface>
+      <stage-footer>
+        ${this.stage.progress.showParticipantProgress
+          ? html`<progress-stage-completed></progress-stage-completed>`
+          : nothing}
+      </stage-footer>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'private-chat-participant-view': PrivateChatView;
+  }
+}

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -6,6 +6,9 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant.service';
+
 import {PrivateChatStageConfig} from '@deliberation-lab/utils';
 
 import {styles} from './group_chat_participant_view.scss';
@@ -15,14 +18,21 @@ import {styles} from './group_chat_participant_view.scss';
 export class PrivateChatView extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly participantService = core.getService(ParticipantService);
+
   @property() stage: PrivateChatStageConfig | undefined = undefined;
 
   override render() {
     if (!this.stage) return nothing;
 
+    const chatMessages =
+      this.participantService.privateChatMap[this.stage.id] ?? [];
+
     return html`
-      <chat-interface .stage=${this.stage} disableInput>
-        <div>Private chat coming soon</div>
+      <chat-interface .stage=${this.stage}>
+        ${chatMessages.map(
+          (message) => html`<chat-message .chat=${message}></chat-message`,
+        )}
       </chat-interface>
       <stage-footer>
         ${this.stage.progress.showParticipantProgress

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -9,7 +9,7 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {ParticipantService} from '../../services/participant.service';
 
-import {PrivateChatStageConfig} from '@deliberation-lab/utils';
+import {ChatMessage, PrivateChatStageConfig} from '@deliberation-lab/utils';
 
 import {styles} from './group_chat_participant_view.scss';
 
@@ -43,12 +43,8 @@ export class PrivateChatView extends MobxLitElement {
 
     return html`
       <chat-interface .stage=${this.stage} .disableInput=${isDisabledInput()}>
-        ${chatMessages.map(
-          (message) => html`<chat-message .chat=${message}></chat-message`,
-        )}
-        ${isDisabledInput()
-          ? html`<div>Waiting for a response...</div>`
-          : nothing}
+        ${chatMessages.map((message) => this.renderChatMessage(message))}
+        ${isDisabledInput() ? this.renderWaitingMessage() : nothing}
       </chat-interface>
       <stage-footer>
         ${this.stage.progress.showParticipantProgress
@@ -56,6 +52,36 @@ export class PrivateChatView extends MobxLitElement {
           : nothing}
       </stage-footer>
     `;
+  }
+
+  private renderWaitingMessage() {
+    const sendError = () => {
+      this.participantService.sendErrorChatMessage({
+        message: 'Request canceled',
+      });
+    };
+
+    return html`
+      <div class="description">
+        <div>Waiting for a response...</div>
+        <pr-tooltip text="Cancel">
+          <pr-icon-button
+            icon="stop_circle"
+            color="neutral"
+            variant="default"
+            @click=${sendError}
+          >
+          </pr-icon-button>
+        </pr-tooltip>
+      </div>
+    `;
+  }
+
+  private renderChatMessage(chatMessage: ChatMessage) {
+    if (chatMessage.isError) {
+      return html`<div class="description error">${chatMessage.message}</div>`;
+    }
+    return html`<chat-message .chat=${chatMessage}></chat-message>`;
   }
 }
 

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -237,6 +237,7 @@ export class CohortService extends Service {
   }
 
   // Returns chat discussion ID (or null if none or finished with all chats)
+  // TODO: Return different type of discussion ID based on chat stage kind
   getChatDiscussionId(stageId: string): string | null {
     const stageData = this.stagePublicDataMap[stageId];
     if (!stageData || stageData.kind !== StageKind.CHAT) {

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -978,6 +978,7 @@ export class ExperimentManager extends Service {
         experimentId,
         cohortId,
         stageId,
+        participantId: '',
         chatMessage,
       };
 

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -15,6 +15,7 @@ import {
   SurveyStageParticipantAnswer,
   UnifiedTimestamp,
   UpdateChatStageParticipantAnswerData,
+  createChatMessage,
   createChatStageParticipantAnswer,
   createParticipantChatMessage,
   createSurveyPerParticipantStageParticipantAnswer,
@@ -578,6 +579,37 @@ export class ParticipantService extends Service {
           avatar: this.profile.avatar,
           pronouns: this.profile.pronouns,
         },
+      });
+
+      const createData: CreateChatMessageData = {
+        experimentId: this.experimentId,
+        cohortId: this.profile.currentCohortId,
+        stageId: this.profile.currentStageId,
+        participantId: this.profile.privateId,
+        chatMessage,
+      };
+
+      response = await createChatMessageCallable(
+        this.sp.firebaseService.functions,
+        createData,
+      );
+    }
+    this.isSendingChat = false;
+    return response;
+  }
+
+  /** Send error chat message. */
+  // createChatMessageCallable will route the chat message based on stage kind
+  async sendErrorChatMessage(config: Partial<ChatMessage> = {}) {
+    let response = {};
+    this.isSendingChat = true;
+    if (this.experimentId && this.profile) {
+      const chatMessage = createChatMessage({
+        ...config,
+        discussionId: this.sp.cohortService.getChatDiscussionId(
+          this.profile.currentStageId,
+        ),
+        isError: true,
       });
 
       const createData: CreateChatMessageData = {

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -498,6 +498,8 @@ export class ParticipantService extends Service {
   }
 
   /** Send chat message. */
+  // createChatMessageCallable will route the chat message to the correct
+  // spot based on the stage kind
   async createChatMessage(config: Partial<ChatMessage> = {}) {
     let response = {};
     this.isSendingChat = true;
@@ -519,6 +521,7 @@ export class ParticipantService extends Service {
         experimentId: this.experimentId,
         cohortId: this.profile.currentCohortId,
         stageId: this.profile.currentStageId,
+        participantId: this.profile.privateId,
         chatMessage,
       };
 

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -28,6 +28,7 @@ import {writeModelLogEntry} from './log.utils';
 export async function processModelResponse(
   experimentId: string,
   cohortId: string,
+  participantId: string,
   stageId: string,
   userProfile: UserProfile,
   publicId: string,
@@ -42,6 +43,7 @@ export async function processModelResponse(
   const log = createModelLogEntry({
     experimentId,
     cohortId,
+    participantId,
     stageId,
     userProfile,
     publicId,

--- a/functions/src/agent_participant.utils.ts
+++ b/functions/src/agent_participant.utils.ts
@@ -89,6 +89,7 @@ export async function completeStageAsAgentParticipant(
       createAgentChatMessageFromPrompt(
         experimentId,
         participant.currentCohortId,
+        participant.privateId,
         stage.id,
         '',
         participant, // profile
@@ -103,6 +104,7 @@ export async function completeStageAsAgentParticipant(
       createAgentChatMessageFromPrompt(
         experimentId,
         participant.currentCohortId,
+        participant.privateId,
         stage.id,
         '',
         participant, // profile

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -41,7 +41,7 @@ export async function createAgentChatMessageFromPrompt(
   // Profile of agent who will be sending the chat message
   user: ParticipantProfileExtended | MediatorProfileExtended,
 ) {
-  if (!user.agentConfig) return;
+  if (!user.agentConfig) return false;
 
   const promptConfig = (
     await app
@@ -72,11 +72,11 @@ export async function createAgentChatMessageFromPrompt(
   );
 
   if (!message) {
-    return;
+    return false;
   }
 
   if (stage?.kind === StageKind.PRIVATE_CHAT) {
-    sendAgentPrivateChatMessage(
+    return await sendAgentPrivateChatMessage(
       experimentId,
       participantId,
       stageId,
@@ -85,7 +85,7 @@ export async function createAgentChatMessageFromPrompt(
       promptConfig.chatSettings,
     );
   } else {
-    sendAgentGroupChatMessage(
+    return await sendAgentGroupChatMessage(
       experimentId,
       cohortId,
       stageId,
@@ -231,7 +231,7 @@ export async function sendAgentGroupChatMessage(
   ) {
     // TODO: Write chat log
     console.log('Conversation has moved on');
-    return;
+    return false;
   }
 
   // Don't send a message if the conversation already has a response
@@ -249,7 +249,7 @@ export async function sendAgentGroupChatMessage(
   const hasTriggerResponse = (await triggerResponseDoc.get()).exists;
   if (hasTriggerResponse) {
     console.log('Someone already responded');
-    return;
+    return false;
   }
 
   // Otherwise, log response ID as trigger message
@@ -297,7 +297,7 @@ export async function sendAgentPrivateChatMessage(
   ) {
     // TODO: Write chat log
     console.log('Conversation has moved on');
-    return;
+    return false;
   }
 
   // Don't send a message if the conversation already has a response
@@ -315,7 +315,7 @@ export async function sendAgentPrivateChatMessage(
   const hasTriggerResponse = (await triggerResponseDoc.get()).exists;
   if (hasTriggerResponse) {
     console.log('Someone already responded');
-    return;
+    return false;
   }
 
   // Otherwise, log response ID as trigger message
@@ -335,6 +335,8 @@ export async function sendAgentPrivateChatMessage(
 
   chatMessage.timestamp = Timestamp.now();
   agentDocument.set(chatMessage);
+
+  return true;
 }
 
 /** Checks if current participant/mediator can send a chat message

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -231,7 +231,7 @@ export async function sendAgentGroupChatMessage(
   ) {
     // TODO: Write chat log
     console.log('Conversation has moved on');
-    return false;
+    return true; // expected outcome (TODO: return status enum)
   }
 
   // Don't send a message if the conversation already has a response
@@ -249,7 +249,7 @@ export async function sendAgentGroupChatMessage(
   const hasTriggerResponse = (await triggerResponseDoc.get()).exists;
   if (hasTriggerResponse) {
     console.log('Someone already responded');
-    return false;
+    return true; // expected outcome (TODO: return status enum)
   }
 
   // Otherwise, log response ID as trigger message
@@ -269,6 +269,8 @@ export async function sendAgentGroupChatMessage(
 
   chatMessage.timestamp = Timestamp.now();
   agentDocument.set(chatMessage);
+
+  return true;
 }
 
 /** Sends agent chat message after typing delay and duplicate check. */
@@ -297,7 +299,7 @@ export async function sendAgentPrivateChatMessage(
   ) {
     // TODO: Write chat log
     console.log('Conversation has moved on');
-    return false;
+    return true; // expected outcome (TODO: return status enum)
   }
 
   // Don't send a message if the conversation already has a response
@@ -315,7 +317,7 @@ export async function sendAgentPrivateChatMessage(
   const hasTriggerResponse = (await triggerResponseDoc.get()).exists;
   if (hasTriggerResponse) {
     console.log('Someone already responded');
-    return false;
+    return true; // expected outcome (TODO: return status enum)
   }
 
   // Otherwise, log response ID as trigger message

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -1,0 +1,30 @@
+import {ChatMessage, createChatMessage} from '@deliberation-lab/utils';
+import {Timestamp} from 'firebase-admin/firestore';
+import {app} from '../app';
+
+/** Used for private chats if model response fails. */
+export async function sendErrorPrivateChatMessage(
+  experimentId: string,
+  participantId: string,
+  stageId: string,
+  config: Partial<ChatMessage> = {},
+) {
+  const chatMessage = createChatMessage({
+    ...config,
+    timestamp: Timestamp.now(),
+    isError: true,
+  });
+
+  const agentDocument = app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('stageData')
+    .doc(stageId)
+    .collection('privateChats')
+    .doc(chatMessage.id);
+
+  agentDocument.set(chatMessage);
+}

--- a/functions/src/mediator.utils.ts
+++ b/functions/src/mediator.utils.ts
@@ -6,7 +6,7 @@ import {
   ProfileAgentConfig,
   createMediatorProfileFromAgentPersona,
 } from '@deliberation-lab/utils';
-import {getAgentPersonas} from './utils/firestore';
+import {getAgentMediatorPersonas} from './utils/firestore';
 
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
@@ -19,7 +19,7 @@ export async function createMediatorsForCohort(
   experimentId: string,
   cohortId: string,
 ): MediatorProfile[] {
-  const personas = await getAgentPersonas(experimentId);
+  const personas = await getAgentMediatorPersonas(experimentId);
   const mediators: MediatorProfile[] = [];
   for (const persona of personas) {
     if (
@@ -31,9 +31,9 @@ export async function createMediatorsForCohort(
           .firestore()
           .collection('experiments')
           .doc(experimentId)
-          .collection('agents')
+          .collection('agentMediators')
           .doc(persona.id)
-          .collection('chatPrompts')
+          .collection('prompts')
           .get()
       ).docs.map((doc) => doc.data() as ChatPromptConfig);
       const mediator = createMediatorProfileFromAgentPersona(

--- a/functions/src/prompt.utils.ts
+++ b/functions/src/prompt.utils.ts
@@ -13,6 +13,7 @@ import {
   getFirestoreExperiment,
   getFirestoreStage,
   getFirestorePublicStageChatMessages,
+  getFirestorePrivateChatMessages,
 } from './utils/firestore';
 import {app} from '../app';
 
@@ -24,7 +25,9 @@ import {app} from '../app';
 export async function getStructuredPrompt(
   experimentId: string,
   cohortId: string,
-  participantId: string | null, // participant ID or null if mediator
+  // participant ID to include answers for, or null if mediator (include all)
+  // TODO: Update field to list of participants to include for answers
+  participantId: string | null,
   stageId: string, // current stage ID
   userProfile: UserProfile,
   agentConfig: ProfileAgentConfig,
@@ -158,6 +161,13 @@ export async function getStageDisplayForPrompt(
         stage.id,
       );
       return getChatPromptMessageHistory(messages, stage);
+    case StageKind.PRIVATE_CHAT:
+      const privateMessages = await getFirestorePrivateChatMessages(
+        experimentId,
+        participantId,
+        stage.id,
+      );
+      return getChatPromptMessageHistory(privateMessages, stage);
     default:
       // TODO: Set up display/answers for ranking stage
       // TODO: Set up display/answers for survey stage

--- a/functions/src/triggers/README.md
+++ b/functions/src/triggers/README.md
@@ -39,7 +39,7 @@ depending on the stage, e.g., for chip stage, check if the transaction is
 ready to be cleared.
 
 
-## onChatMessageCreated
+## onPublicChatMessageCreated
 *When document is updated at `experiments/{experimentId}/cohorts/{cohortId}/publicStageData/{stageId}/chats/{chatId}`*
 
 When a new group chat message is created:
@@ -51,6 +51,13 @@ When a new group chat message is created:
 This includes specific actions for specific stages, e.g., for salesperson
 stage, call different function to build agent chat messages (that sends
 the salesperson game board as part of the prompt).
+
+
+## onPrivateChatMessageCreated
+*When document is updated at `experiments/{experimentId}/participants/{participantId}/stageData/{stageId}/privateChats/{chatId}`*
+
+When a new private chat (only between current participant and mediators) is
+created, generate agent mediator responses to the chat message.
 
 
 ## onChipTransactionCreated

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -109,8 +109,8 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
       stage.id,
       true,
     );
-    mediators.forEach((mediator) => {
-      createAgentChatMessageFromPrompt(
+    mediators.forEach(async (mediator) => {
+      const result = await createAgentChatMessageFromPrompt(
         event.params.experimentId,
         participant.currentCohortId,
         participant.privateId,
@@ -119,8 +119,14 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
         mediator,
         true,
       );
+      if (!result) {
+        // TODO: Mark participant as failed response
+      }
     });
     // TODO: If no mediator, return error (otherwise participant may wait
     // indefinitely for a response).
+    if (mediators.length === 0) {
+      // Mark participant as failed response
+    }
   },
 );

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -14,8 +14,8 @@ import {sendAgentParticipantSalespersonMessage} from '../stages/salesperson.agen
 // TRIGGER FUNCTIONS                                                         //
 // ************************************************************************* //
 
-/** When a chat message is created */
-export const onChatMessageCreated = onDocumentCreated(
+/** When a chat message is created under publicStageData */
+export const onPublicChatMessageCreated = onDocumentCreated(
   'experiments/{experimentId}/cohorts/{cohortId}/publicStageData/{stageId}/chats/{chatId}',
   async (event) => {
     const stage = await getFirestoreStage(
@@ -81,5 +81,20 @@ export const onChatMessageCreated = onDocumentCreated(
         participant,
       );
     });
+  },
+);
+
+/** When a chat message is created under private participant stageData */
+export const onPrivateChatMessageCreated = onDocumentCreated(
+  'experiments/{experimentId}/participants/{participantId}/stageData/{stageId}/privateChats/{chatId}',
+  async (event) => {
+    const stage = await getFirestoreStage(
+      event.params.experimentId,
+      event.params.stageId,
+    );
+    if (!stage) return;
+
+    // TODO: Send agent mediator messages to private chat path
+    console.log('onPrivateChatMessageCreated');
   },
 );

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -280,7 +280,7 @@ export async function getAgentParticipantPrompt(
   return prompt.data() as AgentParticipantPromptConfig;
 }
 
-/** Get chat messages for given cohort and stage ID. */
+/** Get group chat messages for given cohort and stage ID. */
 export async function getFirestorePublicStageChatMessages(
   experimentId: string,
   cohortId: string,
@@ -292,6 +292,28 @@ export async function getFirestorePublicStageChatMessages(
         .firestore()
         .collection(
           `experiments/${experimentId}/cohorts/${cohortId}/publicStageData/${stageId}/chats`,
+        )
+        .orderBy('timestamp', 'asc')
+        .get()
+    ).docs.map((doc) => doc.data() as ChatMessage);
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
+/** Get private chat messages for given participant and stage ID. */
+export async function getFirestorePrivateChatMessages(
+  experimentId: string,
+  participantId: string,
+  stageId: string,
+): Promise<ChatMessage[]> {
+  try {
+    return (
+      await app
+        .firestore()
+        .collection(
+          `experiments/${experimentId}/participants/${participantId}/stageData/${stageId}/privateChats`,
         )
         .orderBy('timestamp', 'asc')
         .get()

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -246,13 +246,13 @@ export async function getFirestoreStagePublicData(
   return doc.data() as StagePublicData;
 }
 
-/** Return all agent personas for a given experiment. */
-export async function getAgentPersonas(experimentId: string) {
+/** Return all agent mediator personas for a given experiment. */
+export async function getAgentMediatorPersonas(experimentId: string) {
   const agentCollection = app
     .firestore()
     .collection('experiments')
     .doc(experimentId)
-    .collection('agents');
+    .collection('agentMediators');
   return (await agentCollection.get()).docs.map(
     (agent) => agent.data() as AgentPersonaConfig,
   );

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -21,7 +21,9 @@ import {AgentChatPromptConfig} from './agent';
  */
 export interface ChatMessage {
   id: string;
-  discussionId: string | null; // discussion during which message was sent
+  // in GROUP_CHAT (currently CHAT), the current thread within the group chat
+  // in CHAT_APP (forthcoming), the ID of the separate discussion chat
+  discussionId: string | null;
   type: UserType;
   message: string;
   timestamp: UnifiedTimestamp;

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -31,6 +31,7 @@ export interface ChatMessage {
   senderId: string; // participant public ID or mediator public ID
   agentId: string; // agent persona used (or blank if none)
   explanation: string; // agent reasoning (or blank if none)
+  isError: boolean; // is error message (used for private chats)
 }
 
 /** Format for LLM API chat message output. */
@@ -70,6 +71,7 @@ export function createChatMessage(
     senderId: config.senderId ?? '',
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
+    isError: config.isError ?? false,
   };
 }
 
@@ -87,6 +89,7 @@ export function createParticipantChatMessage(
     senderId: config.senderId ?? '',
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
+    isError: config.isError ?? false,
   };
 }
 
@@ -104,6 +107,7 @@ export function createMediatorChatMessage(
     senderId: config.senderId ?? '',
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
+    isError: config.isError ?? false,
   };
 }
 
@@ -121,5 +125,6 @@ export function createExperimenterChatMessage(
     senderId: EXPERIMENTER_MANUAL_CHAT_SENDER_ID,
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
+    isError: config.isError ?? false,
   };
 }

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -68,6 +68,8 @@ export * from './stages/info_stage.prompts';
 export * from './stages/info_stage.validation';
 export * from './stages/payout_stage';
 export * from './stages/payout_stage.validation';
+export * from './stages/private_chat_stage';
+export * from './stages/private_chat_stage.validation';
 export * from './stages/profile_stage';
 export * from './stages/profile_stage.validation';
 export * from './stages/reveal_stage';

--- a/utils/src/log.ts
+++ b/utils/src/log.ts
@@ -9,9 +9,10 @@ export type LogEntry = ModelLogEntry;
 export interface BaseLogEntry {
   id: string; // log ID
   type: LogEntryType;
-  experimentId: string;
-  cohortId: string;
-  stageId: string;
+  experimentId: string; // path to file log under
+  cohortId: string; // path to file log under
+  participantId: string; // path to file log under
+  stageId: string; // path to file log under
   userProfile: UserProfile | null; // user profile of participant/mediator
   publicId: string; // Public ID of participant/mediator
   privateId: string; // Private ID of participant/mediator
@@ -41,6 +42,7 @@ export function createModelLogEntry(
     type: LogEntryType.MODEL,
     experimentId: config.experimentId ?? '',
     cohortId: config.cohortId ?? '',
+    participantId: config.participantId ?? '',
     stageId: config.stageId ?? '',
     userProfile: config.userProfile ?? null,
     publicId: config.publicId ?? '',

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -121,7 +121,7 @@ Each message is displayed in chronological order, with the most recent message a
 
 /** Convert chat message to prompt format. */
 export function convertChatMessageToPromptFormat(message: ChatMessage) {
-  return `${convertUnifiedTimestampToTime(message.timestamp)} ${message.profile.name}: ${message.message}`;
+  return `${convertUnifiedTimestampToTime(message.timestamp)} ${message.profile.name ?? message.senderId}: ${message.message}`;
 }
 
 /** Convert chat messages into chat history string for prompt. */

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -15,6 +15,7 @@ import {
 import {AgentChatPromptConfig} from '../agent';
 
 /** Group chat stage types and functions. */
+// TODO: Rename file to group_chat_stage.ts
 
 // ************************************************************************* //
 // TYPES                                                                     //
@@ -29,7 +30,7 @@ export interface ChatStageConfig extends BaseStageConfig {
   kind: StageKind.CHAT;
   discussions: ChatDiscussion[]; // ordered list of discussions
   timeLimitInMinutes: number | null; // How long remaining in the chat.
-  requireFullTime: boolean | null; // Require participants to stay in chat until time limit is up
+  requireFullTime: boolean; // Require participants to stay in chat until time limit is up
 }
 
 /** Chat discussion. */

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -61,6 +61,8 @@ export const CreateChatMessageData = Type.Object(
     experimentId: Type.String({minLength: 1}),
     cohortId: Type.String({minLength: 1}),
     stageId: Type.String({minLength: 1}),
+    // private participant ID (used in private chat cases)
+    participantId: Type.String({minLength: 1}),
     chatMessage: ChatMessageData,
   },
   strict,

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -27,6 +27,19 @@ import {
  */
 export interface PrivateChatStageConfig extends BaseStageConfig {
   kind: StageKind.PRIVATE_CHAT;
+  // If defined, ends chat after specified time limit
+  // (starting from when the first message is sent)
+  timeLimitInMinutes: number | null;
+  // Require participants to stay in chat until time limit is up
+  requireFullTime: boolean;
+  // If true, requires participant to go back and forth with mediator(s)
+  // (rather than being able to send multiple messages at once)
+  isTurnBasedChat: boolean;
+  // If turn based chat set to true, this specifies the max
+  // number of messages the participant can send (since the participant
+  // can only send one message per turn)
+  // If not set, there is no limit
+  maxNumberOfTurns: number | null;
 }
 
 // ************************************************************************* //
@@ -43,5 +56,9 @@ export function createPrivateChatStage(
     progress:
       config.progress ??
       createStageProgressConfig({waitForAllParticipants: true}),
+    timeLimitInMinutes: config.timeLimitInMinutes ?? null,
+    requireFullTime: config.requireFullTime ?? false,
+    isTurnBasedChat: config.isTurnBasedChat ?? true,
+    maxNumberOfTurns: config.maxNumberOfTurns ?? null,
   };
 }

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -1,0 +1,49 @@
+import {generateId} from '../shared';
+import {
+  BaseStageConfig,
+  StageKind,
+  StageGame,
+  createStageTextConfig,
+  createStageProgressConfig,
+} from './stage';
+import {
+  ParticipantProfileBase,
+  createParticipantProfileBase,
+} from '../participant';
+
+/** Private chat stage types and functions.
+ *
+ * NOTE: Private chat means current participant ONLY plus any cohort
+ * mediators. For 1:1 participant chat, use other chat stage(s).
+ */
+
+// ************************************************************************* //
+// TYPES                                                                     //
+// ************************************************************************* //
+
+/**
+ * PrivateChatStageConfig.
+ *
+ * This is saved as a stage doc under experiments/{experimentId}/stages
+ */
+export interface PrivateChatStageConfig extends BaseStageConfig {
+  kind: StageKind.PRIVATE_CHAT;
+}
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+export function createPrivateChatStage(
+  config: Partial<PrivateChatStageConfig> = {},
+): PrivateChatStageConfig {
+  return {
+    id: config.id ?? generateId(),
+    kind: StageKind.PRIVATE_CHAT,
+    game: config.game ?? StageGame.NONE,
+    name: config.name ?? 'Private chat',
+    descriptions: config.descriptions ?? createStageTextConfig(),
+    progress:
+      config.progress ??
+      createStageProgressConfig({waitForAllParticipants: true}),
+  };
+}

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -35,6 +35,8 @@ export interface PrivateChatStageConfig extends BaseStageConfig {
   // If true, requires participant to go back and forth with mediator(s)
   // (rather than being able to send multiple messages at once)
   isTurnBasedChat: boolean;
+  // Minimum number of messages participant must send to move on
+  minNumberOfTurns: number;
   // If turn based chat set to true, this specifies the max
   // number of messages the participant can send (since the participant
   // can only send one message per turn)
@@ -59,6 +61,7 @@ export function createPrivateChatStage(
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
     requireFullTime: config.requireFullTime ?? false,
     isTurnBasedChat: config.isTurnBasedChat ?? true,
+    minNumberOfTurns: config.minNumberOfTurns ?? 0,
     maxNumberOfTurns: config.maxNumberOfTurns ?? null,
   };
 }

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -2,7 +2,6 @@ import {generateId} from '../shared';
 import {
   BaseStageConfig,
   StageKind,
-  StageGame,
   createStageTextConfig,
   createStageProgressConfig,
 } from './stage';
@@ -39,7 +38,6 @@ export function createPrivateChatStage(
   return {
     id: config.id ?? generateId(),
     kind: StageKind.PRIVATE_CHAT,
-    game: config.game ?? StageGame.NONE,
     name: config.name ?? 'Private chat',
     descriptions: config.descriptions ?? createStageTextConfig(),
     progress:

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -2,11 +2,9 @@ import {Type, type Static} from '@sinclair/typebox';
 import {UnifiedTimestampSchema} from '../shared.validation';
 import {StageKind} from './stage';
 import {
-  StageGameSchema,
   StageTextConfigSchema,
   StageProgressConfigSchema,
 } from './stage.validation';
-import {ChatMessageType} from '../chat_message';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = {additionalProperties: false} as const;
@@ -14,7 +12,6 @@ const strict = {additionalProperties: false} as const;
 export const PrivateChatStageConfigData = Type.Object({
   id: Type.String(),
   kind: Type.Literal(StageKind.PRIVATE_CHAT),
-  game: StageGameSchema,
   name: Type.String(),
   descriptions: StageTextConfigSchema,
   progress: StageProgressConfigSchema,

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -1,0 +1,21 @@
+import {Type, type Static} from '@sinclair/typebox';
+import {UnifiedTimestampSchema} from '../shared.validation';
+import {StageKind} from './stage';
+import {
+  StageGameSchema,
+  StageTextConfigSchema,
+  StageProgressConfigSchema,
+} from './stage.validation';
+import {ChatMessageType} from '../chat_message';
+
+/** Shorthand for strict TypeBox object validation */
+const strict = {additionalProperties: false} as const;
+
+export const PrivateChatStageConfigData = Type.Object({
+  id: Type.String(),
+  kind: Type.Literal(StageKind.PRIVATE_CHAT),
+  game: StageGameSchema,
+  name: Type.String(),
+  descriptions: StageTextConfigSchema,
+  progress: StageProgressConfigSchema,
+});

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -28,6 +28,7 @@ import {
 } from './ranking_stage';
 import {InfoStageConfig} from './info_stage';
 import {PayoutStageConfig, PayoutStageParticipantAnswer} from './payout_stage';
+import {PrivateChatStageConfig} from './private_chat_stage';
 import {ProfileStageConfig} from './profile_stage';
 import {RevealStageConfig} from './reveal_stage';
 import {
@@ -64,6 +65,7 @@ export enum StageKind {
   FLIPCARD = 'flipcard', // flip card selection
   RANKING = 'ranking',
   PAYOUT = 'payout',
+  PRIVATE_CHAT = 'privateChat', // participant plus any mediators
   REVEAL = 'reveal',
   SALESPERSON = 'salesperson', // co-op traveling salesperson game
   SURVEY = 'survey',
@@ -105,6 +107,7 @@ export type StageConfig =
   | RankingStageConfig
   | InfoStageConfig
   | PayoutStageConfig
+  | PrivateChatStageConfig
   | ProfileStageConfig
   | RevealStageConfig
   | SalespersonStageConfig

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -6,6 +6,7 @@ import {FlipCardStageConfigData} from './flipcard_stage.validation';
 import {RankingStageConfigData} from './ranking_stage.validation';
 import {InfoStageConfigData} from './info_stage.validation';
 import {PayoutStageConfigData} from './payout_stage.validation';
+import {PrivateChatStageConfigData} from './private_chat_stage.validation';
 import {ProfileStageConfigData} from './profile_stage.validation';
 import {RevealStageConfigData} from './reveal_stage.validation';
 import {SalespersonStageConfigData} from './salesperson_stage.validation';
@@ -28,6 +29,7 @@ export const StageConfigData = Type.Union([
   FlipCardStageConfigData,
   InfoStageConfigData,
   PayoutStageConfigData,
+  PrivateChatStageConfigData,
   ProfileStageConfigData,
   RankingStageConfigData,
   RevealStageConfigData,


### PR DESCRIPTION
This also fixes some chat bugs related to the new refactor #561.

Note that the private chat stage includes a timer option as well as min/max turns, but neither of these are configurable by private stage editor (which has not yet been added) or functional in the participant view. We will address in follow-up PR(s).

We have also not yet added data download(s) for private chat.