### PR TITLE
Update picomatch to version 4.0.3.

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "crypto-browserify": "^3.12.0",
-        "picomatch": "^4.0.3",
         "process": "^0.11.10",
         "uuidv4": "^6.2.13"
       },
@@ -21,6 +20,7 @@
         "babel-jest": "^29.7.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "picomatch": "^4.0.3",
         "ts-jest": "^29.2.5",
         "tsup": "^8.4.0",
         "typescript": "^5.4.5"
@@ -8224,6 +8224,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/utils/package.json
+++ b/utils/package.json
@@ -26,13 +26,13 @@
     "babel-jest": "^29.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "picomatch": "^4.0.3",
     "ts-jest": "^29.2.5",
     "tsup": "^8.4.0",
     "typescript": "^5.4.5"
   },
   "dependencies": {
     "crypto-browserify": "^3.12.0",
-    "picomatch": "^4.0.3",
     "process": "^0.11.10",
     "uuidv4": "^6.2.13"
   },


### PR DESCRIPTION
Fixes #609. We were pulling in a version of picomatch with a bug that broke `npm run build:watch`.