### PR TITLE
Only show API keys for experiment if current viewer is the creator

### DIFF
--- a/frontend/src/components/experimenter/experimenter_data_editor.ts
+++ b/frontend/src/components/experimenter/experimenter_data_editor.ts
@@ -10,6 +10,7 @@ import '@material/web/textfield/filled-text-field.js';
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
 import {ExperimentManager} from '../../services/experiment.manager';
+import {ExperimentService} from '../../services/experiment.service';
 
 import {styles} from './experimenter_data_editor.scss';
 import {
@@ -33,15 +34,29 @@ export class ExperimenterDataEditor extends MobxLitElement {
 
   private readonly authService = core.getService(AuthService);
   private readonly experimentManager = core.getService(ExperimentManager);
+  private readonly experimentService = core.getService(ExperimentService);
 
   @state() geminiKeyResponse: null | boolean = null;
   @state() openAIKeyResponse: null | boolean = null;
   @state() ollamaKeyResponse: null | boolean = null;
 
   override render() {
+    const experiment = this.experimentService.experiment;
+    if (
+      experiment &&
+      experiment.metadata.creator !== this.authService.userEmail
+    ) {
+      return html`
+        <div>
+          This experiment uses API keys provided by the creator of the
+          experiment: ${experiment.metadata.creator}
+        </div>
+      `;
+    }
+
     return html`
       <div class="banner">
-        Note: API keys are shared across all experiments!
+        Note: API keys are shared across all of your experiments!
       </div>
       ${this.renderGeminiKey()}
       <div class="divider"></div>


### PR DESCRIPTION
When viewing API key panel in experiment builder and experiment dashboard, show a message about the experiment creator's keys being used instead of showing the current experimenter's keys (which is inaccurate).

[Screen recording of API key fix](https://github.com/user-attachments/assets/b0447a9e-8e2a-404b-a6e0-403ff65d3fcc)

This PR fixes: #664