### PR TITLE
Remove public:true in the uploadBase64ImageToGCS, follow UBLA conventions.

### DIFF
--- a/functions/src/utils/storage.ts
+++ b/functions/src/utils/storage.ts
@@ -13,7 +13,7 @@ export async function uploadBase64ImageToGCS(
   mimeType: string,
   prefix = 'generated-images',
 ): Promise<string> {
-  const BUCKET_NAME = 'deliberate-labs';
+  const BUCKET_NAME = 'deliberate-lab';
   const bucket = app.storage().bucket(BUCKET_NAME);
   const fileName = `${prefix}/${generateId()}.${mimeType.split('/')[1]}`;
   const file = bucket.file(fileName);


### PR DESCRIPTION

## Description

https://cloud.google.com/storage/docs/uniform-bucket-level-access

Since we use uniform-bucket-level-access, we cannot set the ACL per file, which is what we were trying to do. Additionally, we we were using a GCS bucket that was named "deliberate-labs": typically, GCS buckets have the same name as their project, so I renamed it to "deliberate-lab" in this PR as well.

Once the deliberate-labs bucket was created, the main error in the logs was:

```
  message: 'Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access',
```

Deploying this change should silence that error. It's possible we may need to make some ACL changes to the bucket to verify that everyone can access the images. I don't think so, hopefully.


- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [ ] *Screenshots or videos* included (if applicable)
- [ ] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #879

---
