### PR TITLE
Add botProtection flag and disable pasting in chatInput.

### DIFF
--- a/frontend/src/components/chat/chat_input.ts
+++ b/frontend/src/components/chat/chat_input.ts
@@ -8,6 +8,7 @@ import {classMap} from 'lit/directives/class-map.js';
 import {core} from '../../core/core';
 import {ParticipantAnswerService} from '../../services/participant.answer';
 import {ParticipantService} from '../../services/participant.service';
+import {ExperimentService} from '../../services/experiment.service';
 
 import {styles} from './chat_input.scss';
 
@@ -20,6 +21,7 @@ export class ChatInputComponent extends MobxLitElement {
   private readonly participantAnswerService = core.getService(
     ParticipantAnswerService,
   );
+  private readonly experimentService = core.getService(ExperimentService);
 
   @property() stageId = '';
   @property() sendUserInput: (input: string) => void = async (
@@ -60,6 +62,17 @@ export class ChatInputComponent extends MobxLitElement {
       this.storeUserInput(value);
     };
 
+    const handlePaste = (e: ClipboardEvent) => {
+      // Check if bot protection is enabled
+      const botProtection =
+        this.experimentService.experiment?.defaultCohortConfig?.botProtection ??
+        false;
+      if (botProtection) {
+        e.preventDefault();
+        return false;
+      }
+    };
+
     const autoFocus = () => {
       // Only auto-focus chat input if on desktop
       return navigator.maxTouchPoints === 0;
@@ -75,6 +88,7 @@ export class ChatInputComponent extends MobxLitElement {
           ?disabled=${this.isDisabled}
           @keyup=${handleKeyUp}
           @input=${handleInput}
+          @paste=${handlePaste}
         >
         </pr-textarea>
         <pr-tooltip

--- a/frontend/src/components/experiment_builder/experiment_settings_editor.ts
+++ b/frontend/src/components/experiment_builder/experiment_settings_editor.ts
@@ -132,7 +132,7 @@ export class ExperimentCohortEditor extends MobxLitElement {
           with these settings. You can update each individual cohort's settings
           later.
         </div>
-        ${this.renderMaxParticipantConfig()}
+        ${this.renderMaxParticipantConfig()} ${this.renderBotProtectionConfig()}
       </div>
     `;
   }
@@ -231,6 +231,36 @@ export class ExperimentCohortEditor extends MobxLitElement {
           @input=${updateNum}
         >
         </md-filled-text-field>
+      </div>
+    `;
+  }
+
+  private renderBotProtectionConfig() {
+    const botProtection =
+      this.experimentEditor.experiment.defaultCohortConfig.botProtection ??
+      false;
+
+    const updateBotProtection = () => {
+      this.experimentEditor.updateCohortConfig({
+        botProtection: !botProtection,
+      });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${botProtection}
+            ?disabled=${!this.experimentManager.isCreator}
+            @click=${updateBotProtection}
+          >
+          </md-checkbox>
+          <div>
+            Enable bot protection (disables pasting in chat input to prevent
+            automated responses)
+          </div>
+        </div>
       </div>
     `;
   }

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -70,6 +70,8 @@ export interface CohortParticipantConfig {
   maxParticipantsPerCohort: number | null;
   // If false, exclude booted participant from min/max participant counts
   includeAllParticipantsInCohortCount: boolean;
+  // If true, disable pasting in chat input to prevent bot-like behavior
+  botProtection: boolean;
 }
 
 /** Prolific integration config. */
@@ -124,6 +126,7 @@ export function createCohortParticipantConfig(
     maxParticipantsPerCohort: config.maxParticipantsPerCohort ?? null,
     includeAllParticipantsInCohortCount:
       config.includeAllParticipantsInCohortCount ?? false,
+    botProtection: config.botProtection ?? false,
   };
 }
 


### PR DESCRIPTION
This PR does two things:
* Adds an experiment-wide `botProtection` flag, which can be accessed by various stages.
* Implements a feature that disables pasting into `chatInput` when `botProtection` is enabled (works for both Group Chat and Private Chat).
