### PR TITLE
Handle non-structured outputs in chat.agent.ts (use response.text and response.reasoning).

### DIFF
--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -148,6 +148,7 @@ export async function getOpenAIAPIResponse(
   model: string,
   prompt: string,
   generationConfig: ModelGenerationConfig,
+  structuredOutputConfig?: StructuredOutputConfig,
 ): Promise<ModelResponse> {
   return await getOpenAIAPIChatCompletionResponse(
     apiKeyConfig.openAIApiKey?.apiKey || '',
@@ -155,6 +156,7 @@ export async function getOpenAIAPIResponse(
     model,
     prompt,
     generationConfig,
+    structuredOutputConfig,
   );
 }
 


### PR DESCRIPTION
chat.agent.ts does not properly handle situations where structuredResponse is disabled. This fixes that (keeps same default failsafe behaviors from #662.