### PR TITLE
Update storage.ts to use built-in UUID.

### DIFF
--- a/functions/src/utils/storage.ts
+++ b/functions/src/utils/storage.ts
@@ -1,5 +1,5 @@
 import {app} from '../app';
-import {v4 as uuidv4} from 'uuid';
+import {generateId} from '@deliberation-lab/utils';
 
 /**
  * Uploads a base64 encoded image to Google Cloud Storage.
@@ -15,7 +15,7 @@ export async function uploadBase64ImageToGCS(
 ): Promise<string> {
   const BUCKET_NAME = 'deliberate-labs';
   const bucket = app.storage().bucket(BUCKET_NAME);
-  const fileName = `${prefix}/${uuidv4()}.${mimeType.split('/')[1]}`;
+  const fileName = `${prefix}/${generateId()}.${mimeType.split('/')[1]}`;
   const file = bucket.file(fileName);
 
   const buffer = Buffer.from(base64Data, 'base64');


### PR DESCRIPTION
We moved away from the UUID library in #869, #846 used UUID in `storage.ts`, this migrates away from that to use the built-in one (which uses the native `crypto.randomUUID()`).
