### PR TITLE
Re-add saveAndProgress in FlipCard (removed accidentally in #567).

### DIFF
--- a/frontend/src/components/stages/flipcard_participant_view.ts
+++ b/frontend/src/components/stages/flipcard_participant_view.ts
@@ -69,7 +69,11 @@ export class FlipCardParticipantView extends MobxLitElement {
               </div>
             `
           : nothing}
-        <stage-footer .stage=${this.stage} .disabled=${!isComplete}>
+        <stage-footer
+          .stage=${this.stage}
+          .disabled=${!isComplete}
+          .onNextClick=${this.saveAndProgress}
+        >
           ${isComplete
             ? html`<progress-stage-completed></progress-stage-completed>`
             : nothing}


### PR DESCRIPTION
Re-add saveAndProgress (removed accidentally in #567). FlipCard stage has a custom SaveAndProgress:
```
  private saveAndProgress = async () => {
    if (!this.stage) return;

    await this.participantAnswerService.saveFlipCardAnswers(this.stage.id);
    await this.participantService.progressToNextStage();
  };
```