### PR TITLE
Fix StructuredOutputType selector in agent editor

### DIFF
--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -536,8 +536,7 @@ export class EditorComponent extends MobxLitElement {
           >
             <option
               value="${StructuredOutputType.NONE}"
-              ?selected=${!config.type ||
-              config.type === StructuredOutputType.NONE}
+              ?selected=${config.type === StructuredOutputType.NONE}
             >
               No output forcing
             </option>


### PR DESCRIPTION
For some reason, the `StructuredOutputType` selector does not update when initialized. This fixes it.