### PR TITLE
Handle undefined promptConfig in chat.agent.ts

### DIFF
--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -57,7 +57,11 @@ export async function createAgentChatMessageFromPrompt(
       .collection('prompts')
       .doc(stageId)
       .get()
-  ).data() as ChatPromptConfig;
+  ).data() as ChatPromptConfig | undefined;
+
+  if (!promptConfig) {
+    return false; // No prompt configured for this stage
+  }
 
   // Stage (in order to determin stage kind)
   const stage = await getFirestoreStage(experimentId, stageId);


### PR DESCRIPTION
 (this was throwing an error in my logs, not sure if it's better to handle here or upstream to prevent the config from being undefined in the first place).