### PR TITLE
Add shuffling to PromptItemGroups.

### DIFF
--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -5,6 +5,7 @@ import '../../pair-components/textarea';
 import '@material/web/checkbox/checkbox.js';
 
 import './structured_prompt_editor';
+import {renderShuffleIndicator} from './structured_prompt_editor';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -231,7 +232,7 @@ export class EditorComponent extends MobxLitElement {
         case PromptItemType.GROUP:
           const group = item as PromptItemGroup;
           // prettier-ignore
-          return html`<details class="prompt-group-preview" open><summary class="chip tertiary">GROUP: ${group.title}</summary><div class="chip-collapsible">${group.items.map((subItem) => renderPromptItem(subItem))}</div></details>`;
+          return html`<details class="prompt-group-preview" open><summary class="chip tertiary">GROUP: ${group.title} ${renderShuffleIndicator(group.shuffleConfig)}</summary><div class="chip-collapsible">${group.items.map((subItem) => renderPromptItem(subItem))}</div></details>`;
         default:
           return html`<div class="chip tertiary">${item.type}</div>`;
       }

--- a/frontend/src/components/experiment_builder/structured_prompt_editor.scss
+++ b/frontend/src/components/experiment_builder/structured_prompt_editor.scss
@@ -160,3 +160,32 @@ pr-textarea {
   padding: common.$spacing-medium;
   text-align: center;
 }
+
+.shuffle-config {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-medium;
+  background: var(--md-sys-color-surface);
+  border-radius: common.$spacing-small;
+  margin-bottom: common.$spacing-medium;
+  flex-wrap: wrap;
+
+  select,
+  input[type='text'] {
+    padding: common.$spacing-small;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: common.$spacing-xs;
+    background-color: var(--md-sys-color-surface);
+    color: var(--md-sys-color-on-surface);
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  select {
+    width: fit-content;
+  }
+
+  input[type='text'] {
+    flex: 1;
+  }
+}

--- a/frontend/src/components/experiment_builder/structured_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/structured_prompt_editor.ts
@@ -18,6 +18,7 @@ import {
   createDefaultStageContextPromptItem,
   createDefaultPromptItemGroup,
   ShuffleConfig,
+  SeedStrategy,
 } from '@deliberation-lab/utils';
 
 import {styles} from './structured_prompt_editor.scss';
@@ -402,17 +403,37 @@ export class EditorComponent extends MobxLitElement {
                     shuffleConfig: {
                       ...shuffleConfig,
                       seed: (e.target as HTMLSelectElement)
-                        .value as ShuffleConfig['seed'],
+                        .value as SeedStrategy,
                     },
                   })}
               >
-                <option value="experiment">Experiment ID</option>
-                <option value="cohort">Cohort ID</option>
-                <option value="participant">Participant ID</option>
-                <option value="custom">Custom seed</option>
+                <option
+                  value=${SeedStrategy.EXPERIMENT}
+                  ?selected=${shuffleConfig.seed === SeedStrategy.EXPERIMENT}
+                >
+                  Experiment ID
+                </option>
+                <option
+                  value=${SeedStrategy.COHORT}
+                  ?selected=${shuffleConfig.seed === SeedStrategy.COHORT}
+                >
+                  Cohort ID
+                </option>
+                <option
+                  value=${SeedStrategy.PARTICIPANT}
+                  ?selected=${shuffleConfig.seed === SeedStrategy.PARTICIPANT}
+                >
+                  Participant ID
+                </option>
+                <option
+                  value=${SeedStrategy.CUSTOM}
+                  ?selected=${shuffleConfig.seed === SeedStrategy.CUSTOM}
+                >
+                  Custom seed
+                </option>
               </select>
 
-              ${shuffleConfig.seed === 'custom'
+              ${shuffleConfig.seed === SeedStrategy.CUSTOM
                 ? html`
                     <input
                       type="text"
@@ -450,7 +471,7 @@ export function renderShuffleIndicator(
   return html`
     <span title="Shuffle enabled">
       🔀
-      ${shuffleConfig.seed}${shuffleConfig.seed === 'custom'
+      ${shuffleConfig.seed}${shuffleConfig.seed === SeedStrategy.CUSTOM
         ? `: ${shuffleConfig.customSeed}`
         : ''}
     </span>

--- a/frontend/src/components/experiment_builder/structured_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/structured_prompt_editor.ts
@@ -402,8 +402,8 @@ export class EditorComponent extends MobxLitElement {
                   this.updatePromptItem(group, {
                     shuffleConfig: {
                       ...shuffleConfig,
-                      seed: (e.target as HTMLSelectElement)
-                        .value as SeedStrategy,
+                      seed: ((e.target as HTMLSelectElement).value ||
+                        '') as SeedStrategy,
                     },
                   })}
               >

--- a/utils/src/structured_prompt.ts
+++ b/utils/src/structured_prompt.ts
@@ -12,7 +12,7 @@ import {
   ChatMediatorStructuredOutputConfig,
   createStructuredOutputConfig,
 } from './structured_output';
-import {ShuffleConfig} from './utils/random.utils';
+import {ShuffleConfig, SeedStrategy} from './utils/random.utils';
 
 // ****************************************************************************
 // TYPES
@@ -145,7 +145,7 @@ export function createDefaultPromptItemGroup(
     items,
     shuffleConfig: {
       shuffle: false,
-      seed: 'participant',
+      seed: SeedStrategy.PARTICIPANT,
       customSeed: 'default',
     },
   };

--- a/utils/src/structured_prompt.ts
+++ b/utils/src/structured_prompt.ts
@@ -146,7 +146,7 @@ export function createDefaultPromptItemGroup(
     shuffleConfig: {
       shuffle: false,
       seed: SeedStrategy.PARTICIPANT,
-      customSeed: 'default',
+      customSeed: '',
     },
   };
 }

--- a/utils/src/structured_prompt.ts
+++ b/utils/src/structured_prompt.ts
@@ -12,6 +12,7 @@ import {
   ChatMediatorStructuredOutputConfig,
   createStructuredOutputConfig,
 } from './structured_output';
+import {ShuffleConfig} from './utils/random.utils';
 
 // ****************************************************************************
 // TYPES
@@ -95,6 +96,7 @@ export interface PromptItemGroup extends BasePromptItem {
   type: PromptItemType.GROUP;
   title: string;
   items: PromptItem[];
+  shuffleConfig?: ShuffleConfig;
 }
 
 // ****************************************************************************
@@ -141,6 +143,11 @@ export function createDefaultPromptItemGroup(
     type: PromptItemType.GROUP,
     title,
     items,
+    shuffleConfig: {
+      shuffle: false,
+      seed: 'participant',
+      customSeed: 'default',
+    },
   };
 }
 

--- a/utils/src/utils/random.utils.ts
+++ b/utils/src/utils/random.utils.ts
@@ -75,7 +75,7 @@ export const choices = <T>(array: readonly T[], n: number): T[] => {
 /** Shuffles an array using a string seed for consistent results. */
 export const shuffleWithSeed = <T>(
   array: readonly T[],
-  seedString: string,
+  seedString: string = '',
 ): T[] => {
   // Convert string to numeric seed
   let seedValue = 0;

--- a/utils/src/utils/random.utils.ts
+++ b/utils/src/utils/random.utils.ts
@@ -1,5 +1,12 @@
 /** Random utilities that support seeding. */
 
+/** Configuration for shuffling items with different seed strategies */
+export interface ShuffleConfig {
+  shuffle: boolean;
+  seed: 'experiment' | 'cohort' | 'participant' | 'custom';
+  customSeed: string; // Always set, but only used when seed is 'custom'
+}
+
 // ********************************************************************************************* //
 //                                             SEED                                              //
 // ********************************************************************************************* //

--- a/utils/src/utils/random.utils.ts
+++ b/utils/src/utils/random.utils.ts
@@ -1,10 +1,18 @@
 /** Random utilities that support seeding. */
 
+/** Enum for seed strategies */
+export enum SeedStrategy {
+  EXPERIMENT = 'experiment',
+  COHORT = 'cohort',
+  PARTICIPANT = 'participant',
+  CUSTOM = 'custom',
+}
+
 /** Configuration for shuffling items with different seed strategies */
 export interface ShuffleConfig {
   shuffle: boolean;
-  seed: 'experiment' | 'cohort' | 'participant' | 'custom';
-  customSeed: string; // Always set, but only used when seed is 'custom'
+  seed: SeedStrategy;
+  customSeed: string; // Always set, but only used when seed is SeedStrategy.CUSTOM
 }
 
 // ********************************************************************************************* //


### PR DESCRIPTION
Follow-up to #622 -- adds the ability to shuffle `PromptItemGroup`s based on experiment ID, cohort ID, participant ID, or a custom seed string.

(Need to rebase after #622 is merged)