### PR TITLE
Add default "false" response when offer cannot be accepted in chip assistance

### DIFF
--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -782,7 +782,7 @@ export class ChipView extends MobxLitElement {
 
     const message = this.answer?.currentAssistance?.message ?? '';
     const type = this.answer?.currentAssistance?.type;
-    let proposalLine = '<b>💡 Advisor says:</b>';
+    let proposalLine = '<b>💡 AI Assistant says:</b>';
     if (type === ChipAssistanceType.OFFER) {
       const proposedOffer = this.answer?.currentAssistance?.proposedOffer;
       if (proposedOffer) {

--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -777,7 +777,7 @@ export class ChipView extends MobxLitElement {
     const assistance = this.answer?.currentAssistance;
     if (!assistance || !assistance.type) {
       // Assistance not yet available or malformed
-      return html` <div></div> `;
+      return nothing;
     }
 
     const message = this.answer?.currentAssistance?.message ?? '';
@@ -889,7 +889,7 @@ export class ChipView extends MobxLitElement {
         ? html`<b>Initial Proposal:</b> to give
             ${this.describeChipMap(proposedOffer.sell)} to get
             ${this.describeChipMap(proposedOffer.buy)}`
-        : '';
+        : nothing;
 
       // TODO: Refactor into shared function
       // Quick hack to extract types as there is current only one type

--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -783,7 +783,6 @@ export class ChipView extends MobxLitElement {
     const message = this.answer?.currentAssistance?.message ?? '';
     const type = this.answer?.currentAssistance?.type;
     let proposalLine = '<b>💡 Advisor says:</b>';
-
     if (type === ChipAssistanceType.OFFER) {
       const proposedOffer = this.answer?.currentAssistance?.proposedOffer;
       if (proposedOffer) {
@@ -796,7 +795,6 @@ export class ChipView extends MobxLitElement {
         proposalLine += ` ${responseStr} the offer.`;
       }
     }
-
     return html`
       <div>${unsafeHTML(proposalLine)}</div>
       <div>${message}</div>

--- a/frontend/src/components/stages/chip_participant_view.ts
+++ b/frontend/src/components/stages/chip_participant_view.ts
@@ -777,12 +777,13 @@ export class ChipView extends MobxLitElement {
     const assistance = this.answer?.currentAssistance;
     if (!assistance || !assistance.type) {
       // Assistance not yet available or malformed
-      return nothing;
+      return html` <div></div> `;
     }
 
     const message = this.answer?.currentAssistance?.message ?? '';
     const type = this.answer?.currentAssistance?.type;
     let proposalLine = '<b>💡 Advisor says:</b>';
+
     if (type === ChipAssistanceType.OFFER) {
       const proposedOffer = this.answer?.currentAssistance?.proposedOffer;
       if (proposedOffer) {
@@ -795,6 +796,7 @@ export class ChipView extends MobxLitElement {
         proposalLine += ` ${responseStr} the offer.`;
       }
     }
+
     return html`
       <div>${unsafeHTML(proposalLine)}</div>
       <div>${message}</div>
@@ -889,7 +891,7 @@ export class ChipView extends MobxLitElement {
         ? html`<b>Initial Proposal:</b> to give
             ${this.describeChipMap(proposedOffer.sell)} to get
             ${this.describeChipMap(proposedOffer.buy)}`
-        : nothing;
+        : '';
 
       // TODO: Refactor into shared function
       // Quick hack to extract types as there is current only one type

--- a/frontend/src/shared/templates/chip_negotiation.ts
+++ b/frontend/src/shared/templates/chip_negotiation.ts
@@ -513,7 +513,7 @@ const CHIP_INFO_STAGE_GAMEPLAY5 = createInfoStage({
   id: 'info_gameplay5',
   name: 'Gameplay: AI assistance',
   infoLines: [
-    `Today, you will play three versions of the negotiation game. In each game, you will have access to one of the following AI assistance modes, which will be described in further detail later:`,
+    `Today, you will play three versions of the negotiation game against different players. In each game, you will have access to one of the following AI assistance modes, which will be described in further detail later:`,
     `* **AI delegate**: In delegation mode, you can delegate your trading decisions to an AI assistant. The AI will take actions on your behalf.`,
     `* **AI advisor**: In advisor mode, you can ask an AI assistant to give recommendations on which action to take. The AI will provide suggestions, but you must make the final decision.`,
     `* **AI coach**: In coach mode, you can ask an AI assistant for feedback on your actions. The AI will provide coaching, but you must make the final decision.`,
@@ -906,10 +906,11 @@ const DELEGATE_MODE_INSTRUCTION = createInfoStage({
     '',
     '**• Your choice:** At each turn, you can either make the move yourself or delegate the entire turn to the agent.',
     '**• How the delegate works:** If you choose to delegate, the agent will decide and execute a move for you, and provide you with a reason.',
-    'Remember that the delegate is built upon the same underlying AI model as the advisor and the coach, but you will only be shown its final decision, not its reasoning.',
+    'Remember that the delegate is built upon the same underlying AI model as the advisor and the coach, but you will only be shown its final decision and the reasoning only for the OFFER not the reject/accept decision.',
 
     'Here’s how you can delegate the proposal to the AI:',
     '![Example of the AI delegate making an decision when proposing](https://i.imgur.com/Qbpwm1Z.png)',
+    '![Example of the reasonings](https://i.imgur.com/rhRKCuT.png)',
     'Here’s how you can delegate the response to the AI:',
     '![Example of the AI delegate making an decision when responding to an offer](https://i.imgur.com/1Yev7H7.png)',
   ],
@@ -1232,7 +1233,7 @@ const CHIP_DELEGATE_FEEDBACK_STAGE = createSurveyStage({
     }),
     createTextSurveyQuestion({
       questionTitle:
-        'Please share any additional context on your answers. How did you decide to use (or not use) the coach? What did you think of the quality or usefulness of its suggestions?',
+        'Please share any additional context on your answers. How did you decide to use (or not use) the DELEGATE? What did you think of the quality or usefulness of its suggestions?',
     }),
   ],
 });

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -321,12 +321,10 @@ export const requestChipAssistance = onCall(async (request) => {
     // If participant cannot accept the offer and it's coach mode, return default response
     if (!canAcceptOffer() && data.assistanceMode === ChipAssistanceMode.COACH) {
       response = {
-        success: true,
-        modelResponse: {
-          feedback: "You do not have enough chips to accept this offer. So you need to reject.",
-          reasoning: "Insufficient chips to accept the offer",
-          response: false,
-        }
+        success: false,
+        modelResponse: {},
+        defaultMessage: "You do not have enough chips to accept this offer. So you need to reject.",
+        defaultReasoning: "Insufficient chips to accept the offer"
       };
     } else {
       response = await getChipResponseAssistance(
@@ -366,8 +364,14 @@ export const requestChipAssistance = onCall(async (request) => {
             response.modelResponse['reasoning'] ?? '';
           currentAssistance.modelResponse = response.modelResponse;
         } else {
-          // Set error mode if response failed
-          currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+          // Set error mode if response failed, or use default message if available
+          if (response.defaultMessage && response.defaultReasoning) {
+            currentAssistance.message = response.defaultMessage;
+            currentAssistance.reasoning = response.defaultReasoning;
+            currentAssistance.modelResponse = {};
+          } else {
+            currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+          }
         }
 
         participantAnswer.currentAssistance = currentAssistance;

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -543,11 +543,6 @@ export const selectChipAssistanceMode = onCall(async (request) => {
         currentAssistance.proposedResponse = false; // auto-reject
         currentAssistance.message = "You do not have enough chips to accept this offer. So you need to reject.";
         currentAssistance.reasoning = "Insufficient chips to accept the offer";
-        currentAssistance.modelResponse = {
-          response: false,
-          feedback: "You do not have enough chips to accept this offer. So you need to reject.",
-          reasoning: "Insufficient chips to accept the offer"
-        };
         currentAssistance.proposedTime = Timestamp.now();
         
         // If delegate mode, mark as completed and actually send the reject response

--- a/functions/src/stages/chip.endpoints.ts
+++ b/functions/src/stages/chip.endpoints.ts
@@ -309,18 +309,39 @@ export const requestChipAssistance = onCall(async (request) => {
       return {data: null};
     }
 
-    const response = await getChipResponseAssistance(
-      data.experimentId,
-      stage,
-      publicData,
-      await getFirestoreCohortParticipants(data.experimentId, data.cohortId),
-      participant,
-      participantAnswer,
-      await getExperimenterDataFromExperiment(data.experimentId),
-      data.assistanceMode,
-      currentOffer,
-      data.offerResponse,
-    );
+    // Check if participant can accept the offer (for coach mode)
+    const canAcceptOffer = () => {
+      const buyChip = Object.keys(currentOffer.buy)[0];
+      const participantChipMap = publicData.participantChipMap[participant.publicId] ?? {};
+      const availableSell = participantChipMap[buyChip] ?? 0;
+      return availableSell >= currentOffer.buy[buyChip];
+    };
+
+    let response;
+    // If participant cannot accept the offer and it's coach mode, return default response
+    if (!canAcceptOffer() && data.assistanceMode === ChipAssistanceMode.COACH) {
+      response = {
+        success: true,
+        modelResponse: {
+          feedback: "You do not have enough chips to accept this offer. So you need to reject.",
+          reasoning: "Insufficient chips to accept the offer",
+          response: false,
+        }
+      };
+    } else {
+      response = await getChipResponseAssistance(
+        data.experimentId,
+        stage,
+        publicData,
+        await getFirestoreCohortParticipants(data.experimentId, data.cohortId),
+        participant,
+        participantAnswer,
+        await getExperimenterDataFromExperiment(data.experimentId),
+        data.assistanceMode,
+        currentOffer,
+        data.offerResponse,
+      );
+    }
 
     // If response is valid, add to current assistance
     // If in coach assistance mode, record the proposed response and model feedback
@@ -509,29 +530,66 @@ export const selectChipAssistanceMode = onCall(async (request) => {
         return {data: null};
       }
 
-      const response = await getChipResponseAssistance(
-        data.experimentId,
-        stage,
-        publicData,
-        await getFirestoreCohortParticipants(data.experimentId, data.cohortId),
-        participant,
-        participantAnswer,
-        await getExperimenterDataFromExperiment(data.experimentId),
-        data.assistanceMode,
-        currentOffer,
-        data.offerResponse,
-      );
-      // If response is valid, add to current assistance
-      if (response.success) {
-        currentAssistance.proposedResponse = response.modelResponse['response'];
-        currentAssistance.message = response.modelResponse['feedback'] ?? '';
-        currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
-        currentAssistance.modelResponse = response.modelResponse;
+      // Check if participant can accept the offer
+      const canAcceptOffer = () => {
+        const buyChip = Object.keys(currentOffer.buy)[0];
+        const participantChipMap = publicData.participantChipMap[participant.publicId] ?? {};
+        const availableSell = participantChipMap[buyChip] ?? 0;
+        return availableSell >= currentOffer.buy[buyChip];
+      };
+
+      // If participant cannot accept the offer, set default response without calling LLM
+      if (!canAcceptOffer()) {
+        currentAssistance.proposedResponse = false; // auto-reject
+        currentAssistance.message = "You do not have enough chips to accept this offer. So you need to reject.";
+        currentAssistance.reasoning = "Insufficient chips to accept the offer";
+        currentAssistance.modelResponse = {
+          response: false,
+          feedback: "You do not have enough chips to accept this offer. So you need to reject.",
+          reasoning: "Insufficient chips to accept the offer"
+        };
+        currentAssistance.proposedTime = Timestamp.now();
+        
+        // If delegate mode, mark as completed and actually send the reject response
+        if (data.assistanceMode === ChipAssistanceMode.DELEGATE) {
+          currentAssistance.endTime = Timestamp.now();
+          currentAssistance.finalResponse = false;
+          
+          // Actually send the reject response to the game
+          await addChipResponseToPublicData(
+            data.experimentId,
+            data.cohortId,
+            data.stageId,
+            participant.publicId,
+            false, // reject the offer
+          );
+        }
       } else {
-        // Set error mode if response failed
-        currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+        // Normal flow - call LLM
+        const response = await getChipResponseAssistance(
+          data.experimentId,
+          stage,
+          publicData,
+          await getFirestoreCohortParticipants(data.experimentId, data.cohortId),
+          participant,
+          participantAnswer,
+          await getExperimenterDataFromExperiment(data.experimentId),
+          data.assistanceMode,
+          currentOffer,
+          data.offerResponse,
+        );
+        // If response is valid, add to current assistance
+        if (response.success) {
+          currentAssistance.proposedResponse = response.modelResponse['response'];
+          currentAssistance.message = response.modelResponse['feedback'] ?? '';
+          currentAssistance.reasoning = response.modelResponse['reasoning'] ?? '';
+          currentAssistance.modelResponse = response.modelResponse;
+        } else {
+          // Set error mode if response failed
+          currentAssistance.selectedMode = ChipAssistanceMode.ERROR;
+        }
+        currentAssistance.proposedTime = Timestamp.now();
       }
-      currentAssistance.proposedTime = Timestamp.now();
     } else {
       // Otherwise, assist with offer
       const response = await getChipOfferAssistance(

--- a/utils/src/stages/chip_stage.prompts.ts
+++ b/utils/src/stages/chip_stage.prompts.ts
@@ -122,7 +122,7 @@ export const CHIP_OFFER_ASSISTANCE_STRUCTURED_OUTPUT_CONFIG =
           schema: {
             type: StructuredOutputDataType.STRING,
             description:
-              '2-3 concise sentences explaining why this trade advances your surplus goal',
+              'In 2–3 concise sentences, explain in **first person** why *you* believe this trade helps you maximize your surplus. Stay consistent and avoid using third-person references like "the player" or "they."',
           },
         },
       ],
@@ -257,7 +257,7 @@ export const CHIP_OFFER_ASSISTANCE_ADVISOR_STRUCTURED_OUTPUT_CONFIG =
           schema: {
             type: StructuredOutputDataType.STRING,
             description:
-              '2-3 concise sentences explaining why this trade advances your surplus goal',
+              'In 2–3 concise sentences, explain in **first person** why *you* believe this trade helps you maximize your surplus. Stay consistent and avoid using third-person references like "the player" or "they."',
           },
         },
       ],


### PR DESCRIPTION
1. Add the default response when requested > current in chip-pilot, I have updated the chip.endpoint.ts 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
