### PR TITLE
Expand agent participant configuration with logging, debugging, and web search

### DIFF
--- a/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.scss
+++ b/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.scss
@@ -1,0 +1,94 @@
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+:host {
+  @include common.overlay;
+  z-index: 20; // Above cohort-list header (z-index: 10)
+}
+
+.dialog {
+  @include common.dialog;
+  height: 700px;
+  width: 800px;
+}
+
+.header {
+  @include typescale.title-medium;
+  @include common.flex-row-align-center;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+  gap: common.$spacing-medium;
+  height: common.$header-height;
+  justify-content: space-between;
+  padding: 0 common.$main-content-padding;
+}
+
+.body {
+  @include common.flex-column;
+  flex-grow: 1;
+  gap: common.$spacing-xl;
+  overflow: auto;
+  padding: common.$main-content-padding;
+}
+
+.section {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+}
+
+.section-title {
+  @include typescale.title-medium;
+}
+
+.field {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+  width: 100%;
+}
+
+.field-title {
+  @include typescale.label-small;
+}
+
+.description {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  font-style: italic;
+}
+
+.small {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+}
+
+.action-buttons {
+  @include common.flex-row;
+  flex-wrap: wrap;
+  gap: common.$spacing-medium;
+}
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}
+
+.divider {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  width: 100%;
+}
+
+.buttons-wrapper {
+  @include common.flex-row-align-center;
+  justify-content: end;
+}

--- a/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.ts
+++ b/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.ts
@@ -1,6 +1,7 @@
 import '../../pair-components/button';
 import '../../pair-components/icon_button';
 import '@material/web/textfield/filled-text-field.js';
+import '@material/web/checkbox/checkbox.js';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -15,11 +16,11 @@ import {
   AgentPersonaConfig,
   CohortConfig,
   ApiKeyType,
-  AgentPersonaType,
+  AgentChatSettings,
   createAgentModelSettings,
 } from '@deliberation-lab/utils';
 
-import {styles} from './cohort_settings_dialog.scss';
+import {styles} from './agent_participant_configuration_dialog.scss';
 
 /** Agent participant configuration dialog */
 @customElement('agent-participant-configuration-dialog')
@@ -37,7 +38,15 @@ export class AgentParticipantDialog extends MobxLitElement {
   @property() agentId = '';
   @property() promptContext = '';
   @property() agent: AgentPersonaConfig | undefined = undefined;
-  @property() model: string = '';
+  @property() apiType: ApiKeyType = ApiKeyType.GEMINI_API_KEY;
+  @property() model: string = 'gemini-3-pro-preview';
+  @property() useWebSearch: boolean = false;
+
+  // Chat settings
+  @property() wordsPerMinute: number | null = null;
+  @property() minMessagesBeforeResponding: number = 0;
+  @property() canSelfTriggerCalls: boolean = false;
+  @property() maxResponses: number | null = 100;
 
   private close() {
     this.dispatchEvent(new CustomEvent('close'));
@@ -70,43 +79,78 @@ export class AgentParticipantDialog extends MobxLitElement {
   private resetFields() {
     this.agentId = '';
     this.promptContext = '';
+    this.apiType = ApiKeyType.GEMINI_API_KEY;
+    this.model = 'gemini-3-pro-preview';
+    this.useWebSearch = false;
+    // Reset chat settings
+    this.wordsPerMinute = null;
+    this.minMessagesBeforeResponding = 0;
+    this.canSelfTriggerCalls = false;
+    this.maxResponses = 100;
   }
 
   private renderEdit() {
     return html`
-      ${this.renderAgentModel()} ${this.renderPromptContext()}
+      <div class="section">
+        <div class="section-title">Model settings</div>
+        ${this.renderApiType()} ${this.renderModelId()}
+        ${this.renderWebSearchOption()}
+      </div>
+      <div class="divider"></div>
+      <div class="section">
+        <div class="section-title">Prompt</div>
+        ${this.renderPromptContext()}
+      </div>
+      <div class="divider"></div>
+      <div class="section">
+        <div class="section-title">Chat settings</div>
+        <div class="description">
+          Configure how this agent participates in chat stages.
+        </div>
+        ${this.renderChatSettings()}
+      </div>
       <div class="buttons-wrapper">
         <pr-button
           ?disabled=${this.model === ''}
           ?loading=${this.isLoading}
-          @click=${() => {
-            this.isLoading = true;
-            this.analyticsService.trackButtonClick(
-              ButtonClick.AGENT_PARTICIPANT_ADD,
-            );
-            if (this.cohort && this.model) {
-              this.experimentEditor.addAgentParticipant();
-              this.agentId = ''; //Make agent ID blank for agents added from cohort panel that use default prompts
-              const modelSettings = createAgentModelSettings({
-                apiType: ApiKeyType.GEMINI_API_KEY,
-                modelName: this.model,
-              });
-
-              this.experimentManager.createAgentParticipant(this.cohort.id, {
-                agentId: this.agentId,
-                promptContext: this.promptContext,
-                modelSettings,
-              });
-            }
-            this.resetFields();
-            this.isSuccess = true;
-            this.isLoading = false;
-          }}
+          @click=${this.handleAddAgent}
         >
           Add agent participant
         </pr-button>
       </div>
     `;
+  }
+
+  private handleAddAgent() {
+    this.isLoading = true;
+    this.analyticsService.trackButtonClick(ButtonClick.AGENT_PARTICIPANT_ADD);
+    if (this.cohort && this.model) {
+      this.experimentEditor.addAgentParticipant();
+      this.agentId = ''; // Make agent ID blank for agents added from cohort panel that use default prompts
+      const modelSettings = createAgentModelSettings({
+        apiType: this.apiType,
+        modelName: this.model,
+        useWebSearch: this.useWebSearch,
+      });
+
+      const chatSettings: AgentChatSettings = {
+        initialMessage: '',
+        wordsPerMinute: this.wordsPerMinute,
+        minMessagesBeforeResponding: this.minMessagesBeforeResponding,
+        canSelfTriggerCalls: this.canSelfTriggerCalls,
+        maxResponses: this.maxResponses,
+      };
+
+      this.experimentManager.createAgentParticipant(this.cohort.id, {
+        agentId: this.agentId,
+        promptContext: this.promptContext,
+        modelSettings,
+        chatSettings,
+      });
+    }
+    this.resetFields();
+    this.isSuccess = true;
+    this.isLoading = false;
   }
 
   private renderSuccess() {
@@ -124,44 +168,98 @@ export class AgentParticipantDialog extends MobxLitElement {
     `;
   }
 
-  private renderAgentModel() {
+  private renderApiType() {
     return html`
-      <div class="selections">
-        <div>Model to use for this specific agent participant:</div>
-        <div class="model-selector">
-          ${this.renderModelButton(
-            'gemini-2.5-flash',
-            'Gemini 2.5 Flash',
-            ApiKeyType.GEMINI_API_KEY,
-          )}
-          ${this.renderModelButton(
-            'gemini-2.5-pro',
-            'Gemini 2.5 Pro',
-            ApiKeyType.GEMINI_API_KEY,
-          )}
+      <div class="field">
+        <div class="field-title">LLM API</div>
+        <div class="action-buttons">
+          ${this.renderApiTypeButton('Gemini', ApiKeyType.GEMINI_API_KEY)}
+          ${this.renderApiTypeButton('OpenAI', ApiKeyType.OPENAI_API_KEY)}
+          ${this.renderApiTypeButton('Anthropic', ApiKeyType.CLAUDE_API_KEY)}
+          ${this.renderApiTypeButton('Ollama', ApiKeyType.OLLAMA_CUSTOM_URL)}
         </div>
       </div>
     `;
   }
 
-  private renderModelButton(
-    modelId: string,
-    modelName: string,
-    apiType: ApiKeyType,
-  ) {
-    const updateModel = () => {
-      this.model = modelId;
+  private renderApiTypeButton(apiName: string, apiType: ApiKeyType) {
+    const updateApiType = () => {
+      this.apiType = apiType;
+      // Set a default model name when switching API types
+      if (apiType === ApiKeyType.GEMINI_API_KEY) {
+        this.model = 'gemini-3-pro-preview';
+      } else if (apiType === ApiKeyType.OPENAI_API_KEY) {
+        this.model = 'gpt-5.1-2025-11-13';
+      } else if (apiType === ApiKeyType.CLAUDE_API_KEY) {
+        this.model = 'claude-opus-4-5-20251101';
+      } else if (apiType === ApiKeyType.OLLAMA_CUSTOM_URL) {
+        this.model = 'llama3.2';
+      }
+      // Reset web search when switching to OpenAI or Ollama (not supported)
+      if (
+        apiType === ApiKeyType.OLLAMA_CUSTOM_URL ||
+        apiType === ApiKeyType.OPENAI_API_KEY
+      ) {
+        this.useWebSearch = false;
+      }
     };
 
-    const isActive = modelId == this.model;
+    const isActive = apiType === this.apiType;
     return html`
       <pr-button
         color="${isActive ? 'primary' : 'neutral'}"
         variant=${isActive ? 'tonal' : 'default'}
-        @click=${updateModel}
+        @click=${updateApiType}
       >
-        ${modelName}
+        ${apiName}
       </pr-button>
+    `;
+  }
+
+  private renderModelId() {
+    const updateModel = (e: InputEvent) => {
+      const content = (e.target as HTMLTextAreaElement).value;
+      this.model = content;
+    };
+
+    return html`
+      <div class="field">
+        <md-filled-text-field
+          ?disabled=${this.isLoading}
+          label="Model ID"
+          .value=${this.model}
+          @input=${updateModel}
+        >
+        </md-filled-text-field>
+      </div>
+    `;
+  }
+
+  private renderWebSearchOption() {
+    // Only show for Gemini and Anthropic (OpenAI and Ollama don't support web search in chat completions)
+    if (
+      this.apiType === ApiKeyType.OLLAMA_CUSTOM_URL ||
+      this.apiType === ApiKeyType.OPENAI_API_KEY
+    ) {
+      return nothing;
+    }
+
+    const toggleWebSearch = (event: Event) => {
+      const checked = (event.target as HTMLInputElement).checked;
+      this.useWebSearch = checked;
+    };
+
+    return html`
+      <div class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${this.useWebSearch}
+          ?disabled=${this.isLoading}
+          @change=${toggleWebSearch}
+        >
+        </md-checkbox>
+        <div>Enable web search</div>
+      </div>
     `;
   }
 
@@ -172,14 +270,99 @@ export class AgentParticipantDialog extends MobxLitElement {
     };
 
     return html`
-      <md-filled-text-field
-        ?disabled=${this.isLoading}
-        type="textarea"
-        label="Prompt context for this specific agent participant (optional)"
-        .value=${this.promptContext}
-        @input=${updatePromptContext}
-      >
-      </md-filled-text-field>
+      <div class="field">
+        <md-filled-text-field
+          ?disabled=${this.isLoading}
+          type="textarea"
+          label="Prompt context (optional)"
+          .value=${this.promptContext}
+          @input=${updatePromptContext}
+        >
+        </md-filled-text-field>
+        <div class="description">
+          Additional context to include in the agent's prompts.
+        </div>
+      </div>
+    `;
+  }
+
+  private renderChatSettings() {
+    return html`
+      <div class="field">
+        <label>Typing speed (words per minute)</label>
+        <div class="description">
+          Agent's typing speed. Leave empty for instant messages.
+        </div>
+        <div class="number-input">
+          <input
+            ?disabled=${this.isLoading}
+            type="number"
+            min="1"
+            .value=${this.wordsPerMinute ?? ''}
+            placeholder="Instant"
+            @input=${(e: InputEvent) => {
+              const value = (e.target as HTMLInputElement).value;
+              this.wordsPerMinute = value === '' ? null : Number(value);
+            }}
+          />
+        </div>
+      </div>
+      <div class="field">
+        <label>Minimum messages before responding</label>
+        <div class="description">
+          Number of chat messages that must exist before the agent can respond.
+        </div>
+        <div class="number-input">
+          <input
+            ?disabled=${this.isLoading}
+            type="number"
+            min="0"
+            .value=${this.minMessagesBeforeResponding}
+            @input=${(e: InputEvent) => {
+              const value = Number((e.target as HTMLInputElement).value);
+              if (!isNaN(value)) {
+                this.minMessagesBeforeResponding = value;
+              }
+            }}
+          />
+        </div>
+      </div>
+      <div class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${this.canSelfTriggerCalls}
+          ?disabled=${this.isLoading}
+          @change=${(e: Event) => {
+            this.canSelfTriggerCalls = (e.target as HTMLInputElement).checked;
+          }}
+        >
+        </md-checkbox>
+        <div>
+          Can respond multiple times in a row
+          <span class="small">
+            (Agent's own messages can trigger new responses)
+          </span>
+        </div>
+      </div>
+      <div class="field">
+        <label>Maximum responses</label>
+        <div class="description">
+          Maximum total responses during the chat. Leave empty for no limit.
+        </div>
+        <div class="number-input">
+          <input
+            ?disabled=${this.isLoading}
+            type="number"
+            min="1"
+            .value=${this.maxResponses ?? ''}
+            placeholder="No limit"
+            @input=${(e: InputEvent) => {
+              const value = (e.target as HTMLInputElement).value;
+              this.maxResponses = value === '' ? null : Number(value);
+            }}
+          />
+        </div>
+      </div>
     `;
   }
 }

--- a/frontend/src/components/experiment_dashboard/cohort_settings_dialog.scss
+++ b/frontend/src/components/experiment_dashboard/cohort_settings_dialog.scss
@@ -4,6 +4,7 @@
 
 :host {
   @include common.overlay;
+  z-index: 20; // Above cohort-list header (z-index: 10)
 }
 
 .dialog {

--- a/frontend/src/components/experiment_dashboard/participant_stats.scss
+++ b/frontend/src/components/experiment_dashboard/participant_stats.scss
@@ -40,3 +40,80 @@ h4 {
 .stats-wrapper {
   padding: 0 common.$spacing-large;
 }
+
+// Agent log section
+.agent-log-wrapper {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+  padding: 0 common.$spacing-large;
+}
+
+.agent-config {
+  margin-bottom: common.$spacing-medium;
+}
+
+.agent-log-summary {
+  @include common.flex-row;
+  flex-wrap: wrap;
+  gap: common.$spacing-small;
+  margin-bottom: common.$spacing-medium;
+}
+
+.empty-message {
+  color: var(--md-sys-color-outline);
+  padding: common.$spacing-medium 0;
+}
+
+.log-entry {
+  @include common.flex-column;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-small;
+  gap: common.$spacing-small;
+  padding: common.$spacing-medium;
+  margin-bottom: common.$spacing-small;
+}
+
+.log-entry-header {
+  @include common.flex-row-align-center;
+  flex-wrap: wrap;
+  gap: common.$spacing-small;
+}
+
+.log-timestamp {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+}
+
+.log-duration {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+}
+
+.log-description {
+  @include typescale.body-small;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+details {
+  margin-top: common.$spacing-small;
+}
+
+details summary {
+  @include typescale.label-medium;
+  cursor: pointer;
+  color: var(--md-sys-color-primary);
+}
+
+details pre {
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-small;
+  overflow: auto;
+  padding: common.$spacing-medium;
+  margin-top: common.$spacing-small;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+details code {
+  font-size: 90%;
+}

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -144,6 +144,7 @@ export async function getAgentResponse(
       prompt,
       generationConfig,
       structuredOutputConfig,
+      modelSettings.useWebSearch,
     );
   } else if (modelSettings.apiType === ApiKeyType.OPENAI_API_KEY) {
     response = await getOpenAIAPIResponse(
@@ -152,6 +153,7 @@ export async function getAgentResponse(
       prompt,
       generationConfig,
       structuredOutputConfig,
+      modelSettings.useWebSearch,
     );
   } else if (modelSettings.apiType === ApiKeyType.CLAUDE_API_KEY) {
     response = await getClaudeAPIResponse(
@@ -160,6 +162,7 @@ export async function getAgentResponse(
       prompt,
       generationConfig,
       structuredOutputConfig,
+      modelSettings.useWebSearch,
     );
   } else if (modelSettings.apiType === ApiKeyType.OLLAMA_CUSTOM_URL) {
     response = await getOllamaResponse(
@@ -191,6 +194,7 @@ export async function getGeminiResponse(
   prompt: string | Array<{role: string; content: string; name?: string}>,
   generationConfig: ModelGenerationConfig,
   structuredOutputConfig?: StructuredOutputConfig,
+  useWebSearch?: boolean,
 ): Promise<ModelResponse> {
   return await getGeminiAPIResponse(
     apiKeyConfig.geminiApiKey,
@@ -198,6 +202,7 @@ export async function getGeminiResponse(
     prompt,
     generationConfig,
     structuredOutputConfig,
+    useWebSearch,
   );
 }
 
@@ -207,6 +212,7 @@ export async function getOpenAIAPIResponse(
   prompt: string | Array<{role: string; content: string; name?: string}>,
   generationConfig: ModelGenerationConfig,
   structuredOutputConfig?: StructuredOutputConfig,
+  useWebSearch?: boolean,
 ): Promise<ModelResponse> {
   return await getOpenAIAPIChatCompletionResponse(
     apiKeyConfig.openAIApiKey?.apiKey || '',
@@ -215,6 +221,7 @@ export async function getOpenAIAPIResponse(
     prompt,
     generationConfig,
     structuredOutputConfig,
+    useWebSearch,
   );
 }
 
@@ -224,6 +231,7 @@ export async function getClaudeAPIResponse(
   prompt: string | Array<{role: string; content: string; name?: string}>,
   generationConfig: ModelGenerationConfig,
   structuredOutputConfig?: StructuredOutputConfig,
+  useWebSearch?: boolean,
 ): Promise<ModelResponse> {
   return await getClaudeAPIChatCompletionResponse(
     apiKeyConfig.claudeApiKey?.apiKey || '',
@@ -232,6 +240,7 @@ export async function getClaudeAPIResponse(
     prompt,
     generationConfig,
     structuredOutputConfig,
+    useWebSearch,
   );
 }
 

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -166,6 +166,7 @@ export async function callGemini(
   generationConfig: GenerationConfig,
   modelName = GEMINI_DEFAULT_MODEL,
   safetySettings?: SafetySetting[],
+  useGoogleSearch?: boolean,
 ): Promise<ModelResponse> {
   const genAI = new GoogleGenAI({apiKey});
 
@@ -180,6 +181,11 @@ export async function callGemini(
 
   if (systemInstruction) {
     config.systemInstruction = systemInstruction;
+  }
+
+  // Add Google Search grounding tool if enabled
+  if (useGoogleSearch) {
+    config.tools = [{googleSearch: {}}];
   }
 
   const response = await genAI.models.generateContent({
@@ -265,6 +271,7 @@ export async function getGeminiAPIResponse(
   promptText: string | Array<{role: string; content: string; name?: string}>,
   generationConfig: ModelGenerationConfig,
   structuredOutputConfig?: StructuredOutputConfig,
+  useGoogleSearch?: boolean,
 ): Promise<ModelResponse> {
   // Extract disableSafetyFilters setting from generationConfig
   const disableSafetyFilters = generationConfig.disableSafetyFilters ?? false;
@@ -321,6 +328,7 @@ export async function getGeminiAPIResponse(
       geminiConfig,
       modelName,
       safetySettings,
+      useGoogleSearch,
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/functions/src/api/gemini.api.ts
+++ b/functions/src/api/gemini.api.ts
@@ -15,6 +15,7 @@ import {
   StructuredOutputSchema,
   ModelResponseStatus,
   ModelResponse,
+  addParsedModelResponse,
 } from '@deliberation-lab/utils';
 
 const GEMINI_DEFAULT_MODEL = 'gemini-2.5-flash';
@@ -253,7 +254,8 @@ export async function callGemini(
     imageDataList: imageDataList.length > 0 ? imageDataList : undefined,
   };
 
-  return modelResponse;
+  // Parse JSON from response text if present
+  return addParsedModelResponse(modelResponse) ?? modelResponse;
 }
 
 /** Constructs Gemini API query and returns response. */

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -339,39 +339,51 @@ export async function getAgentChatMessage(
   let shouldRespond = true;
   let readyToEndChat = false;
 
-  if (structured?.enabled && response.text) {
-    const jsonMatch = response.text.match(/```json\n(\{[\s\S]*\})\n```/);
-    if (jsonMatch && jsonMatch[1]) {
-      try {
-        const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+  if (structured?.enabled) {
+    // Try to get parsed response - either from parsedResponse (set by addParsedModelResponse)
+    // or by parsing markdown code blocks in the text
+    let parsed: Record<string, unknown> | null = null;
 
-        const shouldRespondValue = structured.shouldRespondField
-          ? parsed[structured.shouldRespondField]
-          : undefined;
-        shouldRespond = shouldRespondValue === false ? false : true;
-
-        const messageField = structured.messageField || 'response';
-        if (typeof parsed[messageField] === 'string') {
-          message = parsed[messageField] as string;
+    if (response.parsedResponse) {
+      // Use already-parsed response (from OpenAI structured output, etc.)
+      parsed = response.parsedResponse as Record<string, unknown>;
+    } else if (response.text) {
+      // Try to parse from markdown code block (legacy format)
+      const jsonMatch = response.text.match(/```json\n(\{[\s\S]*\})\n```/);
+      if (jsonMatch && jsonMatch[1]) {
+        try {
+          parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+        } catch (error) {
+          console.error('getAgentChatMessage JSON parse error in text:', error);
         }
-
-        const explanationField = structured.explanationField || 'explanation';
-        if (typeof parsed[explanationField] === 'string') {
-          explanation = parsed[explanationField] as string;
-        }
-
-        readyToEndChat = structured.readyToEndField
-          ? Boolean(parsed[structured.readyToEndField])
-          : false;
-      } catch (error) {
-        console.error('getAgentChatMessage JSON parse error in text:', error);
-        // message remains response.text
       }
-    } else {
-      // JSON block not found, message remains response.text
     }
-  } else if (
+
+    if (parsed) {
+      const shouldRespondValue = structured.shouldRespondField
+        ? parsed[structured.shouldRespondField]
+        : undefined;
+      shouldRespond = shouldRespondValue === false ? false : true;
+
+      const messageField = structured.messageField || 'response';
+      if (typeof parsed[messageField] === 'string') {
+        message = parsed[messageField] as string;
+      }
+
+      const explanationField = structured.explanationField || 'explanation';
+      if (typeof parsed[explanationField] === 'string') {
+        explanation = parsed[explanationField] as string;
+      }
+
+      readyToEndChat = structured.readyToEndField
+        ? Boolean(parsed[structured.readyToEndField])
+        : false;
+    }
+  }
+
+  if (
     !response.text &&
+    !response.parsedResponse &&
     (!response.imageDataList || response.imageDataList.length === 0)
   ) {
     return {message: null, success: false};

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -91,6 +91,14 @@ export const onPublicChatMessageCreated = onDocumentCreated(
     const agentParticipants = allParticipants.filter(
       (p) => p.agentConfig && p.currentStatus === ParticipantStatus.IN_PROGRESS,
     );
+    console.log(
+      `[ChatTrigger] onPublicChatMessageCreated: Found ${allParticipants.length} total participants, ${agentParticipants.length} agent participants with IN_PROGRESS status`,
+    );
+    agentParticipants.forEach((p) => {
+      console.log(
+        `[ChatTrigger] Agent participant: publicId=${p.publicId}, privateId=${p.privateId}, status=${p.currentStatus}, stageId=${p.currentStageId}`,
+      );
+    });
     await Promise.all(
       agentParticipants.map((participant) =>
         createAgentChatMessageFromPrompt(

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -386,8 +386,13 @@ export async function getAgentMediatorPrompt(
 export async function getAgentParticipantPrompt(
   experimentId: string,
   stageId: string,
-  agentId: string,
+  agentId: string | undefined,
 ): Promise<ParticipantPromptConfig | null> {
+  // If no agentId, return null to use default prompt
+  if (!agentId) {
+    return null;
+  }
+
   const prompt = await app
     .firestore()
     .collection('experiments')

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -4,10 +4,7 @@ import {
 } from './participant';
 import {generateId} from './shared';
 import {StageKind} from './stages/stage';
-import {
-  ChatMediatorStructuredOutputConfig,
-  createStructuredOutputConfig,
-} from './structured_output';
+import {ChatMediatorStructuredOutputConfig} from './structured_output';
 import {
   MediatorPromptConfig,
   ParticipantPromptConfig,
@@ -37,6 +34,8 @@ export interface ProfileAgentConfig {
   agentId: string; // ID of agent persona used
   promptContext: string; // Additional text to concatenate to agent prompts
   modelSettings: AgentModelSettings;
+  // Optional chat settings override for quick-add agents (when no persona prompt is defined)
+  chatSettings?: AgentChatSettings;
 }
 
 /** Generation config for a specific stage's model call. */
@@ -65,6 +64,8 @@ export interface ModelGenerationConfig {
 export interface AgentModelSettings {
   apiType: ApiKeyType;
   modelName: string;
+  // Enable web search grounding (Google Search for Gemini, web_search for OpenAI/Claude)
+  useWebSearch?: boolean;
 }
 
 // TODO: Move to structured_prompt.ts
@@ -191,6 +192,7 @@ export function createAgentModelSettings(
     apiType: config.apiType ?? DEFAULT_AGENT_API_TYPE,
     // TODO: pick model name that matches API?
     modelName: config.modelName ?? DEFAULT_AGENT_API_MODEL,
+    useWebSearch: config.useWebSearch ?? false,
   };
 }
 

--- a/utils/src/model_response.ts
+++ b/utils/src/model_response.ts
@@ -114,8 +114,13 @@ export function addParsedModelResponse(response: ModelResponse) {
     return;
   }
 
+  // If there's no text to parse, return the response as-is
+  if (!response.text) {
+    return response;
+  }
+
   try {
-    const cleanedText = response.text!.replace(/```json\s*|\s*```/g, '').trim();
+    const cleanedText = response.text.replace(/```json\s*|\s*```/g, '').trim();
     response.parsedResponse = JSON.parse(cleanedText);
     return response;
   } catch (error) {


### PR DESCRIPTION
Hiya! I found agent participants weren't completing stages as intended and had their responses incorrectly parsed in group chats so have vibe-coded a fix. Code was written by Claude - I did my best to guide it towards making the minimum changes necessary and not introduce any breaking changes.

As part of the PR I've included a way to view agent participant API logs in the UI and have expanded the agent participant config UI component. Here's a video showing the result:

![screen-recording-2025-12-08](https://github.com/user-attachments/assets/a9c6bf6c-e4d8-4317-a41a-78cf7b886fce)

## Summary

This PR enhances agent participant functionality with three main improvements:

1. **Agent Log Viewer** - New section in participant stats page to view agent model call history
2. **Bug Fixes** - Debugged and fixed several issues preventing agent participants from working correctly
3. **Expanded Configuration** - New dialog for quick-adding agents with model selection, web search, and chat settings

## Changes

### Agent Log Viewer
- Added "Agent log" section to participant stats page
- Displays model call history with prompts, responses, and timestamps
- Helps debug agent behavior and track API interactions

### Agent Participant Bug Fixes
- Fixed chat settings not being applied for quick-add agents (settings were not merged into prompt config)
- Fixed Claude API not capturing responses when web search is enabled (text was in last content block, not first)
- Fixed OpenAI structured output compatibility issues
- Fixed empty response handling for Gemini API
- Added debug logging for troubleshooting agent behavior

### Expanded Agent Configuration
- New `agent-participant-configuration-dialog` component
- Support for multiple LLM providers: Gemini, OpenAI, Claude, and Ollama
- Web search capability for Gemini (Google Search grounding) and Claude (web_search tool)
- Chat settings: typing speed, min messages before responding, self-triggering, max responses
- Fixed dialog z-index to appear above cohort-list header

### Backend Changes
- Added `useWebSearch` to `AgentModelSettings` interface
- Gemini API: Google Search grounding via `googleSearch` tool
- Claude API: `web_search_20250305` tool integration
- Fixed Claude API text extraction for multi-block responses

## Testing

I've created a few experiments with 'group chat', 'set your profile', and 'survey' stages, and have tested them against each combination of (Google/Anthropic/OpenAI, w/wo web search), with between one and four agent participants. The parsing errors have disappeared, the API log viewer seems to work, and the new agent participant settings worked as intended.

I haven't included automated tests as the contrib guidelines didn't ask for them, however if you have something in mind please say.

- [x] View agent logs in participant stats page
- [x] Add agent participant via cohort panel dialog
- [x] Test with Gemini model (with and without web search)
- [x] Test with Claude model (with and without web search)
- [x] Verify web search option is hidden for OpenAI and Ollama
- [x] Verify chat settings are applied correctly

## Known Limitations

- OpenAI web search not supported - the code's using the Chat Completions API rather than the Responses API, ideally it would use the Responses API 
- Ollama web search not supported