### PR TITLE
Add group chat, private chat quickstart cards to home gallery

### DIFF
--- a/frontend/src/components/gallery/home_gallery.scss
+++ b/frontend/src/components/gallery/home_gallery.scss
@@ -109,17 +109,28 @@ h1 {
 
 .quick-start-card {
   @include common.flex-column-align-center;
-  border: 2px dashed var(--md-sys-color-outline);
+  background: var(--md-sys-color-secondary-container);
+  border: 2px solid transparent;
   border-radius: common.$spacing-medium;
+  color: var(--md-sys-color-on-secondary-container);
   cursor: pointer;
   gap: common.$spacing-medium;
   justify-content: center;
   min-height: 120px;
+  text-align: center;
   padding: common.$spacing-medium;
-  min-width: 200px;
+  width: 150px;
+
+  &.blank {
+    background: none;
+    border-color: var(--md-sys-color-outline);
+    border-style: dashed;
+  }
 
   &:focus,
-  &:hover {
+  &:hover,
+  &:focus.blank,
+  &:hover.blank {
     border-color: var(--md-sys-color-secondary);
   }
 }

--- a/frontend/src/components/gallery/home_gallery.ts
+++ b/frontend/src/components/gallery/home_gallery.ts
@@ -7,11 +7,14 @@ import {customElement} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
+import {ExperimentEditor} from '../../services/experiment.editor';
 import {HomeService} from '../../services/home.service';
 import {Pages, RouterService} from '../../services/router.service';
 
 import {Experiment, Visibility} from '@deliberation-lab/utils';
 import {convertExperimentToGalleryItem} from '../../shared/experiment.utils';
+import {getQuickstartGroupChatTemplate} from '../../shared/templates/quickstart_group_chat';
+import {getQuickstartPrivateChatTemplate} from '../../shared/templates/quickstart_private_chat';
 
 import {styles} from './home_gallery.scss';
 
@@ -123,6 +126,7 @@ export class HomeGalleryTabs extends MobxLitElement {
 export class QuickStartGallery extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly experimentEditor = core.getService(ExperimentEditor);
   private readonly routerService = core.getService(RouterService);
 
   override render() {
@@ -130,13 +134,37 @@ export class QuickStartGallery extends MobxLitElement {
       <div class="quick-start-wrapper">
         <div class="gallery-wrapper">
           <div
-            class="quick-start-card"
+            class="quick-start-card blank"
             @click=${() => {
               this.routerService.navigate(Pages.EXPERIMENT_CREATE);
             }}
           >
-            <pr-icon icon="experiment" color="neutral" size="large"></pr-icon>
-            <div>Start new experiment</div>
+            <pr-icon icon="add_2" color="neutral" size="large"></pr-icon>
+            <div>Build experiment from scratch</div>
+          </div>
+          <div
+            class="quick-start-card"
+            @click=${() => {
+              this.routerService.navigate(Pages.EXPERIMENT_CREATE);
+              this.experimentEditor.loadTemplate(
+                getQuickstartGroupChatTemplate(),
+              );
+            }}
+          >
+            <pr-icon icon="groups" color="neutral" size="large"></pr-icon>
+            <div>Group chat with agent mediator</div>
+          </div>
+          <div
+            class="quick-start-card"
+            @click=${() => {
+              this.routerService.navigate(Pages.EXPERIMENT_CREATE);
+              this.experimentEditor.loadTemplate(
+                getQuickstartPrivateChatTemplate(),
+              );
+            }}
+          >
+            <pr-icon icon="3p" color="neutral" size="large"></pr-icon>
+            <div>Private chat with agent</div>
           </div>
         </div>
       </div>

--- a/frontend/src/shared/templates/quickstart_group_chat.ts
+++ b/frontend/src/shared/templates/quickstart_group_chat.ts
@@ -1,0 +1,84 @@
+import {
+  createAgentChatSettings,
+  createAgentMediatorPersonaConfig,
+  createAgentParticipantPersonaConfig,
+  createChatPromptConfig,
+  createChatStage,
+  createExperimentConfig,
+  createExperimentTemplate,
+  createMetadataConfig,
+  createParticipantProfileBase,
+  createProfileStage,
+  createDefaultPromptFromText,
+  AgentMediatorTemplate,
+  AgentParticipantTemplate,
+  AgentPersonaType,
+  ExperimentTemplate,
+  MediatorPromptConfig,
+  ParticipantPromptConfig,
+  ProfileType,
+  StageConfig,
+  StageKind,
+} from '@deliberation-lab/utils';
+
+// ****************************************************************************
+// Experiment config
+// ****************************************************************************
+export function getQuickstartGroupChatTemplate(): ExperimentTemplate {
+  const stageConfigs = getStageConfigs();
+  const metadata = createMetadataConfig({
+    name: 'Mediated Group Chat Experiment',
+    publicName: 'Group Chat',
+    description: 'Template experiment with agent-mediated group chat',
+  });
+
+  return createExperimentTemplate({
+    experiment: createExperimentConfig(stageConfigs, {metadata}),
+    stageConfigs,
+    agentMediators: [createMediatorAgent()],
+    agentParticipants: [],
+  });
+}
+
+const CHAT_STAGE_ID = 'chat';
+
+function getStageConfigs(): StageConfig[] {
+  const stages: StageConfig[] = [];
+  stages.push(
+    createProfileStage({
+      name: 'View your randomly assigned profile',
+      profileType: ProfileType.ANONYMOUS_ANIMAL,
+    }),
+    createChatStage({
+      id: CHAT_STAGE_ID,
+      name: 'Group chat',
+    }),
+  );
+  return stages;
+}
+
+function createMediatorAgent(): AgentMediatorTemplate {
+  const persona = createAgentMediatorPersonaConfig({
+    name: 'Mediator',
+    description:
+      'Makes sure participants all have the chance to speak and that everyone is polite',
+    isDefaultAddToCohort: true,
+    defaultProfile: createParticipantProfileBase({
+      name: 'Mediator',
+      avatar: '🤖',
+    }),
+  });
+
+  const promptMap: Record<string, MediatorPromptConfig> = {};
+  promptMap[CHAT_STAGE_ID] = createChatPromptConfig(
+    CHAT_STAGE_ID, // stage ID
+    {
+      prompt: createDefaultPromptFromText(
+        'You are facilitating a group chat. Make sure all participants have a chance to speak and that everyone is polite to one another.',
+        CHAT_STAGE_ID,
+      ),
+    },
+  );
+
+  return {persona, promptMap};
+}

--- a/frontend/src/shared/templates/quickstart_private_chat.ts
+++ b/frontend/src/shared/templates/quickstart_private_chat.ts
@@ -1,0 +1,81 @@
+import {
+  createAgentChatSettings,
+  createAgentMediatorPersonaConfig,
+  createAgentParticipantPersonaConfig,
+  createChatPromptConfig,
+  createChatStage,
+  createExperimentConfig,
+  createExperimentTemplate,
+  createMetadataConfig,
+  createParticipantProfileBase,
+  createPrivateChatStage,
+  createProfileStage,
+  createDefaultPromptFromText,
+  AgentMediatorTemplate,
+  AgentParticipantTemplate,
+  AgentPersonaType,
+  ExperimentTemplate,
+  MediatorPromptConfig,
+  ParticipantPromptConfig,
+  ProfileType,
+  StageConfig,
+  StageKind,
+} from '@deliberation-lab/utils';
+
+// ****************************************************************************
+// Experiment config
+// ****************************************************************************
+export function getQuickstartPrivateChatTemplate(): ExperimentTemplate {
+  const stageConfigs = getStageConfigs();
+  const metadata = createMetadataConfig({
+    name: 'Private Chat Experiment',
+    publicName: 'Private Chat',
+    description: 'Template experiment with private chat between user and agent',
+  });
+
+  return createExperimentTemplate({
+    experiment: createExperimentConfig(stageConfigs, {metadata}),
+    stageConfigs,
+    agentMediators: [createMediatorAgent()],
+    agentParticipants: [],
+  });
+}
+
+const CHAT_STAGE_ID = 'chat';
+
+function getStageConfigs(): StageConfig[] {
+  const stages: StageConfig[] = [];
+  stages.push(
+    createProfileStage(),
+    createPrivateChatStage({
+      id: CHAT_STAGE_ID,
+      name: 'Private chat with agent',
+    }),
+  );
+  return stages;
+}
+
+function createMediatorAgent(): AgentMediatorTemplate {
+  const persona = createAgentMediatorPersonaConfig({
+    name: 'Agent',
+    description: 'Has 1-on-1 conversation with user and tries to help them',
+    isDefaultAddToCohort: true,
+    defaultProfile: createParticipantProfileBase({
+      name: 'Agent',
+      avatar: '🤖',
+    }),
+  });
+
+  const promptMap: Record<string, MediatorPromptConfig> = {};
+  promptMap[CHAT_STAGE_ID] = createChatPromptConfig(
+    CHAT_STAGE_ID, // stage ID
+    {
+      prompt: createDefaultPromptFromText(
+        'You are having a private chat with a human user. Make sure you help them with whatever they need',
+        CHAT_STAGE_ID,
+      ),
+    },
+  );
+
+  return {persona, promptMap};
+}


### PR DESCRIPTION
When clicked on, the user is navigated to experiment editor with the given "quickstart" template already loaded.

<img width="1793" height="481" alt="image" src="Screenshot of new quickstart cards" />
