### PR TITLE
Use Node 22 for Cloud functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "config": {
     "firestore_tests": "src/log.utils.test.ts"


### PR DESCRIPTION
Runtime Node.js 18 was decommissioned on 2025-10-31