### PR TITLE
undefined Chip, set default to {} for chip-pilot

### DIFF
--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -491,8 +491,8 @@ export function getChipNegotiationTurnColumns(
         !turn
           ? `player ${index + 1} ${chip.id} before turn`
           : player == senderId
-            ? (turn.senderData.chipsBeforeTurn[chip.id]?.toString() ?? '')
-            : (turn.responseData[player]?.chipsBeforeTurn[
+            ? (turn.senderData.chipsBeforeTurn?.[chip.id]?.toString() ?? '')
+            : (turn.responseData[player]?.chipsBeforeTurn?.[
                 chip.id
               ]?.toString() ?? ''),
       );
@@ -500,8 +500,8 @@ export function getChipNegotiationTurnColumns(
         !turn
           ? `player ${index + 1} ${chip.id} after turn`
           : player == senderId
-            ? (turn.senderData.chipsAfterTurn[chip.id]?.toString() ?? '')
-            : (turn.responseData[player]?.chipsAfterTurn[chip.id]?.toString() ??
+            ? (turn.senderData.chipsAfterTurn?.[chip.id]?.toString() ?? '')
+            : (turn.responseData[player]?.chipsAfterTurn?.[chip.id]?.toString() ??
               ''),
       );
     });
@@ -510,8 +510,8 @@ export function getChipNegotiationTurnColumns(
         !turn
           ? `player ${index + 1} ${chip.id} value`
           : player == senderId
-            ? (turn.senderData.chipValues[chip.id]?.toString() ?? '')
-            : (turn.responseData[player]?.chipValues[chip.id]?.toString() ??
+            ? (turn.senderData.chipValues?.[chip.id]?.toString() ?? '')
+            : (turn.responseData[player]?.chipValues?.[chip.id]?.toString() ??
               ''),
       );
     });
@@ -805,7 +805,7 @@ function getChipPayout(
   chipValueMap: Record<string, number>,
 ): number {
   let payout = 0;
-  if (!currentChipMap) return 0;
+  if (!currentChipMap || !chipValueMap) return 0;
 
   Object.keys(currentChipMap).forEach((chipId) => {
     const value = chipValueMap[chipId] ?? 0;
@@ -850,7 +850,7 @@ function getChipNegotiationTurnData(
   const senderChipValueMap = playerMetadata.participantChipValueMap[senderId];
   const senderData: ChipNegotiationSenderData = {
     participantId: senderId,
-    chipValues: playerMetadata.participantChipValueMap[senderId],
+    chipValues: playerMetadata.participantChipValueMap[senderId] ?? {},
     chipsBeforeTurn: before[senderId] ?? {},
     chipsAfterTurn: after[senderId] ?? {},
     payoutBeforeTurn: getChipPayout(before[senderId], senderChipValueMap),
@@ -871,7 +871,7 @@ function getChipNegotiationTurnData(
       selectedAsRecipient: responderId === transaction.recipientId,
       offerResponse: offerResponse.response,
       offerResponseTimestamp: offerResponse.timestamp,
-      chipValues: playerMetadata.participantChipValueMap[responderId],
+      chipValues: playerMetadata.participantChipValueMap[responderId] ?? {},
       chipsBeforeTurn: before[responderId] ?? {},
       chipsAfterTurn: after[responderId] ?? {},
       payoutBeforeTurn: getChipPayout(
@@ -1226,7 +1226,7 @@ export function getSurveyStageCSVColumns(
   surveyStage.questions.forEach((question) => {
     const answer =
       stageAnswer?.kind === StageKind.SURVEY
-        ? stageAnswer?.answerMap[question.id]
+        ? (stageAnswer as any)?.answerMap[question.id]
         : null;
 
     switch (question.kind) {

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -786,15 +786,19 @@ function runChipTransaction(
   if (!currentChipMap) return {};
 
   Object.keys(currentChipMap).forEach((chipId) => {
-    newChipMap[chipId] = currentChipMap[chipId];
+    newChipMap[chipId] = Number(currentChipMap[chipId]) || 0;
   });
 
   Object.keys(addChipMap).forEach((chipId) => {
-    newChipMap[chipId] = (currentChipMap[chipId] ?? 0) + addChipMap[chipId];
+    const currentAmount = Number(newChipMap[chipId]) || 0;
+    const addAmount = Number(addChipMap[chipId]) || 0;
+    newChipMap[chipId] = currentAmount + addAmount;
   });
 
   Object.keys(removeChipMap).forEach((chipId) => {
-    newChipMap[chipId] = (currentChipMap[chipId] ?? 0) - removeChipMap[chipId];
+    const currentAmount = Number(newChipMap[chipId]) || 0;
+    const removeAmount = Number(removeChipMap[chipId]) || 0;
+    newChipMap[chipId] = currentAmount - removeAmount;
   });
 
   return newChipMap;
@@ -808,8 +812,9 @@ function getChipPayout(
   if (!currentChipMap || !chipValueMap) return 0;
 
   Object.keys(currentChipMap).forEach((chipId) => {
-    const value = chipValueMap[chipId] ?? 0;
-    payout += value * currentChipMap[chipId];
+    const value = Number(chipValueMap[chipId]) || 0;
+    const quantity = Number(currentChipMap[chipId]) || 0;
+    payout += value * quantity;
   });
 
   return Math.ceil(payout * 100) / 100; // round final payout

--- a/utils/src/stages/chip_stage.utils.ts
+++ b/utils/src/stages/chip_stage.utils.ts
@@ -248,8 +248,8 @@ export function calculateChipOfferPayout(
   // Calculate the total payout before the offer
   const currentTotalPayout = Object.keys(chipMap)
     .map((chipId) => {
-      const quantity = chipMap[chipId] ?? 0;
-      const value = chipValueMap[chipId] ?? 0;
+      const quantity = Number(chipMap[chipId]) || 0;
+      const value = Number(chipValueMap[chipId]) || 0;
       return quantity * value;
     })
     .reduce((total, value) => total + value, 0);
@@ -257,13 +257,17 @@ export function calculateChipOfferPayout(
   // Calculate the changes from the offer
   const addAmount = Object.keys(addChipMap)
     .map((chipId) => {
-      return (addChipMap[chipId] ?? 0) * (chipValueMap[chipId] ?? 0);
+      const quantity = Number(addChipMap[chipId]) || 0;
+      const value = Number(chipValueMap[chipId]) || 0;
+      return quantity * value;
     })
     .reduce((total, value) => total + value, 0);
 
   const removeAmount = Object.keys(removeChipMap)
     .map((chipId) => {
-      return (removeChipMap[chipId] ?? 0) * (chipValueMap[chipId] ?? 0);
+      const quantity = Number(removeChipMap[chipId]) || 0;
+      const value = Number(chipValueMap[chipId]) || 0;
+      return quantity * value;
     })
     .reduce((total, value) => total + value, 0);
 


### PR DESCRIPTION
1. ensure chipValue is set to default {} if undefined
2. use ?. to avoid crashing on undefined values
3. Convert addchip to number before processing in the data export function

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
