### PR TITLE
Add system chat messages to display automated notifications in chat that agents and users can read.

### DIFF
--- a/frontend/src/components/chat/chat_message.scss
+++ b/frontend/src/components/chat/chat_message.scss
@@ -111,3 +111,17 @@ $bubble-width: 400px;
   color: var(--md-sys-color-tertiary);
   max-width: $bubble-width;
 }
+
+.system-message {
+  @include common.flex-row-align-center;
+  justify-content: center;
+  width: 100%;
+  padding: common.$spacing-small 0;
+
+  .content {
+    @include typescale.body-small;
+    font-style: italic;
+    color: var(--md-sys-color-outline);
+    text-align: center;
+  }
+}

--- a/frontend/src/components/chat/chat_message.ts
+++ b/frontend/src/components/chat/chat_message.ts
@@ -42,6 +42,8 @@ export class ChatMessageComponent extends MobxLitElement {
     switch (this.chat.type) {
       case UserType.PARTICIPANT:
         return this.renderParticipantMessage(this.chat);
+      case UserType.SYSTEM:
+        return this.renderSystemMessage(this.chat);
       default:
         return this.renderMediatorMessage(this.chat);
     }
@@ -113,6 +115,14 @@ export class ChatMessageComponent extends MobxLitElement {
           <div class="chat-bubble">${chatMessage.message}</div>
           ${this.renderDebuggingExplanation(chatMessage)}
         </div>
+      </div>
+    `;
+  }
+
+  renderSystemMessage(chatMessage: ChatMessage) {
+    return html`
+      <div class="system-message">
+        <div class="content">${chatMessage.message}</div>
       </div>
     `;
   }

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -1,4 +1,8 @@
-import {ChatMessage, createChatMessage} from '@deliberation-lab/utils';
+import {
+  ChatMessage,
+  createChatMessage,
+  createSystemChatMessage,
+} from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 import {app} from '../app';
 
@@ -27,4 +31,30 @@ export async function sendErrorPrivateChatMessage(
     .doc(chatMessage.id);
 
   agentDocument.set(chatMessage);
+}
+
+/** Send system chat message to public chat. */
+export async function sendSystemChatMessage(
+  experimentId: string,
+  cohortId: string,
+  stageId: string,
+  message: string,
+) {
+  const chatMessage = createSystemChatMessage({
+    message,
+    timestamp: Timestamp.now(),
+  });
+
+  const systemDocument = app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('cohorts')
+    .doc(cohortId)
+    .collection('publicStageData')
+    .doc(stageId)
+    .collection('chats')
+    .doc(chatMessage.id);
+
+  await systemDocument.set(chatMessage);
 }

--- a/functions/src/chat/message_converter.utils.ts
+++ b/functions/src/chat/message_converter.utils.ts
@@ -63,6 +63,11 @@ export function convertChatToMessages(
         currentUserType === UserType.MEDIATOR
           ? MessageRole.ASSISTANT
           : MessageRole.USER;
+    } else if (msg.type === UserType.SYSTEM) {
+      // System messages are treated as "user" messages for the AI to see them
+      role = MessageRole.USER;
+      // Prefix content to distinguish from regular user messages
+      msg.message = `[SYSTEM NOTIFICATION]: ${msg.message}`;
     } else {
       // Skip other message types for now
       continue;

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -52,6 +52,7 @@ export interface AgentChatResponse {
 // Sender ID for chat messages manually sent by experimenter
 // This should be consistent to ensure same background color for each message
 export const EXPERIMENTER_MANUAL_CHAT_SENDER_ID = 'experimenter';
+export const SYSTEM_CHAT_SENDER_ID = 'system';
 
 // ************************************************************************* //
 // FUNCTIONS                                                                 //
@@ -126,5 +127,23 @@ export function createExperimenterChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     isError: config.isError ?? false,
+  };
+}
+
+/** Create system chat message. */
+export function createSystemChatMessage(
+  config: Partial<ChatMessage> = {},
+): ChatMessage {
+  return {
+    id: config.id ?? generateId(),
+    discussionId: config.discussionId ?? null,
+    type: UserType.SYSTEM,
+    message: config.message ?? '',
+    timestamp: config.timestamp ?? Timestamp.now(),
+    profile: config.profile ?? {name: 'System', avatar: '⚙️', pronouns: null},
+    senderId: SYSTEM_CHAT_SENDER_ID,
+    agentId: '',
+    explanation: '',
+    isError: false,
   };
 }

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -42,6 +42,7 @@ export enum UserType {
   PARTICIPANT = 'participant',
   MEDIATOR = 'mediator',
   EXPERIMENTER = 'experimenter', // if experimenter needs to intervene
+  SYSTEM = 'system', // for automated messages (e.g., user left chat)
   UNKNOWN = 'unknown',
 }
 

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -5,7 +5,7 @@ import {
   createAgentChatSettings,
   createModelGenerationConfig,
 } from '../agent';
-import {ParticipantProfileBase} from '../participant';
+import {ParticipantProfileBase, UserType} from '../participant';
 import {getParticipantProfilePromptContext} from '../participant.prompts';
 import {convertUnifiedTimestampToTime} from '../shared';
 import {
@@ -79,6 +79,9 @@ Each message is displayed in chronological order, with the most recent message a
 
 /** Convert chat message to prompt format. */
 export function convertChatMessageToPromptFormat(message: ChatMessage) {
+  if (message.type === UserType.SYSTEM) {
+    return `${convertUnifiedTimestampToTime(message.timestamp)} [SYSTEM]: ${message.message}`;
+  }
   return `${convertUnifiedTimestampToTime(message.timestamp)} ${message.profile.name ?? message.senderId}: ${message.message}`;
 }
 

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -35,6 +35,7 @@ export const UserTypeData = Type.Union([
   Type.Literal(UserType.PARTICIPANT),
   Type.Literal(UserType.MEDIATOR),
   Type.Literal(UserType.EXPERIMENTER),
+  Type.Literal(UserType.SYSTEM),
   Type.Literal(UserType.UNKNOWN),
 ]);
 


### PR DESCRIPTION
When a user leaves the chat, it broadcasts a message from system. Users and agents can read those messages. This prompt agents to recognize when a user leaves.


## Description
<!-- Briefly describe the changes introduced by this PR. -->

- [ ] [Documentation]

(https://pair-code.github.io/deliberate-lab/) updated as needed
<img width="3456" height="1828" alt="image" src="https://github.com/user-attachments/assets/a2a5c52c-d7ac-4082-b11b-e360acdc60c7" />


Note: I noticed while testing this that agents will sometimes leave a chat multiple times: 
<img width="3456" height="1828" alt="image" src="https://github.com/user-attachments/assets/be03c00b-38f5-4268-9846-e145c613ed9b" />

This has likely been in the code for a while, just wasn't obvious as we didn't have the notification broadcasted.

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
