### PR TITLE
Run log.utils.test.ts with Firestore emulator.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Install firebase
+      run: |
+        npm install -g firebase-tools
+
     - name: Build utils
       working-directory: ./utils
       run: |

--- a/functions/firebase-test.json
+++ b/functions/firebase-test.json
@@ -1,0 +1,49 @@
+{
+  "firestore": {
+    "rules": "firestore/firestore.rules",
+    "indexes": "firestore/indexes.json"
+  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run lint",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ],
+  "storage": {
+    "rules": "firestore/storage.rules"
+  },
+  "database": {
+    "rules": "firestore/database.rules.json"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "database": {
+      "port": 9000
+    },
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8081
+    },
+    "storage": {
+      "port": 9199
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "test": "npm run test:unit && npm run test:firestore",
-    "test:firestore": "firebase emulators:exec --only firestore \"npx jest $npm_package_config_firestore_tests\"",
+    "test:firestore": "firebase -c firebase-test.json emulators:exec --only firestore \"npx jest $npm_package_config_firestore_tests\"",
     "test:unit": "npx jest --testPathIgnorePatterns=$npm_package_config_firestore_tests"
   },
   "engines": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,10 +9,15 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "jest"
+    "test": "npm run test:unit && npm run test:firestore",
+    "test:firestore": "firebase emulators:exec --only firestore \"npx jest $npm_package_config_firestore_tests\"",
+    "test:unit": "npx jest --testPathIgnorePatterns=$npm_package_config_firestore_tests"
   },
   "engines": {
     "node": "18"
+  },
+  "config": {
+    "firestore_tests": "src/log.utils.test.ts"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/log.utils.test.ts
+++ b/functions/src/log.utils.test.ts
@@ -1,6 +1,7 @@
-// This test assumes that a Firebase emulator is running on port 8080. npm test
-// is configured to set up a temporary emulator to run the test. To do it
-// yourself, run e.g.:
+// This test assumes that a Firestore emulator is running, either at the port
+// specified by the FIRESTORE_EMULATOR_HOST environment variable, or at 8080 if
+// not specified. npm test is configured to set up a temporary emulator to run
+// the test. To do it yourself, run e.g.:
 //
 // firebase emulators:exec --only firestore "npx jest src/log.utils.test.ts"
 
@@ -19,8 +20,6 @@ import {
 } from '@deliberation-lab/utils';
 import {writeModelLogEntry} from './log.utils';
 import {getGeminiAPIResponse} from './api/gemini.api';
-
-const FIREBASE_PORT = 8080;
 
 const MODEL_NAME = 'gemini-2.5-flash';
 
@@ -53,8 +52,10 @@ describe('log.utils', () => {
       projectId: 'deliberate-lab-test',
       firestore: {
         rules: RULES,
-        host: 'localhost',
-        port: FIREBASE_PORT,
+          ...(!process.env.FIRESTORE_EMULATOR_HOST && {
+            host: 'localhost',
+            port: 8080,
+          }),
       },
     });
     mockFirestore = testEnv.unauthenticatedContext().firestore();

--- a/functions/src/log.utils.test.ts
+++ b/functions/src/log.utils.test.ts
@@ -52,10 +52,10 @@ describe('log.utils', () => {
       projectId: 'deliberate-lab-test',
       firestore: {
         rules: RULES,
-          ...(!process.env.FIRESTORE_EMULATOR_HOST && {
-            host: 'localhost',
-            port: 8080,
-          }),
+        ...(!process.env.FIRESTORE_EMULATOR_HOST && {
+          host: 'localhost',
+          port: 8080,
+        }),
       },
     });
     mockFirestore = testEnv.unauthenticatedContext().firestore();

--- a/functions/src/log.utils.test.ts
+++ b/functions/src/log.utils.test.ts
@@ -1,3 +1,9 @@
+// This test assumes that a Firebase emulator is running on port 8080. npm test
+// is configured to set up a temporary emulator to run the test. To do it
+// yourself, run e.g.:
+//
+// firebase emulators:exec --only firestore "npx jest src/log.utils.test.ts"
+
 import {
   initializeTestEnvironment,
   assertSucceeds,
@@ -13,6 +19,8 @@ import {
 } from '@deliberation-lab/utils';
 import {writeModelLogEntry} from './log.utils';
 import {getGeminiAPIResponse} from './api/gemini.api';
+
+const FIREBASE_PORT = 8080;
 
 const MODEL_NAME = 'gemini-2.5-flash';
 
@@ -46,7 +54,7 @@ describe('log.utils', () => {
       firestore: {
         rules: RULES,
         host: 'localhost',
-        port: 8080,
+        port: FIREBASE_PORT,
       },
     });
     mockFirestore = testEnv.unauthenticatedContext().firestore();


### PR DESCRIPTION
Moving #635 to the main branch.

I had a Firestore emulator already running when I was developing locally, and the test doesn't work without one.

Configure package.json to wrap this test with a firebase command to run a temporary emulator on port 8081, and check the FIRESTORE_EMULATOR_HOST environment variable it sets. Fall back to port 8080 otherwise. This way `npm test` will work whether or not an emulator is running locally, and `npx jest` will work if an emulator is running locally.

- [x] Tests pass