### PR TITLE
Agents choose gendered emojis when in the gendered emoji stage.

### DIFF
--- a/frontend/src/shared/constants.ts
+++ b/frontend/src/shared/constants.ts
@@ -16,15 +16,12 @@ export const FIREBASE_LOCAL_HOST_PORT_RTDB = 9000;
 export const APP_NAME = 'Deliberate Lab';
 
 /** Profile avatars. */
-export const MAN_EMOJIS = ['👨🏻', '👨🏼', '👨🏽', '👨🏾', '👨🏿'];
-export const WOMAN_EMOJIS = ['👩🏻', '👩🏼', '👩🏽', '👩🏾', '👩🏿'];
-export const PERSON_EMOJIS = ['🧑🏻', '🧑🏼', '🧑🏽', '🧑🏾', '🧑🏿'];
-
-export const PROFILE_AVATARS = [
-  ...WOMAN_EMOJIS,
-  ...MAN_EMOJIS,
-  ...PERSON_EMOJIS,
-];
+export {
+  MAN_EMOJIS,
+  WOMAN_EMOJIS,
+  PERSON_EMOJIS,
+  PROFILE_AVATARS,
+} from '@deliberation-lab/utils';
 
 /** LLM agent avatars. */
 export const LLM_AGENT_AVATARS = ['🤖', '🙋', '👋', '💡', '⭐'];

--- a/functions/src/stages/profile.utils.ts
+++ b/functions/src/stages/profile.utils.ts
@@ -8,54 +8,74 @@ import {
   createDefaultPromptFromText,
   createModelGenerationConfig,
   createStructuredOutputConfig,
+  PROFILE_AVATARS,
 } from '@deliberation-lab/utils';
 
 import {processModelResponse} from '../agent.utils';
 import {getExperimenterDataFromExperiment} from '../utils/firestore';
 import {getStructuredPrompt} from '../prompt.utils';
 
+const DEFAULT_GENDERED_PROMPT_SUFFIX =
+  ' Pick your emoji from this list and return only one character: ';
+
 const PROFILE_DEFAULT_PROMPT =
   'Please fill out your profile name, emoji, and pronouns.';
 
-const PROFILE_STRUCTURED_OUTPUT_CONFIG = createStructuredOutputConfig({
-  schema: {
-    type: StructuredOutputDataType.OBJECT,
-    properties: [
-      {
-        name: 'name',
-        schema: {
-          type: StructuredOutputDataType.STRING,
-          description: 'Your name',
+function createProfilePrompt(profileType: ProfileType): string {
+  if (profileType !== ProfileType.DEFAULT_GENDERED) {
+    return PROFILE_DEFAULT_PROMPT;
+  }
+  const emojiList = PROFILE_AVATARS.join(' ');
+  return `${PROFILE_DEFAULT_PROMPT}${DEFAULT_GENDERED_PROMPT_SUFFIX}${emojiList}.`;
+}
+
+function createProfileStructuredOutputConfig(profileType: ProfileType) {
+  return createStructuredOutputConfig({
+    schema: {
+      type: StructuredOutputDataType.OBJECT,
+      properties: [
+        {
+          name: 'name',
+          schema: {
+            type: StructuredOutputDataType.STRING,
+            description: 'Your name',
+          },
         },
-      },
-      {
-        name: 'emoji',
-        schema: {
-          type: StructuredOutputDataType.STRING,
-          description: 'A single emoji to be used as your avatar',
+        {
+          name: 'emoji',
+          schema: {
+            type: StructuredOutputDataType.STRING,
+            description: 'A single emoji to be used as your avatar',
+            enumItems:
+              profileType === ProfileType.DEFAULT_GENDERED
+                ? [...PROFILE_AVATARS]
+                : undefined,
+          },
         },
-      },
-      {
-        name: 'pronouns',
-        schema: {
-          type: StructuredOutputDataType.STRING,
-          description:
-            'Your pronouns (either she/her, he/him, they/them, or something else similar)',
+        {
+          name: 'pronouns',
+          schema: {
+            type: StructuredOutputDataType.STRING,
+            description:
+              'Your pronouns (either she/her, he/him, they/them, or something else similar)',
+          },
         },
-      },
-    ],
-  },
-});
+      ],
+    },
+  });
+}
 
 export async function completeProfile(
   experimentId: string,
   participant: ParticipantProfileExtended,
   stageConfig: ProfileStageConfig,
 ) {
+  const stageProfileType = stageConfig.profileType as ProfileType;
+
   if (
     !participant.agentConfig ||
-    stageConfig.profileType === ProfileType.ANONYMOUS_ANIMAL ||
-    stageConfig.profileType === ProfileType.ANONYMOUS_PARTICIPANT
+    stageProfileType === ProfileType.ANONYMOUS_ANIMAL ||
+    stageProfileType === ProfileType.ANONYMOUS_PARTICIPANT
   ) {
     return;
   }
@@ -69,9 +89,13 @@ export async function completeProfile(
   const promptConfig: BasePromptConfig = {
     id: stageConfig.id,
     type: stageConfig.kind,
-    prompt: createDefaultPromptFromText(PROFILE_DEFAULT_PROMPT, stageConfig.id),
+    prompt: createDefaultPromptFromText(
+      createProfilePrompt(stageProfileType),
+      stageConfig.id,
+    ),
     generationConfig: createModelGenerationConfig(),
-    structuredOutputConfig: PROFILE_STRUCTURED_OUTPUT_CONFIG,
+    structuredOutputConfig:
+      createProfileStructuredOutputConfig(stageProfileType),
     numRetries: 0,
   };
   const structuredPrompt = await getStructuredPrompt(
@@ -112,14 +136,32 @@ export async function completeProfile(
     return;
   }
 
-  const parsed = response.parsedResponse;
-  if (parsed['name']) {
-    participant.name = parsed['name'].trim();
+  const parsed = response.parsedResponse as Record<string, unknown>;
+
+  const name = parsed['name'];
+  if (typeof name === 'string') {
+    participant.name = name.trim();
   }
-  if (parsed['emoji']) {
-    participant.avatar = parsed['emoji'].trim();
+
+  const emojiValue = parsed['emoji'];
+  if (typeof emojiValue === 'string') {
+    const emoji = emojiValue.trim();
+    if (stageProfileType !== ProfileType.DEFAULT_GENDERED) {
+      participant.avatar = emoji;
+    } else if (!PROFILE_AVATARS.includes(emoji)) {
+      const fallbackEmoji =
+        PROFILE_AVATARS[Math.floor(Math.random() * PROFILE_AVATARS.length)];
+      console.warn(
+        `LLM returned emoji outside default gendered set: ${emoji}. Using fallback ${fallbackEmoji}.`,
+      );
+      participant.avatar = fallbackEmoji;
+    } else {
+      participant.avatar = emoji;
+    }
   }
-  if (parsed['pronouns']) {
-    participant.pronouns = parsed['pronouns'].trim();
+
+  const pronouns = parsed['pronouns'];
+  if (typeof pronouns === 'string') {
+    participant.pronouns = pronouns.trim();
   }
 }

--- a/utils/src/profile_sets.ts
+++ b/utils/src/profile_sets.ts
@@ -1,5 +1,16 @@
 /** Profile sets to use for anonymous profiles. */
 
+/** Profile avatar constants shared across packages. */
+export const WOMAN_EMOJIS = ['👩🏻', '👩🏼', '👩🏽', '👩🏾', '👩🏿'];
+export const MAN_EMOJIS = ['👨🏻', '👨🏼', '👨🏽', '👨🏾', '👨🏿'];
+export const PERSON_EMOJIS = ['🧑🏻', '🧑🏼', '🧑🏽', '🧑🏾', '🧑🏿'];
+
+export const PROFILE_AVATARS = [
+  ...WOMAN_EMOJIS,
+  ...MAN_EMOJIS,
+  ...PERSON_EMOJIS,
+];
+
 // Temporary hack: include this ID in stage ID in order to use
 // anonymous profile set for display
 export const SECONDARY_PROFILE_SET_ID = 'secondary_profile';


### PR DESCRIPTION
## Description
Now when agents hit the gendered stage, they will choose a gendered emoji.
- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature (if applicable)
- [x] All tests pass (if applicable)

[Creating the agents in the gendered set ](https://github.com/user-attachments/assets/8a62ab8f-9272-462f-ba99-14883512cb1c)

<img width="2860" height="1486" alt="image" src="https://github.com/user-attachments/assets/cb1b8e5c-5381-4e54-b914-623c4b4860ae" />
<img width="2856" height="1638" alt="image" src="https://github.com/user-attachments/assets/48201df4-07b9-4632-9313-15b63bba19ba" />
<img width="2856" height="1588" alt="image" src="https://github.com/user-attachments/assets/12499ba7-cac3-4427-b4f4-a9e5d76c4b09" />



Example of the standard, still working as intended.
<img width="3378" height="1800" alt="image" src="https://github.com/user-attachments/assets/4ecd4fe9-be0d-4f11-b8fe-0f2ea44108e8" />


---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
