### PR TITLE
Fix transfer ID/timestamp update logic for agent participants

### DIFF
--- a/functions/src/agent_participant.utils.ts
+++ b/functions/src/agent_participant.utils.ts
@@ -64,8 +64,14 @@ export async function completeStageAsAgentParticipant(
     updatedStatus = true;
   }
 
-  // Transfer logic: if pending, set back to in progress
+  // Transfer logic: if pending, update timestamp, cohort ID, and status
   if (status === ParticipantStatus.TRANSFER_PENDING) {
+    const timestamp = Timestamp.now();
+    participant.timestamps.cohortTransfers[participant.currentCohortId] =
+      timestamp;
+    participant.currentCohortId = participant.transferCohortId;
+    participant.transferCohortId = null;
+
     participant.currentStatus = ParticipantStatus.IN_PROGRESS;
     // If in a transfer stage, progress to next stage
     if (stage.kind === StageKind.TRANSFER) {


### PR DESCRIPTION
…fer logic

PR #800 updated the participant status during transfer accept, but did not correctly update the participant's cohort ID or transfer timestamp.