### PR TITLE
Fix the all-done icon to show up in production by using pr-icon instead of mwc.

### DIFF
--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -1,5 +1,5 @@
-import '@material/mwc-icon';
 import '../../pair-components/button';
+import '../../pair-components/icon';
 import '../../pair-components/icon_button';
 import '../../pair-components/textarea';
 import '../../pair-components/tooltip';
@@ -236,7 +236,7 @@ export class GroupChatView extends MobxLitElement {
     ) {
       return html`
         <div slot="indicators" class="description">
-          <mwc-icon>done_all</mwc-icon>
+          <pr-icon icon="done_all"></pr-icon>
           All other participants have completed this stage.
         </div>
       `;


### PR DESCRIPTION
## Description
Fix the all-done icon to show up in production by using pr-icon instead of mwc.
<img width="1254" height="1236" alt="image" src="https://github.com/user-attachments/assets/b4e08e45-2669-4f0b-97e4-aa4ebb29942a" />

- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature: be the last person in the chat.
- [x] All tests pass (if applicable)

---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
