### PR TITLE
Remove duplicate survey stage in charity allocation experiment

### DIFF
--- a/frontend/src/shared/templates/charity_allocations.ts
+++ b/frontend/src/shared/templates/charity_allocations.ts
@@ -372,8 +372,6 @@ export function getCharityDebateTemplate(
     if (isMediatedRound) {
       stages.push(createPerMediatorEvaluationStage(roundNum));
     }
-
-    stages.push(createRoundOutcomeSurveyStage(roundNum, isMediatedRound));
   });
 
   stages.push(createAllocationRevealStage());


### PR DESCRIPTION
There's a bug where round outcome surveys are added twice.

<img width="1156" height="917" alt="image" src="https://github.com/user-attachments/assets/61a4f824-1e28-4d30-8cff-ee3ca458658f" />
