### PR TITLE
Add constraints to group chats for agent participant experiment

### DIFF
--- a/frontend/src/shared/templates/agent_participant_integration_template.ts
+++ b/frontend/src/shared/templates/agent_participant_integration_template.ts
@@ -191,6 +191,7 @@ const INT_PRIVATE_CHAT_STAGE = createPrivateChatStage({
     primaryText: INT_PRIVATE_CHAT_DESCRIPTION,
   }),
   timeLimitInMinutes: 5,
+  minNumberOfTurns: 2,
 });
 
 // ****************************************************************************
@@ -248,6 +249,12 @@ const INT_GROUP_CHAT_STAGE = createChatStage({
   descriptions: createStageTextConfig({
     primaryText: INT_GROUP_CHAT_DESCRIPTION,
   }),
+  progress: createStageProgressConfig({
+    waitForAllParticipants: true,
+    minParticipants: 2,
+  }),
+  timeLimitInMinutes: 2,
+  requireFullTime: true,
 });
 
 // ****************************************************************************


### PR DESCRIPTION
## Description
Adds constraints to chat stages to attempt to prevent agent participants from progressing without interacting. Adds min number of turns to private chat, and a time minimum to the group chat (and requires at least 2 participants before chat can begin).
