### PR TITLE
Add retry and fallback logic to chip assistance

### DIFF
--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -40,6 +40,8 @@ import {
   displayChipOfferText,
   getChipLogs,
   getChipOfferChecks,
+  ChipOfferAssistanceMove,
+  ChipResponseAssistanceMove,
 } from '@deliberation-lab/utils';
 import {convertUnifiedTimestampToDate} from '../../shared/utils';
 
@@ -126,6 +128,90 @@ export class ChipView extends MobxLitElement {
       </div>
     `;
   }
+
+  // ✅ NEW Fallback to Manual for System Error
+  private renderErrorOffer() {
+    return html`
+      <div class="warning">
+        ⚠️ A System Error occurred. Please proceed manually.
+      </div>
+      ${this.renderManualOffer(this.sendOffer)}
+    `;
+  }
+
+  private renderErrorResponse() {
+    return html`
+      <div class="warning">
+        ⚠️ A System Error occurred. Please proceed manually.
+      </div>
+      ${this.renderManualResponse(this.acceptOffer, this.rejectOffer)}
+    `;
+  }
+
+  // ✅ NEW Check if Assistant Offer is Valid
+  private isValidAssistantOffer(): boolean {
+    const assistance = this.answer?.currentAssistance;
+    if (!assistance || assistance.type !== ChipAssistanceType.OFFER) {
+      return false;
+    }
+    
+    // For coach mode, check if user has submitted their proposal
+    if (assistance.selectedMode === ChipAssistanceMode.COACH) {
+      // If user hasn't submitted proposal yet, consider it valid (waiting for user input)
+      if (!assistance.proposedTime) {
+        return true;
+      }
+      // If user has submitted, check if LLM provided valid feedback
+      const offerAssistance = assistance as ChipOfferAssistanceMove;
+      const hasValidOffer = offerAssistance.proposedOffer != null &&
+             Object.keys(offerAssistance.proposedOffer.buy ?? {}).length > 0 &&
+             Object.keys(offerAssistance.proposedOffer.sell ?? {}).length > 0;
+      const hasValidMessage = assistance.message != null;
+      
+      return hasValidOffer && hasValidMessage;
+    }
+    
+    // For other modes (advisor, delegate), check if LLM query has completed
+    if (!assistance.proposedTime) {
+      return true; // Still waiting for LLM response
+    }
+    
+    const offerAssistance = assistance as ChipOfferAssistanceMove;
+    return offerAssistance.proposedOffer != null &&
+           Object.keys(offerAssistance.proposedOffer.buy ?? {}).length > 0 &&
+           Object.keys(offerAssistance.proposedOffer.sell ?? {}).length > 0;
+  }
+
+  // ✅ NEW Check if Assistant Response is Valid
+  private isValidAssistantResponse(): boolean {
+    const assistance = this.answer?.currentAssistance;
+    if (!assistance || assistance.type !== ChipAssistanceType.RESPONSE) {
+      return false;
+    }
+    
+    // For coach mode, check if user has submitted their proposal
+    if (assistance.selectedMode === ChipAssistanceMode.COACH) {
+      // If user hasn't submitted proposal yet, consider it valid (waiting for user input)
+      if (!assistance.proposedTime) {
+        return true;
+      }
+      // If user has submitted, check if LLM provided valid feedback
+      const responseAssistance = assistance as ChipResponseAssistanceMove;
+      const hasValidResponse = responseAssistance.proposedResponse !== null;
+      const hasValidMessage = assistance.message != null;
+      
+      return hasValidResponse && hasValidMessage;
+    }
+    
+    // For other modes (advisor, delegate), check if LLM query has completed
+    if (!assistance.proposedTime) {
+      return true; // Still waiting for LLM response
+    }
+    
+    const responseAssistance = assistance as ChipResponseAssistanceMove;
+    return responseAssistance.message != null;
+  }
+
 
   private isAssistanceLoading() {
     return (
@@ -267,9 +353,15 @@ export class ChipView extends MobxLitElement {
       case ChipAssistanceMode.DELEGATE:
         return this.renderDelegateOfferButton(true);
       case ChipAssistanceMode.ADVISOR:
-        return this.renderAdvisorOffer(true);
+        return this.isValidAssistantOffer()
+          ? this.renderAdvisorOffer(true)
+          : this.renderErrorOffer();
       case ChipAssistanceMode.COACH:
-        return this.renderCoachOffer();
+        return this.isValidAssistantOffer()
+          ? this.renderCoachOffer()
+          : this.renderErrorOffer();
+      case ChipAssistanceMode.ERROR:
+        return this.renderErrorOffer(); // ✅ NEW
       default:
         break;
     }
@@ -465,9 +557,15 @@ export class ChipView extends MobxLitElement {
       case ChipAssistanceMode.DELEGATE:
         return this.renderDelegateResponseButton(true);
       case ChipAssistanceMode.ADVISOR:
-        return this.renderAdvisorResponse(true);
+        return this.isValidAssistantResponse()
+          ? this.renderAdvisorResponse(true)
+          : this.renderErrorResponse();
       case ChipAssistanceMode.COACH:
-        return this.renderCoachResponse();
+        return this.isValidAssistantResponse()
+          ? this.renderCoachResponse()
+          : this.renderErrorResponse();
+      case ChipAssistanceMode.ERROR:
+        return this.renderErrorResponse(); // ✅ NEW
       default:
         break;
     }
@@ -701,6 +799,13 @@ export class ChipView extends MobxLitElement {
   }
 
   private renderDelegateOfferButton(disabled = false) {
+    const assistance = this.answer?.currentAssistance;
+    
+    // Only show error if user has selected delegate mode and LLM query has completed but failed
+    const shouldShowError = assistance?.selectedMode === ChipAssistanceMode.DELEGATE && 
+                           assistance.proposedTime && 
+                           !this.isValidAssistantOffer();
+    
     return html`
       <div class="button-wrapper">
         <pr-button
@@ -720,11 +825,22 @@ export class ChipView extends MobxLitElement {
           Delegate decision to agent
         </pr-button>
       </div>
-      ${this.getDelegateMessage()}
+      ${shouldShowError ? html`
+        <div class="warning">
+          ⚠️ A System Error occurred. Please proceed manually.
+        </div>
+      ` : this.getDelegateMessage()}
     `;
   }
 
   private renderDelegateResponseButton(disabled = false) {
+    const assistance = this.answer?.currentAssistance;
+    
+    // Only show error if user has selected delegate mode and LLM query has completed but failed
+    const shouldShowError = assistance?.selectedMode === ChipAssistanceMode.DELEGATE && 
+                           assistance.proposedTime && 
+                           !this.isValidAssistantResponse();
+    
     return html`
       <div class="button-wrapper">
         <pr-button
@@ -745,7 +861,11 @@ export class ChipView extends MobxLitElement {
           Delegate decision to agent
         </pr-button>
       </div>
-      ${this.getDelegateMessage()}
+      ${shouldShowError ? html`
+        <div class="warning">
+          ⚠️ A System Error occurred. Please proceed manually.
+        </div>
+      ` : this.getDelegateMessage()}
     `;
   }
 

--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -805,7 +805,6 @@ export class ChipView extends MobxLitElement {
     const shouldShowError = assistance?.selectedMode === ChipAssistanceMode.DELEGATE && 
                            assistance.proposedTime && 
                            !this.isValidAssistantOffer();
-    
     return html`
       <div class="button-wrapper">
         <pr-button

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -333,7 +333,7 @@ export const requestChipAssistance = onCall(async (request) => {
 
     // If response is valid, add to current assistance
     // If in coach assistance mode, record the proposed response and model feedback
-    if (data.assistanceMode === ChipAssistanceMode.COACH && response.success) {
+    if (data.assistanceMode === ChipAssistanceMode.COACH) {
       const participantAnswer = await getFirestoreParticipantAnswer(
         data.experimentId,
         data.participantId,
@@ -342,13 +342,18 @@ export const requestChipAssistance = onCall(async (request) => {
       if (participantAnswer?.currentAssistance) {
         const currentAssistance = participantAnswer.currentAssistance;
         currentAssistance.proposedResponse = data.offerResponse;
-        currentAssistance.message =
-          response.modelResponse['feedback'] ??
-          response.modelResponse['tradeExplanation'] ??
-          '';
-        currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
-        currentAssistance.modelResponse = response.modelResponse;
-        currentAssistance.proposedTime = requestTime;
+        currentAssistance.proposedTime = requestTime; // Set when user submits proposal
+        
+        // Only update LLM-related fields if response was successful
+        if (response.success) {
+          currentAssistance.message =
+            response.modelResponse['feedback'] ??
+            response.modelResponse['tradeExplanation'] ??
+            '';
+          currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
+          currentAssistance.modelResponse = response.modelResponse;
+        }
+        
         participantAnswer.currentAssistance = currentAssistance;
 
         await app.firestore().runTransaction(async (transaction) => {
@@ -382,7 +387,7 @@ export const requestChipAssistance = onCall(async (request) => {
   );
 
   // If in coach assistance mode, record the proposed offer and model feedback
-  if (data.assistanceMode === ChipAssistanceMode.COACH && response.success) {
+  if (data.assistanceMode === ChipAssistanceMode.COACH) {
     const participantAnswer = await getFirestoreParticipantAnswer(
       data.experimentId,
       data.participantId,
@@ -397,13 +402,18 @@ export const requestChipAssistance = onCall(async (request) => {
         sell: data.sellMap,
         timestamp: requestTime,
       });
-      currentAssistance.message =
-        response.modelResponse['feedback'] ??
-        response.modelResponse['tradeExplanation'] ??
-        '';
-      currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
-      currentAssistance.modelResponse = response.modelResponse;
-      currentAssistance.proposedTime = requestTime;
+      currentAssistance.proposedTime = requestTime; // Set when user submits proposal
+      
+      // Only update LLM-related fields if response was successful
+      if (response.success) {
+        currentAssistance.message =
+          response.modelResponse['feedback'] ??
+          response.modelResponse['tradeExplanation'] ??
+          '';
+        currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
+        currentAssistance.modelResponse = response.modelResponse;
+      }
+      
       participantAnswer.currentAssistance = currentAssistance;
 
       await app.firestore().runTransaction(async (transaction) => {

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -535,9 +535,11 @@ export const selectChipAssistanceMode = onCall(async (request) => {
         currentAssistance.message = response.modelResponse['feedback'] ?? '';
         currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
         currentAssistance.modelResponse = response.modelResponse;
+        console.log('DELEGATE response mode success - assistance updated');
       } else {
         // Set error mode if response failed
         currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+        console.log('DELEGATE response mode failed - setting ERROR mode:', response.errorMessage);
       }
       currentAssistance.proposedTime = Timestamp.now();
     }
@@ -577,9 +579,12 @@ export const selectChipAssistanceMode = onCall(async (request) => {
           '';
         currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
         currentAssistance.modelResponse = response.modelResponse;
+        console.log('DELEGATE mode success - assistance updated');
       } else {
         // Set error mode if response failed
         currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+        console.log('DELEGATE mode failed - setting ERROR mode:', response.errorMessage);
+        console.log(currentAssistance.selectedMode)
       }
       currentAssistance.proposedTime = Timestamp.now();
     }
@@ -596,6 +601,9 @@ export const selectChipAssistanceMode = onCall(async (request) => {
   } else {
     participantAnswer.currentAssistance = currentAssistance;
   }
+  
+  console.log('selectChipAssistanceMode - final currentAssistance.selectedMode:', currentAssistance.selectedMode);
+  
   await app.firestore().runTransaction(async (transaction) => {
     transaction.set(
       getFirestoreParticipantAnswerRef(

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -352,6 +352,9 @@ export const requestChipAssistance = onCall(async (request) => {
             '';
           currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
           currentAssistance.modelResponse = response.modelResponse;
+        } else {
+          // Set error mode if response failed
+          currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
         }
         
         participantAnswer.currentAssistance = currentAssistance;
@@ -412,6 +415,9 @@ export const requestChipAssistance = onCall(async (request) => {
           '';
         currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
         currentAssistance.modelResponse = response.modelResponse;
+      } else {
+        // Set error mode if response failed
+        currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
       }
       
       participantAnswer.currentAssistance = currentAssistance;
@@ -529,6 +535,9 @@ export const selectChipAssistanceMode = onCall(async (request) => {
         currentAssistance.message = response.modelResponse['feedback'] ?? '';
         currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
         currentAssistance.modelResponse = response.modelResponse;
+      } else {
+        // Set error mode if response failed
+        currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
       }
       currentAssistance.proposedTime = Timestamp.now();
     }
@@ -568,6 +577,9 @@ export const selectChipAssistanceMode = onCall(async (request) => {
           '';
         currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
         currentAssistance.modelResponse = response.modelResponse;
+      } else {
+        // Set error mode if response failed
+        currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
       }
       currentAssistance.proposedTime = Timestamp.now();
     }

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -591,7 +591,7 @@ export const selectChipAssistanceMode = onCall(async (request) => {
   }
 
   // If delegate, assistance is over
-  if (data.assistanceMode === ChipAssistanceMode.DELEGATE) {
+  if (currentAssistance.selectedMode === ChipAssistanceMode.DELEGATE) {
     currentAssistance.endTime = Timestamp.now();
   }
 

--- a/functions/src/stages/chip.utils.ts
+++ b/functions/src/stages/chip.utils.ts
@@ -592,7 +592,14 @@ export async function getChipOfferAssistance(
           `Suggested: Give ${responseObj['suggestedSellQuantity']} ${responseObj['suggestedSellType']} to get ${responseObj['suggestedBuyQuantity']} ${responseObj['suggestedBuyType']} (${responseObj['reasoning']})`,
         );
       }
-      return {success: true, modelResponse: responseObj || {}};
+      
+      // Check if responseObj is valid (not empty and has required fields)
+      if (responseObj && Object.keys(responseObj).length > 0) {
+        return {success: true, modelResponse: responseObj};
+      } else {
+        console.log('Response object is empty or invalid');
+        return {success: false, errorMessage: 'Empty or invalid response object'};
+      }
     } catch (errorMessage) {
       // Response is already logged in console during Gemini API call
       console.log('Could not parse JSON:', errorMessage);
@@ -716,7 +723,12 @@ export async function getChipOfferAssistance(
         CHIP_OFFER_ASSISTANCE_ADVISOR_STRUCTURED_OUTPUT_CONFIG,
       );
       // Parse response before returning
-      return parseResponse(delegateResponse, true);
+      const parseResult = parseResponse(delegateResponse, true);
+      console.log('DELEGATE mode parse result:', parseResult);
+      if (!parseResult.success) {
+        console.log('DELEGATE mode failed - will set ERROR mode in endpoints');
+      }
+      return parseResult;
     default:
       return {success: false, errorMessage: 'Invalid assistance mode'};
   }
@@ -873,7 +885,14 @@ export async function getChipResponseAssistance(
           `${responseObject['response']} ${responseObject['feedback']}`,
         );
       }
-      return {success: true, modelResponse: responseObject || {}};
+      
+      // Check if responseObject is valid (not empty and has required fields)
+      if (responseObject && Object.keys(responseObject).length > 0) {
+        return {success: true, modelResponse: responseObject};
+      } else {
+        console.log('Response object is empty or invalid');
+        return {success: false, errorMessage: 'Empty or invalid response object'};
+      }
     } catch (errorMessage) {
       // Response is already logged in console during Gemini API call
       console.log('Could not parse JSON:', errorMessage);

--- a/functions/src/stages/chip.utils.ts
+++ b/functions/src/stages/chip.utils.ts
@@ -37,6 +37,7 @@ import {
   CHIP_RESPONSE_ASSISTANCE_COACH_STRUCTURED_OUTPUT_CONFIG,
   CHIP_RESPONSE_ASSISTANCE_ADVISOR_STRUCTURED_OUTPUT_CONFIG,
   ModelResponse,
+  ModelResponseStatus,
 } from '@deliberation-lab/utils';
 
 import {processModelResponse} from '../agent.utils';
@@ -634,7 +635,7 @@ export async function getChipOfferAssistance(
           structuredOutputConfig,
         );
         
-        if (response.status === 'ok') {
+        if (response.status === ModelResponseStatus.OK) {
           return response;
         }
         
@@ -650,16 +651,15 @@ export async function getChipOfferAssistance(
             basePrompt +
             `\n\nYour previous response is:\n\`\`\`\n${previousText}\n\`\`\`\n\nParse error: ${parseErrorMessage}\n\nPlease try again.`;
           
-          // Wait before retrying (exponential backoff)
-          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          await new Promise(resolve => setTimeout(resolve, attempt * 1000));
         }
       } catch (error) {
         lastError = error;
         console.log(`Attempt ${attempt} threw error:`, error);
         
         if (attempt < maxRetries) {
-          // Wait before retrying (exponential backoff)
-          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          // Wait before retrying
+          await new Promise(resolve => setTimeout(resolve, attempt * 1000));
         }
       }
     }
@@ -834,7 +834,7 @@ export async function getChipResponseAssistance(
           structuredOutputConfig,
         );
         
-        if (response.status === 'ok') {
+        if (response.status === ModelResponseStatus.OK) {
           return response;
         }
         
@@ -850,16 +850,16 @@ export async function getChipResponseAssistance(
             basePrompt +
             `\n\nYour previous response is:\n\`\`\`\n${previousText}\n\`\`\`\n\nParse error: ${parseErrorMessage}\n\nPlease try again.`;
           
-          // Wait before retrying (exponential backoff)
-          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          // Wait before retrying
+          await new Promise(resolve => setTimeout(resolve, attempt * 1000));
         }
       } catch (error) {
         lastError = error;
         console.log(`Attempt ${attempt} threw error:`, error);
         
         if (attempt < maxRetries) {
-          // Wait before retrying (exponential backoff)
-          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          // Wait before retrying
+          await new Promise(resolve => setTimeout(resolve, attempt * 1000));
         }
       }
     }

--- a/utils/src/stages/chip_stage.ts
+++ b/utils/src/stages/chip_stage.ts
@@ -143,6 +143,7 @@ export enum ChipAssistanceMode {
   ADVISOR = 'advisor',
   COACH = 'coach',
   DELEGATE = 'delegate',
+  ERROR = 'error', // ✅ NEW
 }
 
 /** Chip assistance move. */


### PR DESCRIPTION
1. Change the ProposedTime Variable, Only update LLM-related fields if response was successful
2. Add the new Error mode to [utils/src/stages/chip_stage.ts](https://github.com/PAIR-code/deliberate-lab/pull/590/files#diff-91e877b3324e78c1e3dccc27dd4126f8a69bb1329b0b2b25bde83f448857c3b7)
3. In [chip_participant_view.ts](https://github.com/PAIR-code/deliberate-lab/pull/590/files#diff-243102fee910e9b77581ed63fe61e78dd33c318c11effbae8e09ee282bf0ff39), added the error mode and check if the LLM query response is not valid, render the error mode

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
