### PR TITLE
Left aligns info icon to be right next to the stage name

### DIFF
--- a/frontend/src/components/participant_view/participant_header.ts
+++ b/frontend/src/components/participant_view/participant_header.ts
@@ -32,10 +32,10 @@ export class Header extends MobxLitElement {
 
     return html`
       <div class="header">
-        <div class="left">${this.renderMenu()} ${this.stage.name}</div>
-        <div class="right">
-          ${this.renderInfo()} ${this.renderHelp()} ${this.renderProfile()}
+        <div class="left">
+          ${this.renderMenu()} ${this.stage.name}${this.renderInfo()}
         </div>
+        <div class="right">${this.renderHelp()} ${this.renderProfile()}</div>
       </div>
     `;
   }


### PR DESCRIPTION
This clarifies that the info popup refers to the stage itself, rather than containing global or user-related info.

https://screenshot.googleplex.com/AKyiMLrA7c5ihj2

Fixes #696 
