### PR TITLE
Add partial fix for resolving variables in prompt stage display

### DIFF
--- a/utils/src/stages/stage.manager.ts
+++ b/utils/src/stages/stage.manager.ts
@@ -95,6 +95,8 @@ export class StageManager {
   }
 
   /** Returns stage "display" (UI content) used in stage context prompt item.
+   *  NOTE: This does not resolve variables. Stage context passed in should
+   *  already be ready for render.
    *
    * If N > 0 participant answers are provided, then the stage display consists
    * of N "completed" (answers inline) stage displays concatenated


### PR DESCRIPTION
This passes stage configs through variable resolution before assembling the stage context prompt item.

WARNING: This will not work as intended if the prompt has multiple participants passed in for answer rendering and the variables are set at the participant level; in this case, only the "current" user's participant variables will be shown. This will be fixed in a follow-up.

[Resolve variables in stage displays.webm](https://github.com/user-attachments/assets/ac1a3996-383e-4711-91c9-8a098df1e1ef)

- [x] Documentation added in comments
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature (if applicable)
- [x] All tests pass (if applicable)
