### PR TITLE
Update experiment editor UI with streamlined nav, tabs for stage settings, alpha mode tags

### DIFF
--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -102,7 +102,9 @@ export class EditorComponent extends MobxLitElement {
 
   private renderAddButton() {
     return html`
-      <pr-button variant="tonal" @click=${this.addPrompt}>Add prompt</pr-button>
+      <pr-button color="error" variant="tonal" @click=${this.addPrompt}>
+        Add prompt
+      </pr-button>
     `;
   }
 

--- a/frontend/src/components/experiment_builder/agent_persona_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_persona_editor.ts
@@ -50,6 +50,7 @@ export class AgentPersonaEditorComponent extends MobxLitElement {
     return html`
       <div class="agent-wrapper">
         ${this.renderAgentPrivateName(agentConfig)}
+        ${this.renderAgentPrivateDescription(agentConfig)}
         ${this.renderAgentName(agentConfig)} ${this.renderAvatars(agentConfig)}
         ${this.renderAgentApiType(agentConfig)}
         ${this.renderAgentModel(agentConfig)}
@@ -118,6 +119,24 @@ export class AgentPersonaEditorComponent extends MobxLitElement {
         class=${agent.name.length === 0 ? 'required' : ''}
         ?disabled=${!this.experimentEditor.canEditStages}
         @input=${updateName}
+      >
+      </md-filled-text-field>
+    `;
+  }
+
+  private renderAgentPrivateDescription(agent: AgentPersonaConfig) {
+    const updateDescription = (e: InputEvent) => {
+      const description = (e.target as HTMLTextAreaElement).value;
+      this.updatePersona({description});
+    };
+
+    return html`
+      <md-filled-text-field
+        type="textarea"
+        label="Description (viewable to experimenters only)"
+        .value=${agent.description}
+        ?disabled=${!this.experimentEditor.canEditStages}
+        @input=${updateDescription}
       >
       </md-filled-text-field>
     `;

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -129,6 +129,10 @@
   gap: common.$spacing-xxl;
   max-width: common.$info-content-max-width;
   padding-bottom: calc(common.$main-content-padding * 2);
+
+  &.padding {
+    padding: common.$main-content-padding;
+  }
 }
 
 .chip {

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -141,6 +141,17 @@
   padding: common.$spacing-small common.$spacing-medium;
 }
 
+.alpha {
+  @include typescale.label-small;
+  border: 1px solid var(--md-sys-color-secondary);
+  border-radius: common.$spacing-small;
+  color: var(--md-sys-color-secondary);
+  margin-left: common.$spacing-medium;
+  padding: common.$spacing-xs;
+  text-transform: uppercase;
+  width: max-content;
+}
+
 pr-button pr-icon {
   margin-right: common.$spacing-medium;
 }
@@ -188,6 +199,10 @@ pr-button pr-icon {
 
 .subtitle {
   @include typescale.label-small;
+
+  &.warning {
+    color: var(--md-sys-color-tertiary);
+  }
 }
 
 .title-field {

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -9,6 +9,33 @@
   width: 100%;
 }
 
+.sidenav {
+  @include common.flex-column;
+  border-right: 1px solid var(--md-sys-color-outline);
+  flex-shrink: 0;
+  width: common.$sidenav-width;
+}
+
+.sidenav-header {
+  @include common.flex-row;
+  align-items: center;
+  background: var(--md-sys-color-surface);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+  height: common.$header-height;
+  padding: 0 common.$sidenav-padding;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.sidenav-items {
+  @include common.flex-column;
+  flex-shrink: 0;
+  gap: common.$spacing-medium;
+  padding: common.$sidenav-padding;
+}
+
 .panel-wrapper {
   @include common.flex-row;
   border-right: 3px solid var(--md-sys-color-outline-variant);

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -142,14 +142,7 @@
 }
 
 .alpha {
-  @include typescale.label-small;
-  border: 1px solid var(--md-sys-color-secondary);
-  border-radius: common.$spacing-small;
-  color: var(--md-sys-color-secondary);
-  margin-left: common.$spacing-medium;
-  padding: common.$spacing-xs;
-  text-transform: uppercase;
-  width: max-content;
+  @include common.mode-tag;
 }
 
 pr-button pr-icon {

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -128,7 +128,6 @@
   flex-grow: 1;
   gap: common.$spacing-xxl;
   max-width: common.$info-content-max-width;
-  padding: common.$main-content-padding;
   padding-bottom: calc(common.$main-content-padding * 2);
 }
 

--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -47,7 +47,7 @@
 
 .panel-view {
   @include common.flex-column;
-  color: var(--md-sys-color-outline);
+  color: var(--md-sys-color-on-surface-container);
   flex-grow: 1;
   overflow: auto;
 
@@ -70,7 +70,7 @@
 .panel-view-header {
   @include common.flex-row-align-center;
   @include typescale.label-small;
-  color: var(--md-sys-color-outline);
+  color: var(--md-sys-color-secondary);
   flex-shrink: 0;
   flex-wrap: wrap;
   gap: common.$spacing-small;
@@ -192,6 +192,7 @@ pr-button pr-icon {
 
 .subtitle {
   @include typescale.label-small;
+  color: var(--md-sys-color-outline);
 
   &.warning {
     color: var(--md-sys-color-tertiary);
@@ -200,4 +201,22 @@ pr-button pr-icon {
 
 .title-field {
   flex-grow: 1;
+}
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+.inner-wrapper {
+  @include common.flex-column;
+  gap: common.$spacing-xxl;
+  max-width: common.$info-content-max-width;
+  padding: common.$main-content-padding;
+  padding-bottom: calc(common.$main-content-padding * 2);
 }

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -155,7 +155,7 @@ export class ExperimentBuilder extends MobxLitElement {
                 this.panelView = PanelView.API_KEY;
               }}
             >
-              <div>API Key</div>
+              <div>API key</div>
               <div class="subtitle">Configure API key used for agent calls</div>
             </div>
             <div
@@ -164,6 +164,7 @@ export class ExperimentBuilder extends MobxLitElement {
                 : ''}"
               @click=${() => {
                 this.panelView = PanelView.AGENT_MEDIATORS;
+                this.experimentEditor.setAgentIdToLatest(true);
               }}
             >
               <div>Agent mediators</div>
@@ -178,6 +179,7 @@ export class ExperimentBuilder extends MobxLitElement {
                       : ''}"
                     @click=${() => {
                       this.panelView = PanelView.AGENT_PARTICIPANTS;
+                      this.experimentEditor.setAgentIdToLatest(false);
                     }}
                   >
                     <div>
@@ -213,17 +215,28 @@ export class ExperimentBuilder extends MobxLitElement {
   }
 
   private renderAddMediatorButton() {
+    const disabled =
+      this.experimentEditor.getMediatorAllowedStages().length === 0;
+    const tooltipText = disabled
+      ? 'No mediator-compatible stages have been added to this experiment. Add a mediator-compatible stage (e.g., chat) to enable this.'
+      : '';
+
     return html`
-      <pr-button
-        icon="person_add"
-        color="tertiary"
-        variant="tonal"
-        @click=${() => {
-          this.experimentEditor.addAgentMediator();
-        }}
-      >
-        + Add agent mediator persona
-      </pr-button>
+      <pr-tooltip text=${tooltipText} position="BOTTOM_END">
+        <pr-button
+          icon="person_add"
+          color="tertiary"
+          variant="tonal"
+          ?disabled=${disabled}
+          aria-disabled=${disabled ? 'true' : 'false'}
+          @click=${() => {
+            if (disabled) return;
+            this.experimentEditor.addAgentMediator();
+          }}
+        >
+          + Add agent mediator persona
+        </pr-button>
+      </pr-tooltip>
     `;
   }
 
@@ -396,6 +409,11 @@ export class ExperimentBuilder extends MobxLitElement {
         </div>
         <div class="content">
           <agent-persona-editor .agent=${agent?.persona}>
+          <br/>
+          <div class="divider main">
+          
+          ${this.experimentEditor.stages.length === 0 ? '' : html`<div class="header">Stage-specific prompts</div>`}
+
             ${this.experimentEditor.stages.map(
               (stage, index) => html`
                 <agent-chat-prompt-editor
@@ -450,6 +468,9 @@ export class ExperimentBuilder extends MobxLitElement {
         </div>
         <div class="content">
           <agent-persona-editor .agent=${agent?.persona}>
+            ${this.experimentEditor.stages.length === 0
+              ? ''
+              : html`<div class="header">Stage-specific prompts</div>`}
             ${this.experimentEditor.stages.map(
               (stage, index) => html`
                 <agent-chat-prompt-editor

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -29,6 +29,8 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 
+import '@material/web/checkbox/checkbox.js';
+
 import {core} from '../../core/core';
 import {AnalyticsService, ButtonClick} from '../../services/analytics.service';
 import {ExperimentEditor} from '../../services/experiment.editor';
@@ -42,6 +44,7 @@ import {styles} from './experiment_builder.scss';
 enum PanelView {
   AGENT_MEDIATORS = 'agent_mediators',
   AGENT_PARTICIPANTS = 'agent_participants',
+  ALPHA = 'alpha',
   API_KEY = 'api_key',
   COHORT = 'cohort',
   METADATA = 'metadata',
@@ -166,20 +169,44 @@ export class ExperimentBuilder extends MobxLitElement {
               <div>Agent mediators</div>
               <div class="subtitle">Add and configure agent mediators</div>
             </div>
+            ${this.experimentEditor.showAlphaFeatures
+              ? html`
+                  <div
+                    class="general-item ${this.panelView ===
+                    PanelView.AGENT_PARTICIPANTS
+                      ? 'current'
+                      : ''}"
+                    @click=${() => {
+                      this.panelView = PanelView.AGENT_PARTICIPANTS;
+                    }}
+                  >
+                    <div>
+                      Agent participants<span class="alpha">alpha</span>
+                    </div>
+                    <div class="subtitle">
+                      Add and configure agent participants
+                    </div>
+                  </div>
+                `
+              : nothing}
+            <div class="panel-view-header">
+              <div class="header-title">Additional settings</div>
+            </div>
             <div
-              class="general-item ${this.panelView ===
-              PanelView.AGENT_PARTICIPANTS
+              class="general-item ${this.panelView === PanelView.ALPHA
                 ? 'current'
                 : ''}"
               @click=${() => {
-                this.panelView = PanelView.AGENT_PARTICIPANTS;
+                this.panelView = PanelView.ALPHA;
               }}
             >
-              <div>Agent participants<span class="alpha">alpha</span></div>
-              <div class="subtitle">Add and configure agent participants</div>
+              <div>
+                Alpha features
+                <div class="subtitle">Toggle alpha features in editor</div>
+              </div>
             </div>
+            <div class="bottom">${this.renderDeleteButton()}</div>
           </div>
-          <div class="bottom">${this.renderDeleteButton()}</div>
         </div>
       </div>
     `;
@@ -302,6 +329,28 @@ export class ExperimentBuilder extends MobxLitElement {
       return this.renderAgentParticipantsBuilder();
     } else if (this.panelView === PanelView.STAGES) {
       return this.renderStageBuilder();
+    } else if (this.panelView === PanelView.ALPHA) {
+      return html`
+        <div class="inner-wrapper">
+          <div class="title">Alpha mode</div>
+          <div class="checkbox-wrapper">
+            <md-checkbox
+              touch-target="wrapper"
+              ?checked=${this.experimentEditor.showAlphaFeatures}
+              @click=${() => {
+                this.experimentEditor.setShowAlphaFeatures(
+                  !this.experimentEditor.showAlphaFeatures,
+                );
+              }}
+            >
+            </md-checkbox>
+            <div>
+              Show "alpha mode" options when building experiment. Note that
+              alpha features are still in progress and may not work as intended.
+            </div>
+          </div>
+        </div>
+      `;
     }
     return nothing;
   }

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -59,7 +59,7 @@ export class ExperimentBuilder extends MobxLitElement {
 
   override render() {
     return html`
-      ${this.renderNavPanel()} ${this.renderExperimentConfigBuilder()}
+      ${this.renderPanelView()} ${this.renderExperimentConfigBuilder()}
       ${this.renderExperimenterSettings()} ${this.renderStageBuilderDialog()}
     `;
   }
@@ -73,148 +73,111 @@ export class ExperimentBuilder extends MobxLitElement {
     return nothing;
   }
 
-  private renderNavPanel() {
-    const isSelected = (panelView: PanelView) => {
-      return this.panelView === panelView;
-    };
-
+  private renderPanelView() {
     return html`
       <div class="panel-wrapper">
-        <div class="sidebar">
-          <pr-tooltip text="Experiment settings" position="RIGHT_END">
-            <pr-icon-button
-              color="secondary"
-              icon="folder_managed"
-              size="medium"
-              variant=${!isSelected(PanelView.API_KEY) ? 'tonal' : 'default'}
+        <div class="panel-view">
+          <div class="top">
+            <div class="panel-view-header">
+              <div class="header-title">General settings</div>
+              ${this.renderAddStageButton()}
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.DEFAULT
+                ? 'current'
+                : ''}"
               @click=${() => {
                 this.panelView = PanelView.DEFAULT;
               }}
             >
-            </pr-icon-button>
-          </pr-tooltip>
-          <pr-tooltip text="API key settings" position="RIGHT_END">
-            <pr-icon-button
-              color="secondary"
-              icon="key"
-              size="medium"
-              variant=${isSelected(PanelView.API_KEY) ? 'tonal' : 'default'}
+              <div>Metadata</div>
+              <div class="subtitle">
+                Experiment name, visibility, Prolific integration
+              </div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.STAGES
+                ? 'current'
+                : ''}"
+              @click=${() => {
+                this.panelView = PanelView.STAGES;
+              }}
+            >
+              <div>Experiment stages</div>
+              <div class="subtitle">Add and configure experiment stages</div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.API_KEY
+                ? 'current'
+                : ''}"
               @click=${() => {
                 this.panelView = PanelView.API_KEY;
               }}
             >
-            </pr-icon-button>
-          </pr-tooltip>
-        </div>
-        ${this.renderPanelView()}
-      </div>
-    `;
-  }
-
-  private renderPanelView() {
-    if (this.panelView === PanelView.API_KEY) {
-      return html`
-        <div class="panel-view">
-          <div class="top">
-            <div class="panel-view-header">Experimenter settings</div>
-            <div>
-              ⚠️ Note that experimenter API settings are shared across all
-              experiments!
+              <div>API Key</div>
+              <div class="subtitle">Configure API key</div>
             </div>
-          </div>
-        </div>
-      `;
-    }
-
-    return html`
-      <div class="panel-view">
-        <div class="top">
-          <div class="panel-view-header">
-            <div class="header-title">General settings</div>
-            ${this.renderAddStageButton()}
-          </div>
-          <div
-            class="general-item ${this.panelView === PanelView.DEFAULT
-              ? 'current'
-              : ''}"
-            @click=${() => {
-              this.panelView = PanelView.DEFAULT;
-            }}
-          >
-            <div>Metadata</div>
-            <div class="subtitle">
-              Experiment name, visibility, Prolific integration
+            <div class="panel-view-header">
+              <div class="header-title">Agent Mediators</div>
+              ${this.renderAddMediatorButton()}
             </div>
-          </div>
-          <div
-            class="general-item ${this.panelView === PanelView.STAGES
-              ? 'current'
-              : ''}"
-            @click=${() => {
-              this.panelView = PanelView.STAGES;
-            }}
-          >
-            <div>Stages</div>
-            <div class="subtitle">Add and configure experiment stages</div>
-          </div>
-          <div class="panel-view-header">
-            <div class="header-title">Agent Mediators</div>
-            ${this.renderAddMediatorButton()}
-          </div>
-          ${this.experimentEditor.agentMediators.map(
-            (mediator) => html`
-              <div
-                class="agent-item ${this.experimentEditor.currentAgentId ===
-                  mediator.persona.id && this.panelView === PanelView.AGENTS
-                  ? 'current'
-                  : ''}"
-                @click=${() => {
-                  this.panelView = PanelView.AGENTS;
-                  this.experimentEditor.setCurrentAgentId(mediator.persona.id);
-                }}
-              >
-                <div>
-                  ${mediator.persona.name.length > 0
-                    ? mediator.persona.name
-                    : mediator.persona.defaultProfile.name}
+            ${this.experimentEditor.agentMediators.map(
+              (mediator) => html`
+                <div
+                  class="agent-item ${this.experimentEditor.currentAgentId ===
+                    mediator.persona.id && this.panelView === PanelView.AGENTS
+                    ? 'current'
+                    : ''}"
+                  @click=${() => {
+                    this.panelView = PanelView.AGENTS;
+                    this.experimentEditor.setCurrentAgentId(
+                      mediator.persona.id,
+                    );
+                  }}
+                >
+                  <div>
+                    ${mediator.persona.name.length > 0
+                      ? mediator.persona.name
+                      : mediator.persona.defaultProfile.name}
+                  </div>
+                  <div class="subtitle">
+                    ${mediator.persona.defaultModelSettings.modelName}
+                  </div>
+                  <div class="subtitle">${mediator.persona.id}</div>
                 </div>
-                <div class="subtitle">
-                  ${mediator.persona.defaultModelSettings.modelName}
+              `,
+            )}
+            <div class="panel-view-header">
+              <div class="header-title">Agent Participants</div>
+              ${this.renderAddParticipantButton()}
+            </div>
+            ${this.experimentEditor.agentParticipants.map(
+              (agent) => html`
+                <div
+                  class="agent-item ${this.experimentEditor.currentAgentId ===
+                    agent.persona.id && this.panelView === PanelView.AGENTS
+                    ? 'current'
+                    : ''}"
+                  @click=${() => {
+                    this.panelView = PanelView.AGENTS;
+                    this.experimentEditor.setCurrentAgentId(agent.persona.id);
+                  }}
+                >
+                  <div>
+                    ${agent.persona.name.length > 0
+                      ? agent.persona.name
+                      : agent.persona.defaultProfile.name}
+                  </div>
+                  <div class="subtitle">
+                    ${agent.persona.defaultModelSettings.modelName}
+                  </div>
+                  <div class="subtitle">${agent.persona.id}</div>
                 </div>
-                <div class="subtitle">${mediator.persona.id}</div>
-              </div>
-            `,
-          )}
-          <div class="panel-view-header">
-            <div class="header-title">Agent Participants</div>
-            ${this.renderAddParticipantButton()}
+              `,
+            )}
           </div>
-          ${this.experimentEditor.agentParticipants.map(
-            (agent) => html`
-              <div
-                class="agent-item ${this.experimentEditor.currentAgentId ===
-                  agent.persona.id && this.panelView === PanelView.AGENTS
-                  ? 'current'
-                  : ''}"
-                @click=${() => {
-                  this.panelView = PanelView.AGENTS;
-                  this.experimentEditor.setCurrentAgentId(agent.persona.id);
-                }}
-              >
-                <div>
-                  ${agent.persona.name.length > 0
-                    ? agent.persona.name
-                    : agent.persona.defaultProfile.name}
-                </div>
-                <div class="subtitle">
-                  ${agent.persona.defaultModelSettings.modelName}
-                </div>
-                <div class="subtitle">${agent.persona.id}</div>
-              </div>
-            `,
-          )}
+          <div class="bottom">${this.renderDeleteButton()}</div>
         </div>
-        <div class="bottom">${this.renderDeleteButton()}</div>
       </div>
     `;
   }

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -501,76 +501,104 @@ export class ExperimentBuilder extends MobxLitElement {
     switch (stage.kind) {
       case StageKind.INFO:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <info-editor .stage=${stage}></info-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Info settings</div>
+            <info-editor .stage=${stage}></info-editor>
+          </base-stage-editor>
         `;
       case StageKind.PAYOUT:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <payout-editor .stage=${stage}></payout-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Payout settings</div>
+            <payout-editor .stage=${stage}></payout-editor>
+          </base-stage-editor>
         `;
       case StageKind.PROFILE:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <profile-stage-editor .stage=${stage}></profile-stage-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Profile settings</div>
+            <profile-stage-editor .stage=${stage}></profile-stage-editor>
+          </base-stage-editor>
         `;
       case StageKind.CHAT:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <group-chat-editor .stage=${stage}></group-chat-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Chat settings</div>
+            <group-chat-editor .stage=${stage}></group-chat-editor>
+          </base-stage-editor>
         `;
       case StageKind.PRIVATE_CHAT:
         return html` <base-stage-editor .stage=${stage}></base-stage-editor> `;
       case StageKind.FLIPCARD:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <flipcard-editor .stage=${stage}></flipcard-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Flipcard settings</div>
+            <flipcard-editor .stage=${stage}></flipcard-editor>
+          </base-stage-editor>
         `;
       case StageKind.RANKING:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <ranking-editor .stage=${stage}></ranking-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Ranking settings</div>
+            <ranking-editor .stage=${stage}></ranking-editor>
+          </base-stage-editor>
         `;
       case StageKind.REVEAL:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <reveal-editor .stage=${stage}></reveal-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Reveal stages</div>
+            <reveal-editor .stage=${stage}></reveal-editor>
+          </base-stage-editor>
         `;
       case StageKind.ROLE:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <role-editor .stage=${stage}></role-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Roles</div>
+            <role-editor .stage=${stage}></role-editor>
+          </base-stage-editor>
         `;
       case StageKind.STOCKINFO:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <stockinfo-editor .stage=${stage}></stockinfo-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Stock settings</div>
+            <stockinfo-editor .stage=${stage}></stockinfo-editor>
+          </base-stage-editor>
         `;
       case StageKind.ASSET_ALLOCATION:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <asset-allocation-editor .stage=${stage}></asset-allocation-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Asset allocation configuration</div>
+            <asset-allocation-editor .stage=${stage}></asset-allocation-editor>
+          </base-stage-editor>
         `;
       case StageKind.SURVEY:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <survey-editor .stage=${stage}></survey-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Survey questions</div>
+            <survey-editor .stage=${stage}></survey-editor>
+          </base-stage-editor>
         `;
       case StageKind.SURVEY_PER_PARTICIPANT:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <survey-per-participant-editor .stage=${stage}>
-          </survey-per-participant-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Survey questions</div>
+            <survey-per-participant-editor .stage=${stage}>
+            </survey-per-participant-editor>
+          </base-stage-editor>
         `;
       case StageKind.TOS:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <tos-editor .stage=${stage}></tos-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Terms of service</div>
+            <tos-editor .stage=${stage}></tos-editor>
+          </base-stage-editor>
         `;
       case StageKind.TRANSFER:
         return html`
-          <base-stage-editor .stage=${stage}></base-stage-editor>
-          <transfer-editor .stage=${stage}></transfer-editor>
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Transfer settings</div>
+            <transfer-editor .stage=${stage}></transfer-editor>
+          </base-stage-editor>
         `;
       default:
         return html` Stage editor not found. `;

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -43,6 +43,7 @@ enum PanelView {
   API_KEY = 'api_key',
   COHORT = 'cohort',
   DEFAULT = 'default',
+  PERMISSIONS = 'permissions',
   PROLIFIC = 'prolific',
   STAGES = 'stages',
 }
@@ -93,9 +94,18 @@ export class ExperimentBuilder extends MobxLitElement {
               }}
             >
               <div>Metadata</div>
-              <div class="subtitle">
-                Experiment name, description, visibility
-              </div>
+              <div class="subtitle">Experiment name and description</div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.PERMISSIONS
+                ? 'current'
+                : ''}"
+              @click=${() => {
+                this.panelView = PanelView.PERMISSIONS;
+              }}
+            >
+              <div>Permissions</div>
+              <div class="subtitle">Set visibility of experiment dashboard</div>
             </div>
             <div
               class="general-item ${this.panelView === PanelView.STAGES
@@ -301,6 +311,12 @@ export class ExperimentBuilder extends MobxLitElement {
       return html`
         <div class="experiment-builder">
           <experiment-metadata-editor></experiment-metadata-editor>
+        </div>
+      `;
+    } else if (this.panelView === PanelView.PERMISSIONS) {
+      return html`
+        <div class="experiment-builder">
+          <experiment-permissions-editor></experiment-permissions-editor>
         </div>
       `;
     } else if (this.panelView === PanelView.PROLIFIC) {

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -263,7 +263,7 @@ export class ExperimentBuilder extends MobxLitElement {
     }
     return html`
       <div class="experiment-builder">
-        <div class="content">
+        <div class="content padding">
           <experimenter-data-editor></experimenter-data-editor>
         </div>
       </div>

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -175,7 +175,7 @@ export class ExperimentBuilder extends MobxLitElement {
                 this.panelView = PanelView.AGENT_PARTICIPANTS;
               }}
             >
-              <div>Agent participants</div>
+              <div>Agent participants<span class="alpha">alpha</span></div>
               <div class="subtitle">Add and configure agent participants</div>
             </div>
           </div>
@@ -313,6 +313,9 @@ export class ExperimentBuilder extends MobxLitElement {
       <div class="sidenav">
         <div class="sidenav-header">${this.renderAddParticipantButton()}</div>
         <div class="sidenav-items">
+          <div class="subtitle warning">
+            ⚠️ Agent participant are in alpha mode and may not work as expected.
+          </div>
           ${this.experimentEditor.agentParticipants.map(
             (agent) => html`
               <div

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -42,7 +42,7 @@ enum PanelView {
   AGENTS = 'agents',
   API_KEY = 'api_key',
   COHORT = 'cohort',
-  DEFAULT = 'default',
+  METADATA = 'metadata',
   PERMISSIONS = 'permissions',
   PROLIFIC = 'prolific',
   STAGES = 'stages',
@@ -58,7 +58,7 @@ export class ExperimentBuilder extends MobxLitElement {
   private readonly experimentManager = core.getService(ExperimentManager);
   private readonly routerService = core.getService(RouterService);
 
-  @state() panelView: PanelView = PanelView.DEFAULT;
+  @state() panelView: PanelView = PanelView.STAGES;
 
   override render() {
     return html`
@@ -86,11 +86,11 @@ export class ExperimentBuilder extends MobxLitElement {
               ${this.renderAddStageButton()}
             </div>
             <div
-              class="general-item ${this.panelView === PanelView.DEFAULT
+              class="general-item ${this.panelView === PanelView.METADATA
                 ? 'current'
                 : ''}"
               @click=${() => {
-                this.panelView = PanelView.DEFAULT;
+                this.panelView = PanelView.METADATA;
               }}
             >
               <div>Metadata</div>
@@ -307,7 +307,7 @@ export class ExperimentBuilder extends MobxLitElement {
   }
 
   private renderExperimentConfigBuilder() {
-    if (this.panelView === PanelView.DEFAULT) {
+    if (this.panelView === PanelView.METADATA) {
       return html`
         <div class="experiment-builder">
           <experiment-metadata-editor></experiment-metadata-editor>

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -82,6 +82,9 @@ export class ExperimentBuilder extends MobxLitElement {
       <div class="panel-wrapper">
         <div class="panel-view">
           <div class="top">
+            <div class="panel-view-header">
+              <div class="header-title">General settings</div>
+            </div>
             <div
               class="general-item ${this.panelView === PanelView.METADATA
                 ? 'current'
@@ -116,17 +119,6 @@ export class ExperimentBuilder extends MobxLitElement {
               <div class="subtitle">Add and configure experiment stages</div>
             </div>
             <div
-              class="general-item ${this.panelView === PanelView.API_KEY
-                ? 'current'
-                : ''}"
-              @click=${() => {
-                this.panelView = PanelView.API_KEY;
-              }}
-            >
-              <div>API Key</div>
-              <div class="subtitle">Configure API key</div>
-            </div>
-            <div
               class="general-item ${this.panelView === PanelView.PROLIFIC
                 ? 'current'
                 : ''}"
@@ -148,6 +140,20 @@ export class ExperimentBuilder extends MobxLitElement {
               <div>Cohort setup</div>
               <div class="subtitle">Specify default cohort settings</div>
             </div>
+            <div class="panel-view-header">
+              <div class="header-title">LLM settings</div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.API_KEY
+                ? 'current'
+                : ''}"
+              @click=${() => {
+                this.panelView = PanelView.API_KEY;
+              }}
+            >
+              <div>API Key</div>
+              <div class="subtitle">Configure API key used for agent calls</div>
+            </div>
             <div
               class="general-item ${this.panelView === PanelView.AGENT_MEDIATORS
                 ? 'current'
@@ -157,7 +163,7 @@ export class ExperimentBuilder extends MobxLitElement {
               }}
             >
               <div>Agent mediators</div>
-              <div class="subtitle">Define agent mediators</div>
+              <div class="subtitle">Add and configure agent mediators</div>
             </div>
             <div
               class="general-item ${this.panelView ===
@@ -169,7 +175,7 @@ export class ExperimentBuilder extends MobxLitElement {
               }}
             >
               <div>Agent participants</div>
-              <div class="subtitle">Define agent participants</div>
+              <div class="subtitle">Add and configure agent participants</div>
             </div>
           </div>
           <div class="bottom">${this.renderDeleteButton()}</div>

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -41,6 +41,7 @@ import {styles} from './experiment_builder.scss';
 enum PanelView {
   AGENTS = 'agents',
   API_KEY = 'api_key',
+  COHORT = 'cohort',
   DEFAULT = 'default',
   PROLIFIC = 'prolific',
   STAGES = 'stages',
@@ -128,6 +129,17 @@ export class ExperimentBuilder extends MobxLitElement {
             >
               <div>Prolific integration</div>
               <div class="subtitle">Set up Prolific codes</div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.COHORT
+                ? 'current'
+                : ''}"
+              @click=${() => {
+                this.panelView = PanelView.COHORT;
+              }}
+            >
+              <div>Cohort setup</div>
+              <div class="subtitle">Specify default cohort settings</div>
             </div>
             <div class="panel-view-header">
               <div class="header-title">Agent Mediators</div>
@@ -295,6 +307,12 @@ export class ExperimentBuilder extends MobxLitElement {
       return html`
         <div class="experiment-builder">
           <experiment-prolific-editor></experiment-prolific-editor>
+        </div>
+      `;
+    } else if (this.panelView === PanelView.COHORT) {
+      return html`
+        <div class="experiment-builder">
+          <experiment-cohort-editor></experiment-cohort-editor>
         </div>
       `;
     } else if (this.panelView === PanelView.AGENTS) {

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -42,6 +42,7 @@ enum PanelView {
   AGENTS = 'agents',
   API_KEY = 'api_key',
   DEFAULT = 'default',
+  PROLIFIC = 'prolific',
   STAGES = 'stages',
 }
 
@@ -92,7 +93,7 @@ export class ExperimentBuilder extends MobxLitElement {
             >
               <div>Metadata</div>
               <div class="subtitle">
-                Experiment name, visibility, Prolific integration
+                Experiment name, description, visibility
               </div>
             </div>
             <div
@@ -116,6 +117,17 @@ export class ExperimentBuilder extends MobxLitElement {
             >
               <div>API Key</div>
               <div class="subtitle">Configure API key</div>
+            </div>
+            <div
+              class="general-item ${this.panelView === PanelView.PROLIFIC
+                ? 'current'
+                : ''}"
+              @click=${() => {
+                this.panelView = PanelView.PROLIFIC;
+              }}
+            >
+              <div>Prolific integration</div>
+              <div class="subtitle">Set up Prolific codes</div>
             </div>
             <div class="panel-view-header">
               <div class="header-title">Agent Mediators</div>
@@ -276,7 +288,13 @@ export class ExperimentBuilder extends MobxLitElement {
     if (this.panelView === PanelView.DEFAULT) {
       return html`
         <div class="experiment-builder">
-          <experiment-settings-editor></experiment-settings-editor>
+          <experiment-metadata-editor></experiment-metadata-editor>
+        </div>
+      `;
+    } else if (this.panelView === PanelView.PROLIFIC) {
+      return html`
+        <div class="experiment-builder">
+          <experiment-prolific-editor></experiment-prolific-editor>
         </div>
       `;
     } else if (this.panelView === PanelView.AGENTS) {

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -6,6 +6,7 @@ import '../experimenter/experimenter_data_editor';
 import '../stages/asset_allocation_editor';
 import '../stages/base_stage_editor';
 import '../stages/group_chat_editor';
+import '../stages/private_chat_editor';
 import '../stages/flipcard_editor';
 import '../stages/ranking_editor';
 import '../stages/info_editor';
@@ -531,9 +532,7 @@ export class ExperimentBuilder extends MobxLitElement {
         return html`
           <base-stage-editor .stage=${stage}>
             <div slot="title">Mediator settings</div>
-            <div class="description">
-              Navigate to "Agent mediators" tab to add or edit mediators
-            </div>
+            <private-chat-editor .stage=${stage}></private-chat-editor>
           </base-stage-editor>
         `;
       case StageKind.FLIPCARD:

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -495,7 +495,7 @@ export class ExperimentBuilder extends MobxLitElement {
     const stage = this.experimentEditor.currentStage;
 
     if (stage === undefined) {
-      return html` Select a stage to edit. `;
+      return html`<div class="content padding">Select a stage to edit.</div>`;
     }
 
     switch (stage.kind) {
@@ -528,7 +528,14 @@ export class ExperimentBuilder extends MobxLitElement {
           </base-stage-editor>
         `;
       case StageKind.PRIVATE_CHAT:
-        return html` <base-stage-editor .stage=${stage}></base-stage-editor> `;
+        return html`
+          <base-stage-editor .stage=${stage}>
+            <div slot="title">Mediator settings</div>
+            <div class="description">
+              Navigate to "Agent mediators" tab to add or edit mediators
+            </div>
+          </base-stage-editor>
+        `;
       case StageKind.FLIPCARD:
         return html`
           <base-stage-editor .stage=${stage}>

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -17,9 +17,9 @@ import {Visibility} from '@deliberation-lab/utils';
 
 import {styles} from './experiment_settings_editor.scss';
 
-/** Editor for adjusting experiment settings */
-@customElement('experiment-settings-editor')
-export class ExperimentSettingsEditor extends MobxLitElement {
+/** Editor for adjusting experiment metadata */
+@customElement('experiment-metadata-editor')
+export class ExperimentMetadataEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly analyticsService = core.getService(AnalyticsService);
@@ -30,7 +30,7 @@ export class ExperimentSettingsEditor extends MobxLitElement {
     return html`
       <div class="inner-wrapper">
         ${this.renderMetadata()} ${this.renderPermissions()}
-        ${this.renderCohortParticipantConfig()} ${this.renderProlificConfig()}
+        ${this.renderCohortParticipantConfig()}
       </div>
     `;
   }
@@ -225,8 +225,18 @@ export class ExperimentSettingsEditor extends MobxLitElement {
       </div>
     `;
   }
+}
 
-  private renderProlificConfig() {
+/** Editor for adjusting Prolific integration settings */
+@customElement('experiment-prolific-editor')
+export class ExperimentProlificEditor extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly analyticsService = core.getService(AnalyticsService);
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+  private readonly experimentManager = core.getService(ExperimentManager);
+
+  override render() {
     const config = this.experimentEditor.experiment.prolificConfig;
     const isProlific = config.enableProlificIntegration;
 
@@ -236,8 +246,7 @@ export class ExperimentSettingsEditor extends MobxLitElement {
     };
 
     return html`
-      <div class="section">
-        <div class="title">Prolific Integration</div>
+      <div class="inner-wrapper">
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
@@ -248,12 +257,12 @@ export class ExperimentSettingsEditor extends MobxLitElement {
           </md-checkbox>
           <div>Enable integration with Prolific</div>
         </div>
-        ${isProlific ? this.renderProlificRedirectCodes() : nothing}
+        ${this.renderProlificRedirectCodes(isProlific)}
       </div>
     `;
   }
 
-  private renderProlificRedirectCodes() {
+  private renderProlificRedirectCodes(isEnabled: boolean) {
     const updateDefault = (e: InputEvent) => {
       const defaultRedirectCode = (e.target as HTMLTextAreaElement).value;
       this.experimentEditor.updateProlificConfig({defaultRedirectCode});
@@ -270,41 +279,40 @@ export class ExperimentSettingsEditor extends MobxLitElement {
     };
 
     return html`
-      <div class="inner-setting">
-        <md-filled-text-field
-          required
-          label="Default redirect code (e.g., when experiment ends)"
-          .value=${this.experimentEditor.experiment.prolificConfig
-            .defaultRedirectCode ?? ''}
-          .error=${!this.experimentEditor.experiment.prolificConfig
-            .defaultRedirectCode}
-          ?disabled=${!this.experimentManager.isCreator}
-          @input=${updateDefault}
-        >
-        </md-filled-text-field>
-        <md-filled-text-field
-          label="Attention redirect code (used when participants fail attention checks)"
-          .value=${this.experimentEditor.experiment.prolificConfig
-            .attentionFailRedirectCode ?? ''}
-          ?disabled=${!this.experimentManager.isCreator}
-          @input=${updateAttention}
-        >
-        </md-filled-text-field>
-        <md-filled-text-field
-          label="Booted redirect code (used when experimenters boot a participant from an experiment)"
-          .value=${this.experimentEditor.experiment.prolificConfig
-            .bootedRedirectCode ?? ''}
-          ?disabled=${!this.experimentManager.isCreator}
-          @input=${updateBooted}
-        >
-        </md-filled-text-field>
-      </div>
+      <md-filled-text-field
+        required
+        label="Default redirect code (e.g., when experiment ends)"
+        .value=${this.experimentEditor.experiment.prolificConfig
+          .defaultRedirectCode ?? ''}
+        .error=${!this.experimentEditor.experiment.prolificConfig
+          .defaultRedirectCode}
+        ?disabled=${!this.experimentManager.isCreator || !isEnabled}
+        @input=${updateDefault}
+      >
+      </md-filled-text-field>
+      <md-filled-text-field
+        label="Attention redirect code (used when participants fail attention checks)"
+        .value=${this.experimentEditor.experiment.prolificConfig
+          .attentionFailRedirectCode ?? ''}
+        ?disabled=${!this.experimentManager.isCreator || !isEnabled}
+        @input=${updateAttention}
+      >
+      </md-filled-text-field>
+      <md-filled-text-field
+        label="Booted redirect code (used when experimenters boot a participant from an experiment)"
+        .value=${this.experimentEditor.experiment.prolificConfig
+          .bootedRedirectCode ?? ''}
+        ?disabled=${!this.experimentManager.isCreator || !isEnabled}
+        @input=${updateBooted}
+      >
+      </md-filled-text-field>
     `;
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'experiment-settings-editor': ExperimentSettingsEditor;
+    'experiment-metadata-editor': ExperimentMetadataEditor;
+    'experiment-prolific-editor': ExperimentProlificEditor;
   }
 }

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -43,6 +43,7 @@ export class ExperimentMetadataEditor extends MobxLitElement {
 
     return html`
       <div class="inner-wrapper">
+        <div class="title">Experiment metadata</div>
         <md-filled-text-field
           label="Private experiment name (not visible to participants)"
           required
@@ -91,6 +92,7 @@ export class ExperimentPermissionsEditor extends MobxLitElement {
 
     return html`
       <div class="inner-wrapper">
+        <div class="title">Permissions</div>
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
@@ -254,6 +256,7 @@ export class ExperimentProlificEditor extends MobxLitElement {
 
     return html`
       <div class="inner-wrapper">
+        <div class="title">Prolific settings</div>
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -30,7 +30,6 @@ export class ExperimentMetadataEditor extends MobxLitElement {
     return html`
       <div class="inner-wrapper">
         ${this.renderMetadata()} ${this.renderPermissions()}
-        ${this.renderCohortParticipantConfig()}
       </div>
     `;
   }
@@ -110,13 +109,23 @@ export class ExperimentMetadataEditor extends MobxLitElement {
       </div>
     `;
   }
+}
 
-  private renderCohortParticipantConfig() {
+/** Editor for adjusting experiment cohort default settings */
+@customElement('experiment-cohort-editor')
+export class ExperimentCohortEditor extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly analyticsService = core.getService(AnalyticsService);
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+  private readonly experimentManager = core.getService(ExperimentManager);
+
+  override render() {
     // TODO: Consolidate helper functions with the ones under
     // cohorts_settings_dialog.ts (as they're basically the same,
     // just updating experiment config vs. cohort config)
     return html`
-      <div class="section">
+      <div class="inner-wrapper">
         <div class="title">Default cohort settings</div>
         <div class="description">
           Note: Cohorts within your experiment will be automatically created
@@ -313,6 +322,7 @@ export class ExperimentProlificEditor extends MobxLitElement {
 declare global {
   interface HTMLElementTagNameMap {
     'experiment-metadata-editor': ExperimentMetadataEditor;
+    'experiment-cohort-editor': ExperimentCohortEditor;
     'experiment-prolific-editor': ExperimentProlificEditor;
   }
 }

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -22,19 +22,10 @@ import {styles} from './experiment_settings_editor.scss';
 export class ExperimentMetadataEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
-  private readonly analyticsService = core.getService(AnalyticsService);
   private readonly experimentEditor = core.getService(ExperimentEditor);
   private readonly experimentManager = core.getService(ExperimentManager);
 
   override render() {
-    return html`
-      <div class="inner-wrapper">
-        ${this.renderMetadata()} ${this.renderPermissions()}
-      </div>
-    `;
-  }
-
-  private renderMetadata() {
     const updateName = (e: InputEvent) => {
       const name = (e.target as HTMLTextAreaElement).value;
       this.experimentEditor.updateMetadata({name});
@@ -51,7 +42,7 @@ export class ExperimentMetadataEditor extends MobxLitElement {
     };
 
     return html`
-      <div class="section">
+      <div class="inner-wrapper">
         <md-filled-text-field
           label="Private experiment name (not visible to participants)"
           required
@@ -80,8 +71,15 @@ export class ExperimentMetadataEditor extends MobxLitElement {
       </div>
     `;
   }
+}
 
-  private renderPermissions() {
+/** Editor for adjusting experiment permissions */
+@customElement('experiment-permissions-editor')
+export class ExperimentPermissionsEditor extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  override render() {
     const isPublic =
       this.experimentEditor.experiment.permissions.visibility ===
       Visibility.PUBLIC;
@@ -92,7 +90,7 @@ export class ExperimentMetadataEditor extends MobxLitElement {
     };
 
     return html`
-      <div class="section">
+      <div class="inner-wrapper">
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
@@ -323,6 +321,7 @@ declare global {
   interface HTMLElementTagNameMap {
     'experiment-metadata-editor': ExperimentMetadataEditor;
     'experiment-cohort-editor': ExperimentCohortEditor;
+    'experiment-permissions-editor': ExperimentPermissionsEditor;
     'experiment-prolific-editor': ExperimentProlificEditor;
   }
 }

--- a/frontend/src/components/experimenter/experimenter_data_editor.ts
+++ b/frontend/src/components/experimenter/experimenter_data_editor.ts
@@ -40,6 +40,9 @@ export class ExperimenterDataEditor extends MobxLitElement {
 
   override render() {
     return html`
+      <div class="banner">
+        Note: API keys are shared across all experiments!
+      </div>
       ${this.renderGeminiKey()}
       <div class="divider"></div>
       ${this.renderOpenAISettings()}

--- a/frontend/src/components/experimenter/experimenter_data_editor.ts
+++ b/frontend/src/components/experimenter/experimenter_data_editor.ts
@@ -194,7 +194,7 @@ export class ExperimenterDataEditor extends MobxLitElement {
       <div class="section">
         <h3>Open AI API settings</h3>
         <md-filled-text-field
-          label="API Key"
+          label="API key"
           placeholder="Add Open AI API key"
           .value=${data?.apiKeys.openAIApiKey?.apiKey ?? ''}
           @input=${(e: InputEvent) => updateOpenAISettings(e, 'apiKey')}

--- a/frontend/src/components/header/header.scss
+++ b/frontend/src/components/header/header.scss
@@ -96,6 +96,11 @@ h1 {
   color: var(--md-sys-color-outline);
 }
 
+.error {
+  @include typescale.label-small;
+  color: var(--md-sys-color-error);
+}
+
 pr-button {
   pr-icon {
     margin-right: common.$spacing-small;

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -237,10 +237,14 @@ export class Header extends MobxLitElement {
           </pr-tooltip>
         `;
       case Pages.EXPERIMENT_CREATE:
+        const errors = this.experimentEditor.getExperimentConfigErrors();
         return html`
+          ${errors.length === 0
+            ? nothing
+            : html` <div class="error">⚠️ ${errors.join(', ')}</div> `}
           <pr-button
             ?loading=${this.experimentEditor.isWritingExperiment}
-            ?disabled=${!this.experimentEditor.isValidExperimentConfig}
+            ?disabled=${errors.length > 0}
             @click=${async () => {
               this.analyticsService.trackButtonClick(
                 ButtonClick.EXPERIMENT_SAVE_NEW,

--- a/frontend/src/components/stages/base_stage_editor.scss
+++ b/frontend/src/components/stages/base_stage_editor.scss
@@ -4,7 +4,6 @@
 
 :host {
   @include common.flex-column;
-  gap: common.$spacing-xxl;
 }
 
 .section,
@@ -13,17 +12,36 @@
   gap: common.$spacing-large;
 }
 
-summary {
-  @include typescale.title-medium;
-  padding-bottom: common.$spacing-large;
+.tabs {
+  @include common.flex-row;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-wrap: wrap;
+  gap: common.$spacing-medium;
+  padding: 0 common.$spacing-large;
+  width: 100%;
 }
 
-details {
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+.tab {
+  @include common.flex-row;
+  align-items: center;
+  border-bottom: 2px solid transparent;
+  color: var(--md-sys-color-outline);
+  height: common.$header-height;
+  padding: 0 common.$spacing-medium;
 
-  .inner-section {
-    padding-bottom: common.$spacing-large;
+  &:focus,
+  &:hover {
+    cursor: pointer;
   }
+
+  &.active {
+    border-bottom-color: var(--md-sys-color-tertiary);
+    color: var(--md-sys-color-tertiary);
+  }
+}
+
+.inner-section {
+  padding: common.$spacing-large;
 }
 
 .title {
@@ -58,9 +76,4 @@ pr-textarea {
 
 .divider {
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
-}
-
-.tab {
-  margin-top: 0px;
-  margin-left: calc(48px + common.$spacing-medium);
 }

--- a/frontend/src/components/stages/base_stage_editor.ts
+++ b/frontend/src/components/stages/base_stage_editor.ts
@@ -1,6 +1,6 @@
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, property, state} from 'lit/decorators.js';
 
 import '@material/web/textfield/filled-text-field.js';
 import '@material/web/checkbox/checkbox.js';
@@ -20,6 +20,12 @@ import {
 import {styles} from './base_stage_editor.scss';
 import {mustWaitForAllParticipants} from '../../shared/experiment.utils';
 
+enum BaseStageTab {
+  STAGE = 'stage', // settings specific to stage
+  METADATA = 'metadata', // stage name, description, etc.
+  PROGRESS = 'progress', // progress settings
+}
+
 /** Editor for base StageConfig fields. */
 @customElement('base-stage-editor')
 export class BaseStageEditorComponent extends MobxLitElement {
@@ -29,28 +35,68 @@ export class BaseStageEditorComponent extends MobxLitElement {
 
   @property() stage: StageConfig | undefined = undefined;
 
+  @state() currentTab: BaseStageTab = BaseStageTab.STAGE;
+
   override render() {
     if (this.stage === undefined) {
       return nothing;
     }
 
     return html`
-      <details>
-        <summary>Metadata</summary>
-        <div class="inner-section">
-          ${this.renderName()} ${this.renderPrimaryText()}
-          ${this.renderInfoText()} ${this.renderHelpText()}
+      <div class="tabs">
+        <div
+          class="tab ${this.currentTab === BaseStageTab.METADATA
+            ? 'active'
+            : ''}"
+          @click=${() => {
+            this.currentTab = BaseStageTab.METADATA;
+          }}
+        >
+          Metadata
         </div>
-      </details>
-      <details>
-        <summary>Progress settings</summary>
-        <div class="inner-section">
-          ${this.renderWaitForAllParticipants()}
-          ${this.renderWaitForNumParticipants()}
-          ${this.renderShowParticipantProgress()}
+        <div
+          class="tab ${this.currentTab === BaseStageTab.PROGRESS
+            ? 'active'
+            : ''}"
+          @click=${() => {
+            this.currentTab = BaseStageTab.PROGRESS;
+          }}
+        >
+          Progress settings
         </div>
-      </details>
+        <div
+          class="tab ${this.currentTab === BaseStageTab.STAGE ? 'active' : ''}"
+          @click=${() => {
+            this.currentTab = BaseStageTab.STAGE;
+          }}
+        >
+          <slot name="title"></slot>
+        </div>
+      </div>
+      ${this.renderTab()}
     `;
+  }
+
+  private renderTab() {
+    switch (this.currentTab) {
+      case BaseStageTab.METADATA:
+        return html`
+          <div class="inner-section">
+            ${this.renderName()} ${this.renderPrimaryText()}
+            ${this.renderInfoText()} ${this.renderHelpText()}
+          </div>
+        `;
+      case BaseStageTab.PROGRESS:
+        return html`
+          <div class="inner-section">
+            ${this.renderWaitForAllParticipants()}
+            ${this.renderWaitForNumParticipants()}
+            ${this.renderShowParticipantProgress()}
+          </div>
+        `;
+      default:
+        return html`<div class="inner-section"><slot></slot></div>`;
+    }
   }
 
   private renderName() {

--- a/frontend/src/components/stages/group_chat_editor.scss
+++ b/frontend/src/components/stages/group_chat_editor.scss
@@ -24,6 +24,11 @@
   padding: common.$spacing-xl;
 }
 
+.title {
+  @include typescale.title-medium;
+  color: var(--md-sys-color-secondary);
+}
+
 .description {
   @include typescale.label-small;
   color: var(--md-sys-color-outline);

--- a/frontend/src/components/stages/group_chat_editor.scss
+++ b/frontend/src/components/stages/group_chat_editor.scss
@@ -35,6 +35,22 @@
   font-style: italic;
 }
 
+.card-grid {
+  @include common.flex-row;
+  flex-wrap: wrap;
+  gap: common.$spacing-large;
+}
+
+.mediator-card {
+  @include common.flex-column;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-small;
+  gap: common.$spacing-medium;
+  max-width: 300px;
+  padding: common.$spacing-large;
+  width: 100%;
+}
+
 .header {
   @include common.flex-row;
   gap: common.$spacing-medium;
@@ -110,5 +126,5 @@ pr-textarea {
 
 .error-message {
   font-style: italic;
-  color: red;
+  color: var(--md-sys-color-error);
 }

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -33,7 +33,7 @@ export class ChatEditor extends MobxLitElement {
       ${this.renderTimeLimit()}
       <div class="divider"></div>
       <div class="title">Agent settings</div>
-      <div>See agent tab to configure mediator agents!</div>
+      <div>Navigate to "Agent mediators" tab to add or edit mediators</div>
     `;
   }
 

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -32,8 +32,40 @@ export class ChatEditor extends MobxLitElement {
       <div class="title">Conversation settings</div>
       ${this.renderTimeLimit()}
       <div class="divider"></div>
-      <div class="title">Agent settings</div>
-      <div>Navigate to "Agent mediators" tab to add or edit mediators</div>
+      <div class="title">Agent mediators</div>
+      <div class="description">
+        Navigate to "Agent mediators" tab to add or edit mediators
+      </div>
+      ${this.renderMediators()}
+    `;
+  }
+
+  private renderMediators() {
+    const agentMediators = this.experimentEditor.agentMediators.filter(
+      (template) => template.promptMap[this.stage?.id ?? ''],
+    );
+
+    if (agentMediators.length === 0) {
+      return html`
+        <div class="error-message">No mediators added to this stage</div>
+      `;
+    }
+
+    return html`
+      <div class="card-grid">
+        ${agentMediators.map(
+          (mediator) => html`
+            <div class="mediator-card">
+              <div class="mediator-card-title">
+                ${mediator.persona.defaultProfile.avatar}
+                ${mediator.persona.defaultProfile.name ??
+                `Agent ${mediator.persona.id}`}
+              </div>
+              <div class="description">${mediator.persona.description}</div>
+            </div>
+          `,
+        )}
+      </div>
     `;
   }
 

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -1,0 +1,68 @@
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {ExperimentEditor} from '../../services/experiment.editor';
+
+import {PrivateChatStageConfig} from '@deliberation-lab/utils';
+
+import {styles} from './group_chat_editor.scss';
+
+@customElement('private-chat-editor')
+export class ChatEditor extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  @property() stage: PrivateChatStageConfig | undefined = undefined;
+
+  override render() {
+    if (this.stage === undefined) {
+      return nothing;
+    }
+
+    return html`
+      <div class="title">Agent mediators</div>
+      <div class="description">
+        Navigate to "Agent mediators" tab to add or edit mediators
+      </div>
+      ${this.renderMediators()}
+    `;
+  }
+
+  private renderMediators() {
+    const agentMediators = this.experimentEditor.agentMediators.filter(
+      (template) => template.promptMap[this.stage?.id ?? ''],
+    );
+
+    if (agentMediators.length === 0) {
+      return html`
+        <div class="error-message">No mediators added to this stage</div>
+      `;
+    }
+
+    return html`
+      <div class="card-grid">
+        ${agentMediators.map(
+          (mediator) => html`
+            <div class="mediator-card">
+              <div class="mediator-card-title">
+                ${mediator.persona.defaultProfile.avatar}
+                ${mediator.persona.defaultProfile.name ??
+                `Agent ${mediator.persona.id}`}
+              </div>
+              <div class="description">${mediator.persona.description}</div>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'private-chat-editor': ChatEditor;
+  }
+}

--- a/frontend/src/components/stages/transfer_editor.scss
+++ b/frontend/src/components/stages/transfer_editor.scss
@@ -1,10 +1,19 @@
-@use "../../sass/colors";
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
   gap: common.$spacing-xxl;
+}
+
+.title {
+  @include typescale.title-medium;
+  color: var(--md-sys-color-secondary);
+}
+
+.alpha {
+  @include common.mode-tag;
 }
 
 .section {

--- a/frontend/src/components/stages/transfer_editor.ts
+++ b/frontend/src/components/stages/transfer_editor.ts
@@ -27,7 +27,7 @@ export class TransferEditorComponent extends MobxLitElement {
 
   @property() stage: TransferStageConfig | undefined = undefined;
 
-  private renderSurveyToggle() {
+  private renderAutoTransfer() {
     if (!this.stage) return nothing;
     const isSurveyMatchingEnabled = this.stage.autoTransferConfig;
 
@@ -41,7 +41,10 @@ export class TransferEditorComponent extends MobxLitElement {
 
     return html`
       <div class="section">
-        <div class="title">Automatic transfer</div>
+        <div class="title">
+          Automatic transfer
+          <span class="alpha">alpha</span>
+        </div>
         <div class="description">
           If you would like to transfer participants based on rules rather than
           manually, specify the behavior here.
@@ -58,6 +61,7 @@ export class TransferEditorComponent extends MobxLitElement {
           <div>Automatically match participants based on survey answers</div>
         </div>
       </div>
+      ${this.stage.autoTransferConfig ? this.renderSurveyConfig() : nothing}
     `;
   }
 
@@ -66,11 +70,7 @@ export class TransferEditorComponent extends MobxLitElement {
       return nothing;
     }
 
-    return html`
-      ${this.renderSurveyToggle()}
-      ${this.stage.autoTransferConfig ? this.renderSurveyConfig() : nothing}
-      ${this.renderTimeout()}
-    `;
+    return html` ${this.renderTimeout()} ${this.renderAutoTransfer()} `;
   }
 
   private renderTimeout() {

--- a/frontend/src/components/stages/transfer_editor.ts
+++ b/frontend/src/components/stages/transfer_editor.ts
@@ -70,7 +70,12 @@ export class TransferEditorComponent extends MobxLitElement {
       return nothing;
     }
 
-    return html` ${this.renderTimeout()} ${this.renderAutoTransfer()} `;
+    return html`
+      ${this.renderTimeout()}
+      ${this.experimentEditor.showAlphaFeatures
+        ? this.renderAutoTransfer()
+        : nothing}
+    `;
   }
 
   private renderTimeout() {

--- a/frontend/src/sass/_common.scss
+++ b/frontend/src/sass/_common.scss
@@ -136,6 +136,17 @@
   }
 }
 
+@mixin mode-tag {
+  @include typescale.label-small;
+  border: 1px solid var(--md-sys-color-tertiary);
+  border-radius: $spacing-small;
+  color: var(--md-sys-color-tertiary);
+  margin-left: $spacing-medium;
+  padding: $spacing-xs;
+  text-transform: uppercase;
+  width: max-content;
+}
+
 @mixin table {
   @include flex-column;
   border: 1px solid var(--md-sys-color-outline);

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -102,6 +102,13 @@ export class ExperimentEditor extends Service {
     return errors;
   }
 
+  getMediatorAllowedStages() {
+    return this.stages.filter(
+      (stage) =>
+        stage.kind === StageKind.CHAT || stage.kind === StageKind.PRIVATE_CHAT,
+    );
+  }
+
   @computed get canEditStages() {
     return this.sp.experimentManager.canEditExperimentStages;
   }
@@ -272,6 +279,15 @@ export class ExperimentEditor extends Service {
 
   setCurrentAgentId(id: string) {
     this.currentAgentId = id;
+  }
+
+  setAgentIdToLatest(isMediator: boolean = true) {
+    const agents = isMediator ? this.agentMediators : this.agentParticipants;
+    if (agents.length === 0) {
+      this.setCurrentAgentId('');
+    } else {
+      this.setCurrentAgentId(agents[agents.length - 1].persona.id);
+    }
   }
 
   setAgentMediators(templates: AgentMediatorTemplate[]) {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -73,23 +73,32 @@ export class ExperimentEditor extends Service {
   // EXPERIMENT LOADING
   // **************************************************************************
 
-  @computed get isValidExperimentConfig() {
-    // TODO: Add other validation checks here
-    if (this.experiment.metadata.name.length == 0) {
-      return false;
+  getExperimentConfigErrors() {
+    const errors: string[] = [];
+
+    if (this.experiment.metadata.name.length === 0) {
+      errors.push('Experiment does not have a name');
+    }
+
+    if (this.stages.length === 0) {
+      errors.push('You must add at least one stage to your experiment');
     }
 
     for (const stage of this.stages) {
       switch (stage.kind) {
         case StageKind.SURVEY:
           // Ensure all questions have a non-empty title
-          if (!stage.questions.every((q) => q.questionTitle !== '')) {
-            return false;
-          }
+          stage.questions.forEach((question, index) => {
+            if (question.questionTitle === '') {
+              errors.push(
+                `${stage.name} question ${index + 1} is missing a title`,
+              );
+            }
+          });
           break;
       }
     }
-    return true;
+    return errors;
   }
 
   @computed get canEditStages() {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -68,6 +68,7 @@ export class ExperimentEditor extends Service {
   @observable currentStageId: string | undefined = undefined;
   @observable showStageBuilderDialog = false;
   @observable showTemplatesTab = false;
+  @observable showAlphaFeatures = false;
 
   // **************************************************************************
   // EXPERIMENT LOADING
@@ -146,6 +147,10 @@ export class ExperimentEditor extends Service {
 
   isInitializedExperiment() {
     return this.experiment.id.length > 0;
+  }
+
+  setShowAlphaFeatures(show: boolean) {
+    this.showAlphaFeatures = show;
   }
 
   updateMetadata(metadata: Partial<MetadataConfig>) {

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -130,6 +130,8 @@ export interface BaseAgentPersonaConfig {
   id: string;
   // Viewable only to experimenters
   name: string;
+  // Viewable only to experimenters
+  description: string;
   // Agent persona type
   type: AgentPersonaType;
   // If true, add to cohort on cohort creation
@@ -261,6 +263,7 @@ export function createAgentMediatorPersonaConfig(
   return {
     id: config.id ?? generateId(),
     name: config.name ?? '',
+    description: config.description ?? '',
     type: AgentPersonaType.MEDIATOR,
     isDefaultAddToCohort: config.isDefaultAddToCohort ?? true,
     defaultProfile:
@@ -280,6 +283,7 @@ export function createAgentParticipantPersonaConfig(
   return {
     id: config.id ?? generateId(),
     name: config.name ?? 'Agent Participant',
+    description: config.description ?? '',
     type: AgentPersonaType.PARTICIPANT,
     isDefaultAddToCohort: config.isDefaultAddToCohort ?? false,
     defaultProfile:

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -262,7 +262,7 @@ export function createAgentMediatorPersonaConfig(
   const type = AgentPersonaType.MEDIATOR;
   return {
     id: config.id ?? generateId(),
-    name: config.name ?? '',
+    name: config.name ?? 'Agent Mediator',
     description: config.description ?? '',
     type: AgentPersonaType.MEDIATOR,
     isDefaultAddToCohort: config.isDefaultAddToCohort ?? true,
@@ -270,7 +270,7 @@ export function createAgentMediatorPersonaConfig(
       config.defaultProfile ??
       createParticipantProfileBase({
         name: 'Mediator',
-        avatar: '🙋',
+        avatar: '🤖',
       }),
     defaultModelSettings:
       config.defaultModelSettings ?? createAgentModelSettings(),
@@ -289,8 +289,8 @@ export function createAgentParticipantPersonaConfig(
     defaultProfile:
       config.defaultProfile ??
       createParticipantProfileBase({
-        name: '',
-        avatar: '',
+        name: 'Participant',
+        avatar: '🙋',
       }),
     defaultModelSettings:
       config.defaultModelSettings ?? createAgentModelSettings(),


### PR DESCRIPTION
- Update experiment editor nav to contain single, more granular menu of panel options (with sub-settings, e.g., agent persona configs, hidden inside panels)
- Use tabs inside of stage editors to set metadata vs. progress vs. stage-specific settings
- Show errors when creating experiment (e.g., if name is missing, no stages have been added)
- Add description field to agent persona configs
- Show agent mediator previews in group/private chat stage settings
- Only show "alpha mode" features if additional setting (in experiment editor) is checked

Fixes #626 

<img width="1441" height="819" alt="Screenshot of updated experiment editor" src="https://github.com/user-attachments/assets/c5044ae0-667f-4421-b27d-4513b134db52" />
