### PR TITLE
Use structured prompts and structured output for agent participants in survey stage.

### DIFF
--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -17,7 +17,6 @@ import {ExperimentEditor} from '../../services/experiment.editor';
 import {
   AgentPersonaConfig,
   AgentPersonaType,
-  ApiKeyType,
   BasePromptConfig,
   ChatMediatorStructuredOutputConfig,
   ChatPromptConfig,
@@ -29,13 +28,10 @@ import {
   StructuredOutputType,
   StructuredOutputDataType,
   StructuredOutputSchema,
-  createDefaultPromptFromText,
   makeStructuredOutputPrompt,
   structuredOutputEnabled,
   TextPromptItem,
 } from '@deliberation-lab/utils';
-import {LLM_AGENT_AVATARS} from '../../shared/constants';
-import {getHashBasedColor} from '../../shared/utils';
 
 import {styles} from './agent_chat_prompt_editor.scss';
 import {styles as dialogStyles} from './stage_builder_dialog.scss';
@@ -178,7 +174,10 @@ export class EditorComponent extends MobxLitElement {
     }
   }
 
-  private renderDialog(stageConfig: StageConfig, promptConfig: BasePromptConfig) {
+  private renderDialog(
+    stageConfig: StageConfig,
+    promptConfig: BasePromptConfig,
+  ) {
     if (!this.agent || !this.showDialog) return nothing;
 
     const isChatStage =
@@ -206,9 +205,10 @@ export class EditorComponent extends MobxLitElement {
         <div class="divider"></div>
         ${isChatStage
           ? html`${this.renderAgentChatSettings(
-              this.agent,
-              promptConfig as ChatPromptConfig,
-            )}<div class="divider"></div>`
+                this.agent,
+                promptConfig as ChatPromptConfig,
+              )}
+              <div class="divider"></div>`
           : nothing}
         ${this.renderAgentSamplingParameters(this.agent, promptConfig)}
         <div class="divider"></div>

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -2,7 +2,6 @@ import {
   AgentMediatorTemplate,
   AgentMediatorPersonaConfig,
   AgentParticipantPersonaConfig,
-  AgentPersonaType,
   AgentParticipantTemplate,
   ApiKeyType,
   CohortParticipantConfig,
@@ -21,9 +20,6 @@ import {
   createBasePromptConfig,
   createChatPromptConfig,
   createExperimentConfig,
-  createMetadataConfig,
-  createPermissionsConfig,
-  createProlificConfig,
   generateId,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase/firestore';

--- a/functions/src/prompt.utils.ts
+++ b/functions/src/prompt.utils.ts
@@ -119,7 +119,7 @@ export async function getStructuredPrompt(
   userProfile: UserProfile,
   agentConfig: ProfileAgentConfig,
   promptConfig: BasePromptConfig,
-  promptParameters?: Record<string, any>,
+  promptParameters?: Record<string, unknown>,
 ) {
   const promptText = await processPromptItems(
     promptConfig.prompt,
@@ -149,7 +149,7 @@ async function processPromptItems(
   stageId: string,
   userProfile: UserProfile,
   agentConfig: ProfileAgentConfig,
-  promptParameters?: Record<string, any>,
+  promptParameters?: Record<string, unknown>,
 ): Promise<string> {
   const items: string[] = [];
   for (const promptItem of promptItems) {
@@ -161,7 +161,6 @@ async function processPromptItems(
         items.push(agentConfig.promptContext);
         break;
       case PromptItemType.PROFILE_INFO:
-        const profileInfo: string[] = [];
         const getProfileSetId = () => {
           if (stageId.includes(SECONDARY_PROFILE_SET_ID)) {
             return PROFILE_SET_ANIMALS_2_ID;
@@ -246,7 +245,7 @@ export async function getStageContextForPrompt(
   participantIds: string[],
   currentStageId: string,
   item: StageContextPromptItem,
-  promptParameters?: Record<string, any>,
+  promptParameters?: Record<string, unknown>,
 ) {
   // Get the specific stage
   const stage = await getFirestoreStage(experimentId, item.stageId);
@@ -297,7 +296,10 @@ export async function getStageContextForPrompt(
     promptParameters?.answerMap
   ) {
     const question = promptParameters.question as SurveyQuestion;
-    const answerMap = promptParameters.answerMap as Record<string, SurveyAnswer>;
+    const answerMap = promptParameters.answerMap as Record<
+      string,
+      SurveyAnswer
+    >;
     const currentQuestionIndex = stage.questions.findIndex(
       (q: SurveyQuestion) => q.id === question.id,
     );
@@ -321,7 +323,7 @@ export async function getStageDisplayForPrompt(
   participantIds: string[], // participant private IDs for answer inclusion
   stage: StageConfig,
   includeAnswers: boolean,
-  promptParameters?: Record<string, any>,
+  promptParameters?: Record<string, unknown>,
 ) {
   switch (stage.kind) {
     case StageKind.TOS:
@@ -410,11 +412,13 @@ export async function getStageDisplayForPrompt(
       return assetAllocationDisplay;
     case StageKind.SURVEY:
     case StageKind.SURVEY_PER_PARTICIPANT:
-      const surveyStage =
-        stage as SurveyStageConfig | SurveyPerParticipantStageConfig;
+      const surveyStage = stage as
+        | SurveyStageConfig
+        | SurveyPerParticipantStageConfig;
       const question = promptParameters?.question as SurveyQuestion | undefined;
-      const answerMap =
-        promptParameters?.answerMap as Record<string, SurveyAnswer> | undefined;
+      const answerMap = promptParameters?.answerMap as
+        | Record<string, SurveyAnswer>
+        | undefined;
 
       if (includeAnswers && question && answerMap) {
         const currentQuestionIndex = surveyStage.questions.findIndex(

--- a/functions/src/stages/survey.agent.test.ts
+++ b/functions/src/stages/survey.agent.test.ts
@@ -9,7 +9,6 @@ jest.mock('../app', () => ({
   },
 }));
 
-import { app } from '../app';
 import * as agentUtils from '../agent.utils';
 import * as firestoreUtils from '../utils/firestore';
 import {
@@ -27,8 +26,7 @@ import {
   StageKind,
   createBasePromptConfig,
 } from '@deliberation-lab/utils';
-import * as admin from 'firebase-admin';
-import { getAgentParticipantSurveyStageResponse } from './survey.agent';
+import {getAgentParticipantSurveyStageResponse} from './survey.agent';
 
 describe('survey.agent', () => {
   let processModelResponseSpy: jest.SpyInstance;
@@ -45,7 +43,7 @@ describe('survey.agent', () => {
     agentConfig: {
       agentId: 'agent1',
       promptContext: '',
-      modelSettings: { apiType: 'GEMINI', modelName: 'gemini-pro' },
+      modelSettings: {apiType: 'GEMINI', modelName: 'gemini-pro'},
     },
   } as ParticipantProfileExtended;
 
@@ -56,8 +54,8 @@ describe('survey.agent', () => {
   });
 
   it('should return undefined if participant is not an agent', async () => {
-    const participant = { ...mockParticipant, agentConfig: undefined };
-    const stage = { questions: [] } as SurveyStageConfig;
+    const participant = {...mockParticipant, agentConfig: undefined};
+    const stage = {questions: []} as SurveyStageConfig;
 
     const response = await getAgentParticipantSurveyStageResponse(
       mockExperimentId,
@@ -70,8 +68,8 @@ describe('survey.agent', () => {
   });
 
   it('should return undefined if no prompt config is found', async () => {
-    const stage = { questions: [] } as SurveyStageConfig;
-    mockDocGet.mockResolvedValue({ exists: false, data: () => undefined });
+    const stage = {questions: []} as SurveyStageConfig;
+    mockDocGet.mockResolvedValue({exists: false, data: () => undefined});
 
     const response = await getAgentParticipantSurveyStageResponse(
       mockExperimentId,
@@ -111,7 +109,7 @@ describe('survey.agent', () => {
       getFirestoreStageSpy.mockResolvedValue(stage);
       processModelResponseSpy.mockResolvedValue({
         status: ModelResponseStatus.OK,
-        parsedResponse: { response: 'My name is Agent' },
+        parsedResponse: {response: 'My name is Agent'},
       });
 
       const response = await getAgentParticipantSurveyStageResponse(
@@ -145,7 +143,7 @@ describe('survey.agent', () => {
       getFirestoreStageSpy.mockResolvedValue(stage);
       processModelResponseSpy.mockResolvedValue({
         status: ModelResponseStatus.OK,
-        parsedResponse: { response: true },
+        parsedResponse: {response: true},
       });
 
       const response = await getAgentParticipantSurveyStageResponse(
@@ -166,7 +164,7 @@ describe('survey.agent', () => {
       const question = createMultipleChoiceSurveyQuestion({
         id: 'q3',
         questionTitle: 'Favorite color?',
-        options: [createMultipleChoiceItem({ id: 'red', text: 'Red' })],
+        options: [createMultipleChoiceItem({id: 'red', text: 'Red'})],
       });
       const stage = {
         id: 'stage1',
@@ -180,7 +178,7 @@ describe('survey.agent', () => {
       getFirestoreStageSpy.mockResolvedValue(stage);
       processModelResponseSpy.mockResolvedValue({
         status: ModelResponseStatus.OK,
-        parsedResponse: { response: 'red' },
+        parsedResponse: {response: 'red'},
       });
 
       const response = await getAgentParticipantSurveyStageResponse(
@@ -217,7 +215,7 @@ describe('survey.agent', () => {
       getFirestoreStageSpy.mockResolvedValue(stage);
       processModelResponseSpy.mockResolvedValue({
         status: ModelResponseStatus.OK,
-        parsedResponse: { response: 4 },
+        parsedResponse: {response: 4},
       });
 
       const response = await getAgentParticipantSurveyStageResponse(
@@ -254,7 +252,7 @@ describe('survey.agent', () => {
       getFirestoreStageSpy.mockResolvedValue(stage);
       processModelResponseSpy.mockResolvedValue({
         status: ModelResponseStatus.OK,
-        parsedResponse: { response: 0.7 },
+        parsedResponse: {response: 0.7},
       });
 
       const response = await getAgentParticipantSurveyStageResponse(

--- a/functions/src/stages/survey.agent.ts
+++ b/functions/src/stages/survey.agent.ts
@@ -162,7 +162,8 @@ async function getAgentParticipantSurveyQuestionResponse(
     return;
   }
 
-  const structuredOutputConfig = createStructuredOutputConfigForSurvey(question);
+  const structuredOutputConfig =
+    createStructuredOutputConfigForSurvey(question);
 
   const prompt = await getStructuredPrompt(
     experimentId,
@@ -200,29 +201,29 @@ async function getAgentParticipantSurveyQuestionResponse(
   const responseValue = rawResponse.parsedResponse.response;
 
   switch (question.kind) {
-  case SurveyQuestionKind.TEXT:
-    return {
-      id: question.id,
-      kind: SurveyQuestionKind.TEXT,
-      answer: responseValue as string,
-    };
-  case SurveyQuestionKind.CHECK:
-    return {
-      id: question.id,
-      kind: SurveyQuestionKind.CHECK,
-      isChecked: responseValue as boolean,
-    };
-  case SurveyQuestionKind.MULTIPLE_CHOICE:
-    return {
-      id: question.id,
-      kind: SurveyQuestionKind.MULTIPLE_CHOICE,
-      choiceId: responseValue as string,
-    };
-  case SurveyQuestionKind.SCALE:
-    return {
-      id: question.id,
-      kind: SurveyQuestionKind.SCALE,
-      value: responseValue as number,
-    };
+    case SurveyQuestionKind.TEXT:
+      return {
+        id: question.id,
+        kind: SurveyQuestionKind.TEXT,
+        answer: responseValue as string,
+      };
+    case SurveyQuestionKind.CHECK:
+      return {
+        id: question.id,
+        kind: SurveyQuestionKind.CHECK,
+        isChecked: responseValue as boolean,
+      };
+    case SurveyQuestionKind.MULTIPLE_CHOICE:
+      return {
+        id: question.id,
+        kind: SurveyQuestionKind.MULTIPLE_CHOICE,
+        choiceId: responseValue as string,
+      };
+    case SurveyQuestionKind.SCALE:
+      return {
+        id: question.id,
+        kind: SurveyQuestionKind.SCALE,
+        value: responseValue as number,
+      };
   }
 }

--- a/utils/src/structured_prompt.ts
+++ b/utils/src/structured_prompt.ts
@@ -1,6 +1,5 @@
 /** Structured prompt types, constants, and functions. */
 import {
-  AgentChatPromptConfig,
   AgentChatSettings,
   ModelGenerationConfig,
   createAgentChatSettings,


### PR DESCRIPTION
Fixes #702 

This also extends agent_chat_prompt_editor.ts to be able to edit prompt configs more generally instead of just ChatPromptConfig, and uses it for editing the survey prompt.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR (n/a)
