### PR TITLE
Move experimentDownload to backend (from #744).

### DIFF
--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -1,12 +1,10 @@
 import {computed, makeObservable, observable} from 'mobx';
 import {
   collection,
-  doc,
   getDocs,
   onSnapshot,
   orderBy,
   query,
-  Timestamp,
   Unsubscribe,
   where,
 } from 'firebase/firestore';
@@ -21,7 +19,6 @@ import {Service} from './service';
 import JSZip from 'jszip';
 
 import {
-  DEFAULT_AGENT_MODEL_SETTINGS,
   AlertMessage,
   AlertStatus,
   AgentPersonaConfig,
@@ -31,8 +28,6 @@ import {
   CohortConfig,
   CohortParticipantConfig,
   CreateChatMessageData,
-  Experiment,
-  ExperimentDownload,
   LogEntry,
   MediatorProfileExtended,
   MediatorStatus,
@@ -40,7 +35,6 @@ import {
   ParticipantProfileExtended,
   ParticipantStatus,
   ProfileAgentConfig,
-  StageConfig,
   StageKind,
   createCohortConfig,
   createExperimenterChatMessage,
@@ -52,6 +46,7 @@ import {
   createChatMessageCallable,
   createCohortCallable,
   createMediatorCallable,
+  downloadExperimentCallable,
   createParticipantCallable,
   deleteCohortCallable,
   deleteExperimentCallable,
@@ -70,14 +65,11 @@ import {
   hasMaxParticipantsInCohort,
 } from '../shared/cohort.utils';
 import {
-  downloadCSV,
-  downloadJSON,
   getAlertData,
   getChatHistoryData,
   getChipNegotiationCSV,
   getChipNegotiationData,
   getChipNegotiationPlayerMapCSV,
-  getExperimentDownload,
   getParticipantDataCSV,
 } from '../shared/file.utils';
 import {
@@ -886,12 +878,13 @@ export class ExperimentManager extends Service {
     let data = {};
     const experimentId = this.sp.routerService.activeRoute.params['experiment'];
     if (experimentId) {
-      const result = await getExperimentDownload(
-        this.sp.firebaseService.firestore,
+      const response = await downloadExperimentCallable(
+        this.sp.firebaseService.functions,
         experimentId,
       );
 
-      if (result) {
+      if (response.data) {
+        const result = response.data;
         const zip = new JSZip();
         const experimentName = result.experiment.metadata.name;
 

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -99,6 +99,21 @@ export const getExperimentTemplateCallable = async (
   return data;
 };
 
+/** Generic endpoint to download experiment data. */
+export const downloadExperimentCallable = async (
+  functions: Functions,
+  experimentId: string,
+) => {
+  const {data} = await httpsCallable<
+    {experimentId: string},
+    ExperimentDownloadResponse
+  >(
+    functions,
+    'downloadExperiment',
+  )({experimentId});
+  return data;
+};
+
 /** Generic endpoint to set experiment cohort lock */
 export const setExperimentCohortLockCallable = async (
   functions: Functions,

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -2,23 +2,8 @@
  * Functions for data downloads.
  */
 
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  Firestore,
-  orderBy,
-  query,
-} from 'firebase/firestore';
 import {stringify as csvStringify} from 'csv-stringify/sync';
 import {
-  AgentDataObject,
-  AgentMediatorPersonaConfig,
-  AgentMediatorTemplate,
-  AgentParticipantPersonaConfig,
-  AgentParticipantTemplate,
-  AgentPersonaConfig,
   AlertMessage,
   ChatMessage,
   ChipItem,
@@ -26,34 +11,21 @@ import {
   ChipStagePublicData,
   ChipTransaction,
   ChipTransactionStatus,
-  CohortConfig,
   CohortDownload,
-  Experiment,
   ExperimentDownload,
-  MediatorPromptConfig,
-  ParticipantPromptConfig,
   ParticipantDownload,
   ParticipantProfileExtended,
   PayoutItemType,
   PayoutStageConfig,
   PayoutStageParticipantAnswer,
   RankingStageConfig,
-  RankingStagePublicData,
-  StageConfig,
   StageKind,
-  StageParticipantAnswer,
-  StagePublicData,
-  SurveyAnswer,
   SurveyPerParticipantStageConfig,
-  SurveyStageConfig,
-  SurveyQuestion,
   SurveyQuestionKind,
+  SurveyStageConfig,
   UnifiedTimestamp,
   calculatePayoutResult,
   calculatePayoutTotal,
-  createCohortDownload,
-  createExperimentDownload,
-  createParticipantDownload,
 } from '@deliberation-lab/utils';
 import {convertUnifiedTimestampToISO} from './utils';
 
@@ -106,191 +78,6 @@ export function toCSV(text: string | null) {
   if (!text) return '';
 
   return text.replaceAll(',', '').replaceAll('\n', '');
-}
-
-// ****************************************************************************
-// EXPERIMENT DOWNLOAD JSON
-// ****************************************************************************
-export async function getExperimentDownload(
-  firestore: Firestore,
-  experimentId: string,
-) {
-  // Get experiment config from experimentId
-  const experimentConfig = (
-    await getDoc(doc(firestore, 'experiments', experimentId))
-  ).data() as Experiment;
-
-  // Create experiment download using experiment config
-  const experimentDownload = createExperimentDownload(experimentConfig);
-
-  // For each experiment stage config, add to ExperimentDownload
-  const stageConfigs = (
-    await getDocs(collection(firestore, 'experiments', experimentId, 'stages'))
-  ).docs.map((doc) => doc.data() as StageConfig);
-  for (const stage of stageConfigs) {
-    experimentDownload.stageMap[stage.id] = stage;
-  }
-
-  // For each participant, add ParticipantDownload
-  const profiles = (
-    await getDocs(
-      collection(firestore, 'experiments', experimentId, 'participants'),
-    )
-  ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
-  for (const profile of profiles) {
-    // Create new ParticipantDownload
-    const participantDownload = createParticipantDownload(profile);
-
-    // For each stage answer, add to ParticipantDownload map
-    const stageAnswers = (
-      await getDocs(
-        collection(
-          firestore,
-          'experiments',
-          experimentId,
-          'participants',
-          profile.privateId,
-          'stageData',
-        ),
-      )
-    ).docs.map((doc) => doc.data() as StageParticipantAnswer);
-    for (const stage of stageAnswers) {
-      participantDownload.answerMap[stage.id] = stage;
-    }
-    // Add ParticipantDownload to ExperimentDownload
-    experimentDownload.participantMap[profile.publicId] = participantDownload;
-  }
-
-  // For each agent mediator, add template
-  const agentMediatorCollection = collection(
-    firestore,
-    'experiments',
-    experimentId,
-    'agentMediators',
-  );
-  const mediatorAgents = (await getDocs(agentMediatorCollection)).docs.map(
-    (agent) => agent.data() as AgentMediatorPersonaConfig,
-  );
-  for (const persona of mediatorAgents) {
-    const mediatorPrompts = (
-      await getDocs(
-        collection(
-          firestore,
-          'experiments',
-          experimentId,
-          'agentMediators',
-          persona.id,
-          'prompts',
-        ),
-      )
-    ).docs.map((doc) => doc.data() as MediatorPromptConfig);
-    const mediatorTemplate: AgentMediatorTemplate = {
-      persona,
-      promptMap: {},
-    };
-    mediatorPrompts.forEach((prompt) => {
-      mediatorTemplate.promptMap[prompt.id] = prompt;
-    });
-    // Add to ExperimentDownload
-    experimentDownload.agentMediatorMap[persona.id] = mediatorTemplate;
-  }
-
-  // For each agent participant, add template
-  const agentParticipantCollection = collection(
-    firestore,
-    'experiments',
-    experimentId,
-    'agentParticipants',
-  );
-  const participantAgents = (
-    await getDocs(agentParticipantCollection)
-  ).docs.map((agent) => agent.data() as AgentParticipantPersonaConfig);
-  for (const persona of participantAgents) {
-    const participantPrompts = (
-      await getDocs(
-        collection(
-          firestore,
-          'experiments',
-          experimentId,
-          'agentParticipants',
-          persona.id,
-          'prompts',
-        ),
-      )
-    ).docs.map((doc) => doc.data() as ParticipantPromptConfig);
-    const participantTemplate: AgentParticipantTemplate = {
-      persona,
-      promptMap: {},
-    };
-    participantPrompts.forEach((prompt) => {
-      participantTemplate.promptMap[prompt.id] = prompt;
-    });
-    // Add to ExperimentDownload
-    experimentDownload.agentParticipantMap[persona.id] = participantTemplate;
-  }
-
-  // For each cohort, add CohortDownload
-  const cohorts = (
-    await getDocs(collection(firestore, 'experiments', experimentId, 'cohorts'))
-  ).docs.map((cohort) => cohort.data() as CohortConfig);
-  for (const cohort of cohorts) {
-    // Create new CohortDownload
-    const cohortDownload = createCohortDownload(cohort);
-
-    // For each public stage data, add to CohortDownload
-    const publicStageData = (
-      await getDocs(
-        collection(
-          firestore,
-          'experiments',
-          experimentId,
-          'cohorts',
-          cohort.id,
-          'publicStageData',
-        ),
-      )
-    ).docs.map((doc) => doc.data() as StagePublicData);
-    for (const data of publicStageData) {
-      cohortDownload.dataMap[data.id] = data;
-      // If chat stage, add list of chat messages to CohortDownload
-      if (data.kind === StageKind.CHAT) {
-        const chatList = (
-          await getDocs(
-            query(
-              collection(
-                firestore,
-                'experiments',
-                experimentId,
-                'cohorts',
-                cohort.id,
-                'publicStageData',
-                data.id,
-                'chats',
-              ),
-              orderBy('timestamp', 'asc'),
-            ),
-          )
-        ).docs.map((doc) => doc.data() as ChatMessage);
-        cohortDownload.chatMap[data.id] = chatList;
-      }
-    }
-
-    // Add CohortDownload to ExperimentDownload
-    experimentDownload.cohortMap[cohort.id] = cohortDownload;
-
-    // Add alerts to ExperimentDownload
-    const alertList = (
-      await getDocs(
-        query(
-          collection(firestore, 'experiments', experimentId, 'alerts'),
-          orderBy('timestamp', 'asc'),
-        ),
-      )
-    ).docs.map((doc) => doc.data() as AlertMessage);
-    experimentDownload.alerts = alertList;
-  }
-
-  return experimentDownload;
 }
 
 // ****************************************************************************

--- a/functions/src/data.ts
+++ b/functions/src/data.ts
@@ -1,0 +1,209 @@
+/**
+ * Data download utilities for Firebase Admin SDK
+ */
+
+import {Firestore} from 'firebase-admin/firestore';
+import {
+  AgentMediatorPersonaConfig,
+  AgentMediatorTemplate,
+  AgentParticipantPersonaConfig,
+  AgentParticipantTemplate,
+  AlertMessage,
+  ChatMessage,
+  CohortConfig,
+  createCohortDownload,
+  createExperimentDownload,
+  createParticipantDownload,
+  Experiment,
+  ExperimentDownload,
+  MediatorPromptConfig,
+  ParticipantProfileExtended,
+  ParticipantPromptConfig,
+  StageConfig,
+  StageKind,
+  StageParticipantAnswer,
+  StagePublicData,
+} from '@deliberation-lab/utils';
+import {convertTimestamps} from './data.utils';
+
+/**
+ * Build a complete ExperimentDownload structure using Firebase Admin SDK.
+ *
+ * @param firestore - Firestore instance from firebase-admin/firestore
+ * @param experimentId - ID of the experiment to download
+ * @returns Complete experiment download data
+ */
+export async function getExperimentDownload(
+  firestore: Firestore,
+  experimentId: string,
+): Promise<ExperimentDownload> {
+  // Get experiment config from experimentId
+  const experimentConfig = (
+    await firestore.collection('experiments').doc(experimentId).get()
+  ).data() as Experiment;
+
+  // Create experiment download using experiment config
+  const experimentDownload = createExperimentDownload(experimentConfig);
+
+  // For each experiment stage config, add to ExperimentDownload
+  const stageConfigs = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('stages')
+      .get()
+  ).docs.map((doc) => doc.data() as StageConfig);
+  for (const stage of stageConfigs) {
+    experimentDownload.stageMap[stage.id] = stage;
+  }
+
+  // For each participant, add ParticipantDownload
+  const profiles = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('participants')
+      .get()
+  ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
+  for (const profile of profiles) {
+    // Create new ParticipantDownload
+    const participantDownload = createParticipantDownload(profile);
+
+    // For each stage answer, add to ParticipantDownload map
+    const stageAnswers = (
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(profile.privateId)
+        .collection('stageData')
+        .get()
+    ).docs.map((doc) => doc.data() as StageParticipantAnswer);
+    for (const stage of stageAnswers) {
+      participantDownload.answerMap[stage.id] = stage;
+    }
+    // Add ParticipantDownload to ExperimentDownload
+    experimentDownload.participantMap[profile.publicId] = participantDownload;
+  }
+
+  // For each agent mediator, add template
+  const mediatorAgents = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('agentMediators')
+      .get()
+  ).docs.map((agent) => agent.data() as AgentMediatorPersonaConfig);
+  for (const persona of mediatorAgents) {
+    const mediatorPrompts = (
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('agentMediators')
+        .doc(persona.id)
+        .collection('prompts')
+        .get()
+    ).docs.map((doc) => doc.data() as MediatorPromptConfig);
+    const mediatorTemplate: AgentMediatorTemplate = {
+      persona,
+      promptMap: {},
+    };
+    mediatorPrompts.forEach((prompt) => {
+      mediatorTemplate.promptMap[prompt.id] = prompt;
+    });
+    // Add to ExperimentDownload
+    experimentDownload.agentMediatorMap[persona.id] = mediatorTemplate;
+  }
+
+  // For each agent participant, add template
+  const participantAgents = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('agentParticipants')
+      .get()
+  ).docs.map((agent) => agent.data() as AgentParticipantPersonaConfig);
+  for (const persona of participantAgents) {
+    const participantPrompts = (
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('agentParticipants')
+        .doc(persona.id)
+        .collection('prompts')
+        .get()
+    ).docs.map((doc) => doc.data() as ParticipantPromptConfig);
+    const participantTemplate: AgentParticipantTemplate = {
+      persona,
+      promptMap: {},
+    };
+    participantPrompts.forEach((prompt) => {
+      participantTemplate.promptMap[prompt.id] = prompt;
+    });
+    // Add to ExperimentDownload
+    experimentDownload.agentParticipantMap[persona.id] = participantTemplate;
+  }
+
+  // For each cohort, add CohortDownload
+  const cohorts = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('cohorts')
+      .get()
+  ).docs.map((cohort) => cohort.data() as CohortConfig);
+  for (const cohort of cohorts) {
+    // Create new CohortDownload
+    const cohortDownload = createCohortDownload(cohort);
+
+    // For each public stage data, add to CohortDownload
+    const publicStageData = (
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('cohorts')
+        .doc(cohort.id)
+        .collection('publicStageData')
+        .get()
+    ).docs.map((doc) => doc.data() as StagePublicData);
+    for (const data of publicStageData) {
+      cohortDownload.dataMap[data.id] = data;
+      // If chat stage, add list of chat messages to CohortDownload
+      if (data.kind === StageKind.CHAT) {
+        const chatList = (
+          await firestore
+            .collection('experiments')
+            .doc(experimentId)
+            .collection('cohorts')
+            .doc(cohort.id)
+            .collection('publicStageData')
+            .doc(data.id)
+            .collection('chats')
+            .orderBy('timestamp', 'asc')
+            .get()
+        ).docs.map((doc) => doc.data() as ChatMessage);
+        cohortDownload.chatMap[data.id] = chatList;
+      }
+    }
+
+    // Add CohortDownload to ExperimentDownload
+    experimentDownload.cohortMap[cohort.id] = cohortDownload;
+  }
+
+  // Add alerts to ExperimentDownload
+  const alertList = (
+    await firestore
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('alerts')
+      .orderBy('timestamp', 'asc')
+      .get()
+  ).docs.map((doc) => doc.data() as AlertMessage);
+  experimentDownload.alerts = alertList;
+
+  // Convert all Timestamp objects to UnifiedTimestamp format
+  const normalized = convertTimestamps(
+    experimentDownload,
+  ) as ExperimentDownload;
+  return normalized;
+}

--- a/functions/src/data.utils.ts
+++ b/functions/src/data.utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Data utilities for Firebase Admin SDK
+ */
+
+import {Timestamp} from 'firebase-admin/firestore';
+import {UnifiedTimestamp} from '@deliberation-lab/utils';
+
+/**
+ * Converts a Firestore Admin SDK Timestamp to UnifiedTimestamp format.
+ * Uses the public seconds/nanoseconds properties instead of the serialized _seconds/_nanoseconds.
+ */
+export function toUnifiedTimestamp(timestamp: Timestamp): UnifiedTimestamp {
+  return {
+    seconds: timestamp.seconds,
+    nanoseconds: timestamp.nanoseconds,
+  };
+}
+
+/**
+ * Recursively converts all Timestamp objects in the data structure to UnifiedTimestamp format.
+ * This is necessary because Admin SDK Timestamps serialize with _seconds/_nanoseconds,
+ * but the frontend expects seconds/nanoseconds (without underscores).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function convertTimestamps(obj: any): any {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  // Check if this is a Timestamp object
+  if (obj instanceof Timestamp) {
+    return toUnifiedTimestamp(obj);
+  }
+
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    return obj.map((item) => convertTimestamps(item));
+  }
+
+  // Handle plain objects
+  if (typeof obj === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any = {};
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        result[key] = convertTimestamps(obj[key]);
+      }
+    }
+    return result;
+  }
+
+  // Return primitives as-is
+  return obj;
+}

--- a/functions/src/experiment.endpoints.ts
+++ b/functions/src/experiment.endpoints.ts
@@ -6,6 +6,7 @@ import {
   AgentParticipantTemplate,
   Experiment,
   ExperimentDeletionData,
+  ExperimentDownloadResponse,
   MediatorPromptConfig,
   ParticipantPromptConfig,
   SeedStrategy,
@@ -14,6 +15,7 @@ import {
   createExperimentTemplate,
   createVariableToValueMapForSeed,
 } from '@deliberation-lab/utils';
+import {getExperimentDownload} from './data';
 
 import * as functions from 'firebase-functions';
 import {onCall} from 'firebase-functions/v2/https';
@@ -372,4 +374,31 @@ export const setExperimentCohortLock = onCall(async (request) => {
   });
 
   return {success: true};
+});
+
+// ************************************************************************* //
+// downloadExperiment for experimenters                                      //
+//                                                                           //
+// Input structure: { experimentId }                                         //
+// Returns: ExperimentDownloadResponse                                       //
+// ************************************************************************* //
+export const downloadExperiment = onCall(async (request) => {
+  await AuthGuard.isExperimenter(request);
+  const {data} = request;
+
+  try {
+    const experimentDownload = await getExperimentDownload(
+      app.firestore(),
+      data.experimentId,
+    );
+
+    const response: ExperimentDownloadResponse = {
+      data: experimentDownload,
+    };
+
+    return response;
+  } catch (error) {
+    console.error('Error downloading experiment:', error);
+    return {data: null};
+  }
 });

--- a/utils/src/data.ts
+++ b/utils/src/data.ts
@@ -1,4 +1,13 @@
-import {AgentMediatorTemplate, AgentParticipantTemplate} from './agent';
+import {
+  AgentMediatorTemplate,
+  AgentParticipantTemplate,
+  AgentMediatorPersonaConfig,
+  AgentParticipantPersonaConfig,
+} from './agent';
+import {
+  MediatorPromptConfig,
+  ParticipantPromptConfig,
+} from './structured_prompt';
 import {AlertMessage} from './alert';
 import {CohortConfig} from './cohort';
 import {Experiment} from './experiment';
@@ -6,10 +15,10 @@ import {ParticipantProfileExtended} from './participant';
 import {ChatMessage} from './chat_message';
 import {
   StageConfig,
+  StageKind,
   StageParticipantAnswer,
   StagePublicData,
 } from './stages/stage';
-
 /** Experiment data download types and functions. */
 
 // ************************************************************************* //


### PR DESCRIPTION
This moves the experimentDownload functionality to `functions/` so that it can be used on the frontend and backend (this is important for the new API in #744).