### PR TITLE
Fix markdown-breaking formatting issue in charity allocations template

### DIFF
--- a/frontend/src/shared/templates/charity_allocations.ts
+++ b/frontend/src/shared/templates/charity_allocations.ts
@@ -783,8 +783,8 @@ function createAllocationStage(
 
   charityVariableNames.forEach((variableName) => {
     primaryText += `\n
-        [{{${variableName}.name}}]({{${variableName}.link}}) (Charity Navigator score: {{${variableName}.score}})
-        *{{${variableName}.mission}}*\n`;
+[{{${variableName}.name}}]({{${variableName}.link}}) (Charity Navigator score: {{${variableName}.score}})
+*{{${variableName}.mission}}*\n`;
   });
 
   const charityStocks = charityVariableNames.map((variableName) => {


### PR DESCRIPTION
adding spaces to the formatted string in the charity allocation stages broke markdown. I reverted this. 