### PR TITLE
Collect behavioral data for bot detection

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,56 +1,65 @@
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import globals from "globals";
-import tsParser from "@typescript-eslint/parser";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import globals from 'globals';
+import tsParser from '@typescript-eslint/parser';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import js from '@eslint/js';
+import {FlatCompat} from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default [{
+export default [
+  {
     ignores: [
-        "**/dist/",
-        "**/node_modules/",
-        "**/webpack.config.js",
-        "**/lit-css-loader.js",
+      '**/dist/',
+      '**/node_modules/',
+      '**/webpack.config.js',
+      '**/lit-css-loader.js',
     ],
-}, ...compat.extends(
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-), {
+  },
+  ...compat.extends(
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+  ),
+  {
     plugins: {
-        "@typescript-eslint": typescriptEslint,
+      '@typescript-eslint': typescriptEslint,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.browser,
-        },
+      globals: {
+        ...globals.browser,
+      },
 
-        parser: tsParser,
-        ecmaVersion: 2020,
-        sourceType: "module",
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
     },
 
     rules: {
-        "no-case-declarations": "off",
-        "no-prototype-builtins": "off",
-        "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-explicit-any": "error",
-        "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-unused-vars": ["warn", {
-            argsIgnorePattern: "^_",
-        }],
+      'no-case-declarations': 'off',
+      'no-prototype-builtins': 'off',
+      '@typescript-eslint/ban-types': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
-}];
+  },
+];

--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -113,7 +113,7 @@ service cloud.firestore {
       match /agents/{agentId} {
         allow get: if isExperimenter();
         allow list: if isExperimenter();
-        // Experimenters can use cloud function endpoints
+      // Experimenters can use cloud function endpoints
         allow write: if false;
 
         match /chatPrompts/{promptId} {
@@ -131,13 +131,13 @@ service cloud.firestore {
         allow get: if true; // Public read
         allow list: if canEditExperiment(experimentId);
 
-        // Experimenters can use cloud function endpoints
+      // Experimenters can use cloud function endpoints
         allow write: if false;
 
         match /publicStageData/{stageId} {
           allow read: if true;
 
-          // TODO: Triggered by cloud function triggers
+        // TODO: Triggered by cloud function triggers
           allow write: if false;
 
           match /chats/{chatId} {
@@ -169,7 +169,7 @@ service cloud.firestore {
         allow get: if true;
         allow list: if true;
 
-        // Use cloud function endpoints
+      // Use cloud function endpoints
         allow update: if false;
       }
 
@@ -180,18 +180,24 @@ service cloud.firestore {
         allow list: if true;
         allow get: if true; // Public read
 
-        // Participants can use cloud function endpoints
+      // Participants can use cloud function endpoints
         allow update: if false;
 
         match /stageData/{stageId} {
           allow read: if true;
 
-          // Participants can use cloud function endpoints
+        // Participants can use cloud function endpoints
           allow write: if false;
         }
 
         match /alerts/{alertId} {
           allow read: if true;
+          allow write: if false; // Use cloud functions
+        }
+
+        // Append-only participant behavior events
+        match /behavior/{eventId} {
+          allow read: if isExperimenter();
           allow write: if false; // Use cloud functions
         }
       }
@@ -200,7 +206,7 @@ service cloud.firestore {
         allow list: if true;
         allow get: if true;
 
-        // Triggered by cloud function triggers
+      // Triggered by cloud function triggers
         allow write: if false;
       }
     }

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -1,15 +1,11 @@
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement} from 'lit/decorators.js';
 
 import '@material/web/textfield/filled-text-field.js';
 import '@material/web/checkbox/checkbox.js';
 
 import {core} from '../../core/core';
-import {ButtonClick, AnalyticsService} from '../../services/analytics.service';
-import {AuthService} from '../../services/auth.service';
-import {HomeService} from '../../services/home.service';
-import {Pages, RouterService} from '../../services/router.service';
 import {ExperimentEditor} from '../../services/experiment.editor';
 import {ExperimentManager} from '../../services/experiment.manager';
 
@@ -22,7 +18,6 @@ import {styles} from './experiment_settings_editor.scss';
 export class ExperimentSettingsEditor extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
-  private readonly analyticsService = core.getService(AnalyticsService);
   private readonly experimentEditor = core.getService(ExperimentEditor);
   private readonly experimentManager = core.getService(ExperimentManager);
 
@@ -92,9 +87,16 @@ export class ExperimentSettingsEditor extends MobxLitElement {
       this.experimentEditor.updatePermissions({visibility});
     };
 
+    const isBehaviorEnabled =
+      this.experimentEditor.experiment.collectBehaviorData;
+
+    const updateBehavior = () => {
+      this.experimentEditor.updateCollectBehaviorData(!isBehaviorEnabled);
+    };
+
     return html`
       <div class="section">
-        <div class="checkbox-wrapper">
+        <div class="checkbox-wrapper" style="margin-top: 8px;">
           <md-checkbox
             touch-target="wrapper"
             ?checked=${isPublic}
@@ -105,6 +107,19 @@ export class ExperimentSettingsEditor extends MobxLitElement {
           <div>
             Make experiment public (all researchers on platform can view and
             manage the experiment dashboard if you share the link with them)
+          </div>
+        </div>
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${isBehaviorEnabled}
+            ?disabled=${!this.experimentEditor.isCreator}
+            @click=${updateBehavior}
+          >
+          </md-checkbox>
+          <div>
+            Collect behavior data for bot detection (may incur additional
+            database costs)
           </div>
         </div>
       </div>

--- a/frontend/src/service_provider.ts
+++ b/frontend/src/service_provider.ts
@@ -16,6 +16,7 @@ import {SettingsService} from './services/settings.service';
 import {ExperimentEditor} from './services/experiment.editor';
 import {ExperimentManager} from './services/experiment.manager';
 import {PresenceService} from './services/presence.service';
+import {BehaviorService} from './services/behavior.service';
 
 /**
  * Defines a map of services to their identifier
@@ -66,6 +67,9 @@ export function makeServiceProvider(self: Core) {
     },
     get presenceService() {
       return self.getService(PresenceService);
+    },
+    get behaviorService() {
+      return self.getService(BehaviorService);
     },
     // Editors
     get experimentEditor() {

--- a/frontend/src/services/behavior.service.ts
+++ b/frontend/src/services/behavior.service.ts
@@ -326,7 +326,7 @@ export class BehaviorService extends Service {
         newLength: newVal.length,
         selectionStart: selStart,
         selectionEnd: selEnd,
-        isTrusted: e.isTrusted === true,
+        isTrusted: e.isTrusted,
         targetTag: el.tagName,
         inputTypeAttr: (el as HTMLInputElement).type || 'text',
       });

--- a/frontend/src/services/behavior.service.ts
+++ b/frontend/src/services/behavior.service.ts
@@ -1,0 +1,255 @@
+import {makeObservable} from 'mobx';
+import {FirebaseService} from './firebase.service';
+import {ParticipantService} from './participant.service';
+import {addBehaviorEventsCallable} from '../shared/callables';
+import {Service} from './service';
+
+interface ServiceProvider {
+  firebaseService: FirebaseService;
+  participantService: ParticipantService;
+}
+
+/** Collects client interaction events and sends in small batches. */
+export class BehaviorService extends Service {
+  constructor(private readonly sp: ServiceProvider) {
+    super();
+    makeObservable(this);
+  }
+
+  private experimentId: string | null = null;
+  private participantPrivateId: string | null = null;
+  private buffer: {
+    eventType: string;
+    relativeTimestamp: number;
+    stageId: string;
+    metadata: Record<string, unknown>;
+  }[] = [];
+  private maxBufferSize = 50;
+  private flushIntervalMs = 5000;
+  private intervalHandle: number | null = null;
+  private listenersAttached = false;
+
+  start(experimentId: string, participantPrivateId: string) {
+    // Ignore if already tracking same participant
+    if (
+      this.experimentId === experimentId &&
+      this.participantPrivateId === participantPrivateId &&
+      this.listenersAttached
+    ) {
+      return;
+    }
+    this.stop();
+    this.experimentId = experimentId;
+    this.participantPrivateId = participantPrivateId;
+    this.attachListeners();
+    // Periodic flush
+    this.intervalHandle = window.setInterval(
+      () => this.flush(),
+      this.flushIntervalMs,
+    );
+    // Flush when page hidden/unloaded
+    document.addEventListener('visibilitychange', this.onVisibilityChange, {
+      capture: true,
+    });
+    window.addEventListener('beforeunload', this.onBeforeUnload, {
+      capture: true,
+    });
+  }
+
+  stop() {
+    if (this.listenersAttached) {
+      document.removeEventListener('click', this.onClick, true);
+      document.removeEventListener('keydown', this.onKeyDown, true);
+      document.removeEventListener('copy', this.onCopy, true);
+      document.removeEventListener('paste', this.onPaste, true);
+      window.removeEventListener('blur', this.onWindowBlur, true);
+      window.removeEventListener('focus', this.onWindowFocus, true);
+      this.listenersAttached = false;
+    }
+    document.removeEventListener(
+      'visibilitychange',
+      this.onVisibilityChange,
+      true,
+    );
+    window.removeEventListener('beforeunload', this.onBeforeUnload, true);
+    if (this.intervalHandle) {
+      window.clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    // Do not flush after clearing identifiers
+    void this.flush();
+    this.experimentId = null;
+    this.participantPrivateId = null;
+    this.buffer = [];
+  }
+
+  /** Manually log a custom behavior event. */
+  log(eventType: string, metadata: Record<string, unknown> = {}) {
+    const stageId =
+      this.sp.participantService.currentStageViewId ??
+      this.sp.participantService.profile?.currentStageId ??
+      'unknown';
+    const evt = {
+      eventType,
+      relativeTimestamp: performance.now(),
+      stageId,
+      metadata,
+    };
+    this.buffer.push(evt);
+    if (this.buffer.length >= this.maxBufferSize) {
+      void this.flush();
+    }
+  }
+
+  // Internal
+  private attachListeners() {
+    if (this.listenersAttached) return;
+    document.addEventListener('click', this.onClick, true);
+    document.addEventListener('keydown', this.onKeyDown, true);
+    document.addEventListener('copy', this.onCopy, true);
+    document.addEventListener('paste', this.onPaste, true);
+    window.addEventListener('blur', this.onWindowBlur, true);
+    window.addEventListener('focus', this.onWindowFocus, true);
+    this.listenersAttached = true;
+  }
+
+  private onClick = (e: MouseEvent) => {
+    // Keep minimal metadata; avoid PII
+    const target = e.target as HTMLElement | null;
+    const tag = target?.tagName || '';
+    const id = target?.id || '';
+    const cls = target?.className?.toString?.().slice(0, 200) || '';
+    this.log('click', {
+      x: e.clientX,
+      y: e.clientY,
+      button: e.button,
+      isTrusted: e.isTrusted,
+      targetTag: tag,
+      targetId: id,
+      targetClass: cls,
+    });
+  };
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    // Do not capture actual key values; only log whether it was backspace/delete
+    const keyName = (e.key || '').toLowerCase();
+    const isBackspace = keyName === 'backspace';
+    const isDelete = keyName === 'delete' || keyName === 'del';
+    this.log('keydown', {
+      isBackspace,
+      isDelete,
+      ctrlKey: e.ctrlKey,
+      metaKey: e.metaKey,
+      altKey: e.altKey,
+      shiftKey: e.shiftKey,
+      repeat: e.repeat,
+      isTrusted: e.isTrusted,
+      targetTag: (e.target as HTMLElement | null)?.tagName || '',
+    });
+  };
+
+  private onCopy = (e: ClipboardEvent) => {
+    // Try to capture the actual copied text safely
+    let text = '';
+    const active = document.activeElement as HTMLElement | null;
+    // If copying from an input or textarea, use selection range
+    if (
+      active &&
+      (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')
+    ) {
+      const el = active as HTMLInputElement | HTMLTextAreaElement;
+      if (
+        typeof el.selectionStart === 'number' &&
+        typeof el.selectionEnd === 'number'
+      ) {
+        text = el.value.substring(el.selectionStart, el.selectionEnd);
+      }
+    }
+    // Otherwise, use the document selection
+    if (!text) {
+      text = document.getSelection()?.toString() ?? '';
+    }
+
+    const MAX_COPY_LEN = 10000;
+    const truncated = text.length > MAX_COPY_LEN;
+    const storedText = truncated ? text.slice(0, MAX_COPY_LEN) : text;
+
+    this.log('copy', {
+      text: storedText,
+      length: text.length,
+      truncated,
+      isTrusted: e.isTrusted,
+      targetTag: active?.tagName || '',
+      contentEditable: !!active?.isContentEditable,
+    });
+  };
+
+  private onPaste = (e: ClipboardEvent) => {
+    // Read pasted text from clipboard data (covers keyboard, menu, context menu)
+    let text = '';
+    if (e.clipboardData) {
+      text = e.clipboardData.getData('text/plain') || '';
+    }
+
+    // Cap length to avoid huge payloads
+    const MAX_PASTE_LEN = 10000;
+    const truncated = text.length > MAX_PASTE_LEN;
+    const storedText = truncated ? text.slice(0, MAX_PASTE_LEN) : text;
+
+    const active = document.activeElement as HTMLElement | null;
+    this.log('paste', {
+      text: storedText,
+      length: text.length,
+      truncated,
+      isTrusted: e.isTrusted,
+      targetTag: active?.tagName || '',
+      contentEditable: !!active?.isContentEditable,
+    });
+  };
+
+  private onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      void this.flush();
+    }
+  };
+
+  private onBeforeUnload = () => {
+    void this.flush();
+  };
+
+  // Public flush for callers that need to ensure the buffer is persisted now
+  public async flush() {
+    if (!this.experimentId || !this.participantPrivateId) return;
+    if (this.buffer.length === 0) return;
+    const events = this.buffer.slice();
+    this.buffer = [];
+    const payload = {
+      experimentId: this.experimentId,
+      participantId: this.participantPrivateId,
+      events,
+    };
+    try {
+      await addBehaviorEventsCallable(
+        this.sp.firebaseService.functions,
+        payload,
+      );
+    } catch (_) {
+      // re-queue on failure (cap size to avoid growth)
+      this.buffer = events.concat(this.buffer).slice(-200);
+    }
+  }
+
+  private onWindowBlur = () => {
+    this.log('window_blur', {
+      visibility: document.visibilityState,
+      hasFocus: document.hasFocus(),
+    });
+  };
+
+  private onWindowFocus = () => {
+    this.log('window_focus', {
+      visibility: document.visibilityState,
+      hasFocus: document.hasFocus(),
+    });
+  };
+}

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -7,10 +7,6 @@ import {
   StageConfig,
   StageKind,
   createExperimentConfig,
-  createMetadataConfig,
-  createPermissionsConfig,
-  createProlificConfig,
-  generateId,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase/firestore';
 import {computed, makeObservable, observable} from 'mobx';
@@ -115,6 +111,10 @@ export class ExperimentEditor extends Service {
       ...this.experiment.prolificConfig,
       ...config,
     };
+  }
+
+  updateCollectBehaviorData(enabled: boolean) {
+    this.experiment.collectBehaviorData = enabled;
   }
 
   setCurrentStageId(id: string | undefined) {

--- a/frontend/src/services/experiment.service.ts
+++ b/frontend/src/services/experiment.service.ts
@@ -1,17 +1,11 @@
 import {computed, makeObservable, observable} from 'mobx';
-import {
-  collection,
-  doc,
-  getDocs,
-  onSnapshot,
-  Unsubscribe,
-} from 'firebase/firestore';
+import {collection, doc, onSnapshot, Unsubscribe} from 'firebase/firestore';
 import {FirebaseService} from './firebase.service';
 import {AgentEditor} from './agent.editor';
-import {Pages, RouterService} from './router.service';
+import {RouterService} from './router.service';
 import {Service} from './service';
 
-import {Experiment, StageConfig, StageKind} from '@deliberation-lab/utils';
+import {Experiment, StageConfig} from '@deliberation-lab/utils';
 import {getPublicExperimentName} from '../shared/experiment.utils';
 
 interface ServiceProvider {
@@ -32,6 +26,8 @@ export class ExperimentService extends Service {
 
   // Experiment configs
   @observable experiment: Experiment | undefined = undefined;
+  // Temporary local flag until type updates propagate
+  @observable collectBehaviorData = false;
   @observable stageConfigMap: Record<string, StageConfig> = {};
   // TODO: Add roleConfigMap
 
@@ -69,6 +65,9 @@ export class ExperimentService extends Service {
             cohortLockMap: {}, // for experiments version <= 11
             ...doc.data(),
           } as Experiment;
+          // Keep a local mirror of the flag if present
+          this.collectBehaviorData =
+            (doc.data() as Experiment).collectBehaviorData === true;
           this.isExperimentLoading = false;
         },
       ),

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -511,3 +511,31 @@ export const ackAlertMessageCallable = async (
   )(config);
   return data;
 };
+
+/** Participant behavior logging (batched). */
+type BehaviorEventInput = {
+  eventType: string;
+  relativeTimestamp: number;
+  stageId: string;
+  metadata: Record<string, unknown>;
+};
+
+type AddBehaviorEventsData = {
+  experimentId: string;
+  participantId: string; // private id
+  events: BehaviorEventInput[];
+};
+
+export const addBehaviorEventsCallable = async (
+  functions: Functions,
+  config: AddBehaviorEventsData,
+) => {
+  const {data} = await httpsCallable<
+    AddBehaviorEventsData,
+    {success: boolean; count: number}
+  >(
+    functions,
+    'addBehaviorEvents',
+  )(config);
+  return data;
+};

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -44,6 +44,7 @@ import {
   SurveyQuestion,
   SurveyQuestionKind,
   UnifiedTimestamp,
+  BehaviorEvent,
   calculatePayoutResult,
   calculatePayoutTotal,
   createCohortDownload,
@@ -145,6 +146,24 @@ export async function getExperimentDownload(
     for (const stage of stageAnswers) {
       participantDownload.answerMap[stage.id] = stage;
     }
+
+    // Fetch behavior events (ordered by server timestamp)
+    const behaviorDocs = await getDocs(
+      query(
+        collection(
+          firestore,
+          'experiments',
+          experimentId,
+          'participants',
+          profile.privateId,
+          'behavior',
+        ),
+        orderBy('timestamp', 'asc'),
+      ),
+    );
+    participantDownload.behavior = behaviorDocs.docs.map(
+      (doc) => doc.data() as BehaviorEvent,
+    );
     // Add ParticipantDownload to ExperimentDownload
     experimentDownload.participantMap[profile.publicId] = participantDownload;
   }

--- a/functions/src/behavior.endpoints.ts
+++ b/functions/src/behavior.endpoints.ts
@@ -1,0 +1,61 @@
+import {onCall} from 'firebase-functions/v2/https';
+import * as functions from 'firebase-functions';
+import {app} from './app';
+import {Type} from '@sinclair/typebox';
+import {Value} from '@sinclair/typebox/value';
+
+// Local schema to avoid depending on utils build output
+const BehaviorEventInputSchema = Type.Object({
+  eventType: Type.String({minLength: 1}),
+  relativeTimestamp: Type.Number(),
+  stageId: Type.String({minLength: 1}),
+  metadata: Type.Record(Type.String(), Type.Any()),
+});
+
+const AddBehaviorEventsDataSchema = Type.Object({
+  experimentId: Type.String({minLength: 1}),
+  participantId: Type.String({minLength: 1}),
+  events: Type.Array(BehaviorEventInputSchema, {minItems: 1, maxItems: 200}),
+});
+
+/**
+ * addBehaviorEvents: batched append-only event log under participant.
+ * Path: experiments/{experimentId}/participants/{participantPrivateId}/behavior/{autoId}
+ */
+export const addBehaviorEvents = onCall(async (request) => {
+  const {data} = request as {
+    data: {experimentId: string; participantId: string; events: unknown[]};
+  };
+
+  if (!Value.Check(AddBehaviorEventsDataSchema, data)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Invalid data');
+  }
+
+  const batch = app.firestore().batch();
+  const base = app
+    .firestore()
+    .collection('experiments')
+    .doc(data.experimentId)
+    .collection('participants')
+    .doc(data.participantId)
+    .collection('behavior');
+
+  for (const evt of data.events as Array<{
+    eventType: string;
+    relativeTimestamp: number;
+    stageId: string;
+    metadata?: Record<string, unknown>;
+  }>) {
+    const ref = base.doc();
+    batch.set(ref, {
+      type: evt.eventType,
+      relativeTimestamp: evt.relativeTimestamp,
+      stageId: evt.stageId,
+      metadata: evt.metadata ?? {},
+      timestamp: new Date(), // server time
+    });
+  }
+
+  await batch.commit();
+  return {success: true, count: data.events.length};
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,6 +22,7 @@ export * from './agent.utils';
 export * from './log.utils';
 
 export * from './mediator.endpoints';
+export * from './behavior.endpoints';
 
 export * from './stages/chat.endpoints';
 export * from './stages/chat.triggers';

--- a/utils/src/behavior.ts
+++ b/utils/src/behavior.ts
@@ -11,6 +11,17 @@ export interface BehaviorEventInput {
   metadata: Record<string, unknown>;
 }
 
+// Event shape as stored/exported from Firestore
+// Note: backend writes field name `type` in documents.
+import type {UnifiedTimestamp} from './shared';
+export interface BehaviorEvent {
+  type: string;
+  relativeTimestamp: number;
+  stageId: string;
+  metadata: Record<string, unknown>;
+  timestamp: UnifiedTimestamp;
+}
+
 export interface AddBehaviorEventsData {
   experimentId: string;
   /** Participant private ID. */

--- a/utils/src/behavior.ts
+++ b/utils/src/behavior.ts
@@ -1,0 +1,20 @@
+/** Behavioral event types for participant interaction logging. */
+
+export interface BehaviorEventInput {
+  /** Event type identifier, e.g., 'click', 'keydown'. */
+  eventType: string;
+  /** High-resolution relative timestamp in milliseconds (e.g., performance.now()). */
+  relativeTimestamp: number;
+  /** Current stage ID when event was captured. */
+  stageId: string;
+  /** Arbitrary metadata map; contents depend on eventType. */
+  metadata: Record<string, unknown>;
+}
+
+export interface AddBehaviorEventsData {
+  experimentId: string;
+  /** Participant private ID. */
+  participantId: string;
+  /** Events to add in a single batch. */
+  events: BehaviorEventInput[];
+}

--- a/utils/src/data.ts
+++ b/utils/src/data.ts
@@ -2,6 +2,7 @@ import {AgentDataObject} from './agent';
 import {CohortConfig} from './cohort';
 import {Experiment} from './experiment';
 import {ParticipantProfileExtended} from './participant';
+import {BehaviorEvent} from './behavior';
 import {ChatMessage} from './stages/chat_stage';
 import {
   StageConfig,
@@ -33,6 +34,8 @@ export interface ParticipantDownload {
   profile: ParticipantProfileExtended;
   // Maps from stage ID to participant's stage answer
   answerMap: Record<string, StageParticipantAnswer>;
+  // Ordered list of behavior events (if any)
+  behavior: BehaviorEvent[];
 }
 
 export interface CohortDownload {
@@ -63,6 +66,7 @@ export function createParticipantDownload(
   return {
     profile,
     answerMap: {},
+    behavior: [],
   };
 }
 

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -33,8 +33,9 @@ import {StageConfig} from './stages/stage';
  * VERSION 16 - switch to new mediator workflow including updated ChatMessage
  * VERSION 17 - add structured output config to agent prompt configs
  * VERSION 18 - add agent participant config to ParticipantProfileExtended
+ * VERSION 19 - add collectBehaviorData flag to Experiment
  */
-export const EXPERIMENT_VERSION_ID = 18;
+export const EXPERIMENT_VERSION_ID = 19;
 
 /** Experiment. */
 export interface Experiment {
@@ -47,6 +48,7 @@ export interface Experiment {
   prolificConfig: ProlificConfig;
   stageIds: string[]; // Ordered list of stage IDs
   cohortLockMap: Record<string, boolean>; // maps cohort ID to is locked
+  collectBehaviorData: boolean; // enable behavior logging for bot detection
 }
 
 /** Experiment config for participant options. */
@@ -92,6 +94,7 @@ export function createExperimentConfig(
     prolificConfig: config.prolificConfig ?? createProlificConfig(),
     stageIds: stages.map((stage) => stage.id),
     cohortLockMap: config.cohortLockMap ?? {},
+    collectBehaviorData: config.collectBehaviorData ?? false,
   };
 }
 

--- a/utils/src/experiment.validation.ts
+++ b/utils/src/experiment.validation.ts
@@ -82,6 +82,7 @@ export const ExperimentCreationData = Type.Object(
         prolificConfig: ProlificConfigSchema,
         stageIds: Type.Array(Type.String()),
         cohortLockMap: Type.Record(Type.String(), Type.Boolean()),
+        collectBehaviorData: Type.Boolean(),
       },
       strict,
     ),

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -80,3 +80,6 @@ export * from './utils/cache.utils';
 export * from './utils/object.utils';
 export * from './utils/random.utils';
 export * from './utils/string.utils';
+
+// Behavior
+export * from './behavior';

--- a/utils/src/shared.validation.ts
+++ b/utils/src/shared.validation.ts
@@ -1,5 +1,6 @@
 import {Type} from '@sinclair/typebox';
 import {Visibility} from './shared';
+import type {BehaviorEventInput} from './behavior';
 
 /** UnifiedTimestamp input validation. */
 export const UnifiedTimestampSchema = Type.Object({
@@ -26,4 +27,18 @@ export const PermissionsConfigSchema = Type.Object({
     Type.Literal(Visibility.PRIVATE),
   ]),
   readers: Type.Array(Type.String()),
+});
+
+// Behavior event validation
+export const BehaviorEventInputSchema = Type.Object({
+  eventType: Type.String({minLength: 1}),
+  relativeTimestamp: Type.Number(),
+  stageId: Type.String({minLength: 1}),
+  metadata: Type.Record(Type.String(), Type.Any()),
+});
+
+export const AddBehaviorEventsDataSchema = Type.Object({
+  experimentId: Type.String({minLength: 1}),
+  participantId: Type.String({minLength: 1}),
+  events: Type.Array(BehaviorEventInputSchema, {minItems: 1, maxItems: 200}),
 });


### PR DESCRIPTION
Fixes #649

This PR adds optional logging of click, keydown, input change, copy/paste, and window focus events. Of course, it only logs events that occur within the Deliberate Lab window. The goal is to use this behavioral data during analysis to attempt to identify users who are completing the task using a bot, and users who are having an LLM compose their survey or chat responses for them.

- [X] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
