### PR TITLE
 Fix duplicate initial messages and Gemini API failures with multiple mediators

### DIFF
--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -466,6 +466,16 @@ export class EditorComponent extends MobxLitElement {
       }
     };
 
+    const updateDisableSafetyFilters = (e: Event) => {
+      const disableSafetyFilters = (e.target as HTMLInputElement).checked;
+      this.updatePrompt({
+        generationConfig: {
+          ...agentPromptConfig.generationConfig,
+          disableSafetyFilters,
+        },
+      });
+    };
+
     return html`
       <div class="section">
         <div class="section-header">
@@ -545,6 +555,22 @@ export class EditorComponent extends MobxLitElement {
               .value=${generationConfig.presencePenalty}
               @input=${updatePresencePenalty}
             />
+          </div>
+        </div>
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${generationConfig.disableSafetyFilters ?? false}
+            ?disabled=${!this.experimentEditor.isCreator}
+            @change=${updateDisableSafetyFilters}
+          >
+          </md-checkbox>
+          <div>
+            Disable safety filters
+            <span class="small">
+              (Only supported for Gemini. Uses BLOCK_NONE threshold instead of
+              BLOCK_ONLY_HIGH)
+            </span>
           </div>
         </div>
       </div>

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -148,6 +148,7 @@ export async function getOpenAIAPIResponse(
   model: string,
   prompt: string,
   generationConfig: ModelGenerationConfig,
+  structuredOutputConfig?: StructuredOutputConfig,
 ): Promise<ModelResponse> {
   return await getOpenAIAPIChatCompletionResponse(
     apiKeyConfig.openAIApiKey?.apiKey || '',
@@ -155,6 +156,7 @@ export async function getOpenAIAPIResponse(
     model,
     prompt,
     generationConfig,
+    structuredOutputConfig,
   );
 }
 

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -205,7 +205,7 @@ export async function callGemini(
     };
   }
 
-  if (!response.candidates) {
+  if (!response.candidates || response.candidates.length === 0) {
     return {
       status: ModelResponseStatus.UNKNOWN_ERROR,
       generationConfig,

--- a/functions/src/chat/message_converter.utils.ts
+++ b/functions/src/chat/message_converter.utils.ts
@@ -122,10 +122,17 @@ export function shouldUseMessageFormat(
   isPrivateChat: boolean,
   allowMessageFormat: boolean = true,
   participantCount: number = 1,
+  mediatorCount: number = 1,
 ): boolean {
   // Only use message format for:
   // 1. Private chats
   // 2. When explicitly enabled
-  // 3. With a single participant (one-on-one with mediator)
-  return isPrivateChat && allowMessageFormat && participantCount === 1;
+  // 3. With exactly one participant and one mediator (true one-on-one conversation)
+  // Multiple mediators sometimes create conflicting "assistant" messages that break API flow.
+  return (
+    isPrivateChat &&
+    allowMessageFormat &&
+    participantCount === 1 &&
+    mediatorCount === 1
+  );
 }

--- a/functions/src/chat/message_converter.utils.ts
+++ b/functions/src/chat/message_converter.utils.ts
@@ -1,0 +1,131 @@
+/**
+ * Utilities for converting chat history to message-based API format
+ */
+
+import {ChatMessage, UserType} from '@deliberation-lab/utils';
+// Define types locally since they're not in the utils package yet
+export enum MessageRole {
+  SYSTEM = 'system',
+  USER = 'user',
+  ASSISTANT = 'assistant',
+}
+
+export interface ConversationMessage {
+  role: MessageRole;
+  content: string;
+  name?: string;
+}
+
+export interface MessageBasedPrompt {
+  messages: ConversationMessage[];
+  systemPrompt?: string;
+}
+
+export interface ChatToMessageOptions {
+  isPrivateChat: boolean;
+  mediatorId?: string;
+  participantId?: string;
+  includeSystemPrompt?: boolean;
+}
+
+/**
+ * Convert chat messages to conversation format for message-based APIs
+ * For private chats with one participant and one mediator, this creates
+ * a proper conversation flow with user/assistant roles.
+ */
+export function convertChatToMessages(
+  chatHistory: ChatMessage[],
+  currentUserType: UserType,
+  currentUserId: string,
+  options: ChatToMessageOptions,
+): ConversationMessage[] {
+  const messages: ConversationMessage[] = [];
+
+  if (!options.isPrivateChat) {
+    // For group chats, return empty array (fallback to text prompt)
+    return [];
+  }
+
+  // For private chats, convert to user/assistant format
+  for (const msg of chatHistory) {
+    let role: MessageRole;
+
+    // Determine role based on who sent the message
+    if (msg.type === UserType.PARTICIPANT) {
+      // Participant messages are "user" from the mediator's perspective
+      role =
+        currentUserType === UserType.MEDIATOR
+          ? MessageRole.USER
+          : MessageRole.ASSISTANT;
+    } else if (msg.type === UserType.MEDIATOR) {
+      // Mediator messages are "assistant" from the participant's perspective
+      role =
+        currentUserType === UserType.MEDIATOR
+          ? MessageRole.ASSISTANT
+          : MessageRole.USER;
+    } else {
+      // Skip other message types for now
+      continue;
+    }
+
+    messages.push({
+      role,
+      content: msg.message,
+      name: msg.profile.name || msg.senderId,
+    });
+  }
+
+  return messages;
+}
+
+/**
+ * Create a message-based prompt from chat history and system instructions
+ */
+export function createMessageBasedPrompt(
+  systemPrompt: string,
+  chatHistory: ChatMessage[],
+  currentUserType: UserType,
+  currentUserId: string,
+  options: ChatToMessageOptions,
+): MessageBasedPrompt {
+  const messages: ConversationMessage[] = [];
+
+  // Add system prompt if requested
+  if (options.includeSystemPrompt && systemPrompt) {
+    messages.push({
+      role: MessageRole.SYSTEM,
+      content: systemPrompt,
+    });
+  }
+
+  // Add conversation history
+  const conversationMessages = convertChatToMessages(
+    chatHistory,
+    currentUserType,
+    currentUserId,
+    options,
+  );
+
+  messages.push(...conversationMessages);
+
+  return {
+    messages,
+    systemPrompt: options.includeSystemPrompt ? undefined : systemPrompt,
+  };
+}
+
+/**
+ * Check if we should use message-based format for this chat
+ * Returns true only for private chats with specific conditions
+ */
+export function shouldUseMessageFormat(
+  isPrivateChat: boolean,
+  allowMessageFormat: boolean = true,
+  participantCount: number = 1,
+): boolean {
+  // Only use message format for:
+  // 1. Private chats
+  // 2. When explicitly enabled
+  // 3. With a single participant (one-on-one with mediator)
+  return isPrivateChat && allowMessageFormat && participantCount === 1;
+}

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -281,6 +281,44 @@ export function getFirestoreStagePublicDataRef(
     .doc(stageId);
 }
 
+/** Get trigger log reference for group chat stages */
+export function getGroupChatTriggerLogRef(
+  experimentId: string,
+  cohortId: string,
+  stageId: string,
+  triggerLogId: string,
+) {
+  return app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('cohorts')
+    .doc(cohortId)
+    .collection('publicStageData')
+    .doc(stageId)
+    .collection('triggerLogs')
+    .doc(triggerLogId);
+}
+
+/** Get trigger log reference for private chat stages */
+export function getPrivateChatTriggerLogRef(
+  experimentId: string,
+  participantId: string,
+  stageId: string,
+  triggerLogId: string,
+) {
+  return app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('stageData')
+    .doc(stageId)
+    .collection('triggerLogs')
+    .doc(triggerLogId);
+}
+
 /** Fetch stage public data from Firestore. */
 export async function getFirestoreStagePublicData(
   experimentId: string,

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -61,6 +61,8 @@ export interface ModelGenerationConfig {
   // many reasoning tokens in the budget.
   reasoningBudget?: number;
   includeReasoning?: boolean;
+  // Gemini-only: Disable safety filters (uses BLOCK_NONE instead of BLOCK_ONLY_HIGH)
+  disableSafetyFilters?: boolean;
 }
 
 /** Model settings for a specific agent. */
@@ -212,6 +214,7 @@ export function createModelGenerationConfig(
     customRequestBodyFields: config.customRequestBodyFields ?? [],
     reasoningBudget: config.reasoningBudget,
     includeReasoning: config.includeReasoning ?? true,
+    disableSafetyFilters: config.disableSafetyFilters ?? false,
   };
 }
 


### PR DESCRIPTION
Depends on #671.

This PR fixes two issues:

##  1. Duplicate initial messages in chat stages
- Initial messages were being re-sent times when participants reconnected / sessions were restored
- Root cause: Missing duplicate prevention mechanism for private chat stages (logRef was only being for group chats).

### Fix:
- Added trigger log checks for private chat initial messages (was previously just for GroupChat)

##  2. Gemini API returning empty responses with multiple mediators
- When using sturcutred-message API (#668) with multiple mediators, APIs would return empty responses (because there were multiple "Assistant" messages being sent in sequence). It is now only used for true one-on-one conversations (1 participant, 1 mediator)

### Fix:
- Modified shouldUseMessageFormat to check for exactly one mediator AND one participant
- Added mediator counting logic before deciding on message format
- Falls back to traditional string prompt format when multiple mediators are present
- This ensures chat APIs receives properly alternating user/assistant messages

## Clean-up:
- Consolidated message sending logic to use existing sendAgentGroupChatMessage and sendAgentPrivateChatMessage functions
- Removed duplicate code paths for initial message handling
- Created helper functions getGroupChatTriggerLogRef and getPrivateChatTriggerLogRef in firestore.ts because this pattern is used a lot in chat.agent.ts.
