### PR TITLE
Fixes agent participant adding through cohort panel

### DIFF
--- a/frontend/src/components/experiment_dashboard/cohort_settings_dialog.scss
+++ b/frontend/src/components/experiment_dashboard/cohort_settings_dialog.scss
@@ -12,6 +12,12 @@
   width: 800px;
 }
 
+.persona-selector {
+  @include common.flex-row;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .header {
   @include typescale.title-medium;
   @include common.flex-row-align-center;


### PR DESCRIPTION
## Description
Allows users to add agent participants directly from the cohort panel.

Adds new button allowing users to generate a new agent participant in the cohort panel. Future change will remove persona options and simply have users select between models when creating an agent participant. 

---

## Verification
<img width="1654" height="1250" alt="image" src="https://github.com/user-attachments/assets/d046635f-85df-4de5-9b2b-24e04d72f843" />

## Related issues
This PR fixes: #730 
