### PR TITLE
Increase firebase emulator timeout to max.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,8 @@
       "port": 9000
     },
     "functions": {
-      "port": 5001
+      "port": 5001,
+      "timeout": 540
     },
     "firestore": {
       "port": 8080


### PR DESCRIPTION
Emulator timeout is 60s by default, this breaks for long-running model calls.