### PR TITLE
Refactor experiment CRUD logic into utils.

### DIFF
--- a/docs/assets/api/openapi.yaml
+++ b/docs/assets/api/openapi.yaml
@@ -82,7 +82,17 @@ paths:
       tags:
         - experiments
       summary: Create experiment
-      description: Create a new experiment with specified configuration
+      description: |
+        Create a new experiment with specified configuration.
+
+        Supports two modes:
+
+        **1. Simple creation:** Provide `name` (required), `description`, `stages`, `prolificConfig`.
+        This is the easiest way to create a basic experiment.
+
+        **2. Full template creation:** Provide a complete `template` object (ExperimentTemplate).
+        This creates the experiment with all stages and agents, using the same logic as the UI.
+        Other fields are ignored when template is provided.
       operationId: createExperiment
       requestBody:
         required: true
@@ -90,27 +100,45 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - name
               properties:
                 name:
                   type: string
-                  description: Experiment name
+                  description: (Simple creation) Experiment name - required unless template provided
                   example: My Experiment
                 description:
                   type: string
-                  description: Experiment description
+                  description: (Simple creation) Experiment description
                   example: Research on decision making
                 prolificRedirectCode:
                   type: string
-                  description: Prolific completion redirect code (optional)
+                  description: (Simple creation) Prolific completion redirect code
                   example: C1234ABC
                 stages:
                   type: array
-                  description: Array of stage configurations (optional)
+                  description: (Simple creation) Array of stage configurations
                   items:
                     $ref: '#/components/schemas/Stage'
                   default: []
+                agentMediators:
+                  type: array
+                  description: |
+                    (Simple creation) Array of agent mediator templates.
+                    Each agent includes persona config and a promptMap with stage-specific prompts.
+                  items:
+                    type: object
+                agentParticipants:
+                  type: array
+                  description: |
+                    (Simple creation) Array of agent participant templates.
+                    Each agent includes persona config and a promptMap with stage-specific prompts.
+                  items:
+                    type: object
+                template:
+                  type: object
+                  description: |
+                    (Full template creation) Complete ExperimentTemplate object.
+                    When provided, creates experiment with all stages and agents.
+                    All other fields are ignored.
       responses:
         '201':
           description: Experiment created successfully
@@ -165,9 +193,17 @@ paths:
       description: |
         Update an existing experiment's configuration.
 
-        **Partial updates:** Only provided fields are updated. Omit fields you don't want to change.
+        Supports two modes:
 
-        **Stages replacement:** If `stages` is provided, it completely replaces all existing stages. To modify a single stage, first GET the experiment, modify the stages array, then PUT the full array back.
+        **1. Partial updates:** Provide individual fields (name, description, stages, prolificConfig).
+        Only provided fields are updated. Omit fields you don't want to change.
+
+        **2. Full template update:** Provide a complete `template` object (ExperimentTemplate).
+        This replaces the entire experiment including all stages and agents.
+        Other fields are ignored when template is provided.
+
+        **Stages replacement (partial mode):** If `stages` is provided, it completely replaces all existing stages.
+        To modify a single stage, first GET the experiment, modify the stages array, then PUT the full array back.
       operationId: updateExperiment
       parameters:
         - $ref: '#/components/parameters/ExperimentId'
@@ -180,20 +216,43 @@ paths:
               properties:
                 name:
                   type: string
-                  description: Updated experiment name
+                  description: (Partial update) Updated experiment name
                 description:
                   type: string
-                  description: Updated description
+                  description: (Partial update) Updated description
                 prolificRedirectCode:
                   type: string
-                  description: Updated Prolific completion redirect code
+                  description: (Partial update) Updated Prolific completion redirect code
                 stages:
                   type: array
                   description: |
-                    Complete array of stage configurations. If provided, **replaces all existing stages**.
+                    (Partial update) Complete array of stage configurations. If provided, **replaces all existing stages**.
                     Omit this field to leave stages unchanged.
                   items:
                     $ref: '#/components/schemas/Stage'
+                agentMediators:
+                  type: array
+                  description: |
+                    (Partial update) Complete array of agent mediator templates. If provided, **replaces all existing agent mediators**.
+                    Each agent includes persona config and a promptMap with stage-specific prompts.
+                    Omit this field to leave agent mediators unchanged.
+                  items:
+                    type: object
+                agentParticipants:
+                  type: array
+                  description: |
+                    (Partial update) Complete array of agent participant templates. If provided, **replaces all existing agent participants**.
+                    Each agent includes persona config and a promptMap with stage-specific prompts.
+                    Omit this field to leave agent participants unchanged.
+                  items:
+                    type: object
+                template:
+                  type: object
+                  description: |
+                    (Full template update) Complete ExperimentTemplate object.
+                    When provided, replaces the entire experiment including all stages and agents.
+                    All other fields (name, description, stages, agentMediators, agentParticipants) are ignored.
+                    Use this mode when you need atomic replacement of the entire experiment.
             examples:
               updateNameOnly:
                 summary: Update name only
@@ -325,6 +384,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExperimentExport'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitError'
+
+  /experiments/{id}/fork:
+    post:
+      tags:
+        - experiments
+      summary: Fork experiment
+      description: |
+        Create a copy of an experiment with all its stages and agents.
+
+        **Access Control:** You can only fork an experiment if:
+        - The experiment's visibility is set to `PUBLIC`, OR
+        - You are the owner/creator of the experiment
+
+        The forked experiment will have:
+        - A new unique ID
+        - Name set to "Copy of [original name]" (or custom name if provided)
+        - The current user as creator
+        - All stages copied
+        - All agent mediators and agent participants copied
+
+        The forked experiment will NOT include:
+        - Cohorts
+        - Participants
+        - Any collected data
+      operationId: forkExperiment
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Optional custom name for the forked experiment
+                  example: My Forked Experiment
+      responses:
+        '201':
+          description: Experiment forked successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/Experiment'
+                  sourceExperimentId:
+                    type: string
+                    description: ID of the original experiment that was forked
+                    example: exp123
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -100,6 +100,21 @@ export const getExperimentTemplateCallable = async (
   return data;
 };
 
+/** Fork an experiment (create a copy with all stages and agents). */
+export const forkExperimentCallable = async (
+  functions: Functions,
+  config: {collectionName: string; experimentId: string; newName?: string},
+) => {
+  const {data} = await httpsCallable<
+    {collectionName: string; experimentId: string; newName?: string},
+    CreationResponse
+  >(
+    functions,
+    'forkExperiment',
+  )(config);
+  return data;
+};
+
 /** Generic endpoint to download experiment data. */
 export const downloadExperimentCallable = async (
   functions: Functions,

--- a/functions/src/dl_api/dl_api.endpoints.ts
+++ b/functions/src/dl_api/dl_api.endpoints.ts
@@ -21,6 +21,7 @@ import {
   updateExperiment,
   deleteExperiment,
   exportExperimentData,
+  forkExperiment,
 } from './experiments.dl_api';
 import {
   listCohorts,
@@ -71,6 +72,7 @@ app.get('/v1/experiments/:id', getExperiment);
 app.put('/v1/experiments/:id', updateExperiment);
 app.delete('/v1/experiments/:id', deleteExperiment);
 app.get('/v1/experiments/:id/export', exportExperimentData);
+app.post('/v1/experiments/:id/fork', forkExperiment);
 
 // API Routes - Cohorts (nested under experiments)
 app.get('/v1/experiments/:experimentId/cohorts', listCohorts);

--- a/functions/src/experiment.endpoints.ts
+++ b/functions/src/experiment.endpoints.ts
@@ -9,14 +9,16 @@ import {
   ExperimentDownloadResponse,
   MediatorPromptConfig,
   ParticipantPromptConfig,
-  SeedStrategy,
   StageConfig,
-  createExperimentConfig,
   createExperimentTemplate,
-  VariableScope,
 } from '@deliberation-lab/utils';
-import {generateVariablesForScope} from './variables.utils';
 import {getExperimentDownload} from './data';
+import {
+  deleteExperimentById,
+  forkExperimentById,
+  updateExperimentFromTemplate,
+  writeExperimentFromTemplate,
+} from './experiment.utils';
 
 import {onCall, HttpsError} from 'firebase-functions/v2/https';
 
@@ -37,70 +39,18 @@ export const writeExperiment = onCall(async (request) => {
   const {data} = request;
   const template = data.experimentTemplate;
 
-  // Set up experiment config with stageIds
-  const experimentConfig = createExperimentConfig(
-    template.stageConfigs,
-    template.experiment,
+  // Get creator from authenticated user
+  const creatorId = request.auth?.token.email?.toLowerCase() || '';
+
+  // Use shared utility to write experiment
+  const experimentId = await writeExperimentFromTemplate(
+    app.firestore(),
+    template,
+    creatorId,
+    {collectionName: data.collectionName},
   );
 
-  // Define document reference
-  const document = app
-    .firestore()
-    .collection(data.collectionName)
-    .doc(experimentConfig.id);
-
-  // If experiment exists, do not allow creation.
-  if ((await document.get()).exists) {
-    return {id: ''};
-  }
-
-  // Use current experimenter as creator
-  if (request.auth) {
-    experimentConfig.metadata.creator = request.auth.token.email || '';
-    experimentConfig.metadata.creator =
-      experimentConfig.metadata.creator.toLowerCase();
-  }
-
-  // Run document write as transaction to ensure consistency
-  await app.firestore().runTransaction(async (transaction) => {
-    transaction.set(document, experimentConfig);
-
-    // Add collection of stages
-    for (const stage of template.stageConfigs) {
-      transaction.set(document.collection('stages').doc(stage.id), stage);
-    }
-
-    // Add variable values at the experiment level
-    experimentConfig.variableMap = await generateVariablesForScope(
-      experimentConfig.variableConfigs ?? [],
-      {scope: VariableScope.EXPERIMENT, experimentId: experimentConfig.id},
-    );
-
-    // Add agent mediators under `agentMediators` collection
-    template.agentMediators.forEach((agent) => {
-      const doc = document.collection('agentMediators').doc(agent.persona.id);
-      transaction.set(doc, agent.persona);
-      for (const prompt of Object.values(agent.promptMap)) {
-        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
-      }
-    });
-
-    // Add agent participants under `agentParticipants` collection
-    // NOTE: We don't currently allow agent participant persona setup
-    // in the experiment editor, so the list of agentParticipants
-    // is expected to be length 0.
-    template.agentParticipants.forEach((agent) => {
-      const doc = document
-        .collection('agentParticipants')
-        .doc(agent.persona.id);
-      transaction.set(doc, agent.persona);
-      for (const prompt of Object.values(agent.promptMap)) {
-        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
-      }
-    });
-  });
-
-  return {id: document.id};
+  return {id: experimentId};
 });
 
 // ************************************************************************* //
@@ -113,71 +63,19 @@ export const writeExperiment = onCall(async (request) => {
 export const updateExperiment = onCall(async (request) => {
   await AuthGuard.isExperimenter(request);
   const {data} = request;
-  const template = data.experimentTemplate;
 
-  // Set up experiment config with stageIds
-  const experimentConfig = createExperimentConfig(
-    template.stageConfigs,
-    template.experiment,
+  const experimenterId = request.auth?.token.email?.toLowerCase() || '';
+
+  // Use shared utility to update experiment
+  // TODO: Enable admins to update experiment?
+  const result = await updateExperimentFromTemplate(
+    app.firestore(),
+    data.experimentTemplate,
+    experimenterId,
+    {collectionName: data.collectionName},
   );
 
-  // Define document reference
-  const document = app
-    .firestore()
-    .collection(data.collectionName)
-    .doc(experimentConfig.id);
-
-  // If experiment does not exist, return false
-  const oldExperiment = await document.get();
-  if (!oldExperiment.exists) {
-    return {success: false};
-  }
-  // Verify that the experimenter is the creator
-  // TODO: Enable admins to update experiment?
-  if (
-    request.auth?.token.email?.toLowerCase() !==
-    oldExperiment.data()?.metadata.creator
-  ) {
-    return {success: false};
-  }
-
-  // Run document write as transaction to ensure consistency
-  await app.firestore().runTransaction(async (transaction) => {
-    transaction.set(document, experimentConfig);
-
-    // Clean up obsolete docs in stages, agents collections.
-    const oldStageCollection = document.collection('stages');
-    const oldAgentCollection = document.collection('agents');
-    await app.firestore().recursiveDelete(oldStageCollection);
-    await app.firestore().recursiveDelete(oldAgentCollection);
-
-    // Add updated collection of stages
-    for (const stage of template.stageConfigs) {
-      transaction.set(document.collection('stages').doc(stage.id), stage);
-    }
-
-    // Add agent mediators under `agentMediators` collection
-    template.agentMediators.forEach((agent) => {
-      const doc = document.collection('agentMediators').doc(agent.persona.id);
-      transaction.set(doc, agent.persona);
-      for (const prompt of Object.values(agent.promptMap)) {
-        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
-      }
-    });
-
-    // Add agent participants under `agentParticipants` collection
-    template.agentParticipants.forEach((agent) => {
-      const doc = document
-        .collection('agentParticipants')
-        .doc(agent.persona.id);
-      transaction.set(doc, agent.persona);
-      for (const prompt of Object.values(agent.promptMap)) {
-        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
-      }
-    });
-  });
-
-  return {success: true};
+  return {success: result.success};
 });
 
 // ************************************************************************* //
@@ -197,30 +95,68 @@ export const deleteExperiment = onCall(async (request) => {
     throw new HttpsError('invalid-argument', 'Invalid data');
   }
 
-  // Verify that experimenter is the creator before enabling delete
+  const experimenterId = request.auth?.token.email?.toLowerCase() || '';
+
+  // Use shared utility to delete experiment
   // TODO: Enable admins to delete?
-  const experiment = (
-    await app
-      .firestore()
-      .collection(data.collectionName)
-      .doc(data.experimentId)
-      .get()
-  ).data();
-  if (!experiment) {
+  const result = await deleteExperimentById(
+    app.firestore(),
+    data.experimentId,
+    experimenterId,
+    {collectionName: data.collectionName},
+  );
+
+  if (!result.success && result.error === 'not-found') {
     throw new HttpsError(
       'not-found',
       `Experiment ${data.experimentId} not found in collection ${data.collectionName}`,
     );
   }
-  if (request.auth?.token.email?.toLowerCase() !== experiment.metadata.creator)
-    return {success: false};
 
-  // Delete document
-  const doc = app
-    .firestore()
-    .doc(`${data.collectionName}/${data.experimentId}`);
-  app.firestore().recursiveDelete(doc);
-  return {success: true};
+  return {success: result.success};
+});
+
+// ************************************************************************* //
+// forkExperiment endpoint                                                   //
+// (create a copy of an experiment with all stages and agents)               //
+//                                                                           //
+// Input structure: { collectionName, experimentId, newName? }               //
+// Access: Only public experiments or experiments owned by the requester     //
+// ************************************************************************* //
+export const forkExperiment = onCall(async (request) => {
+  await AuthGuard.isExperimenter(request);
+  const {data} = request;
+
+  const {collectionName, experimentId, newName} = data;
+
+  if (!collectionName || !experimentId) {
+    throw new HttpsError(
+      'invalid-argument',
+      'collectionName and experimentId are required',
+    );
+  }
+
+  const experimenterId = request.auth?.token.email?.toLowerCase() || '';
+
+  const result = await forkExperimentById(
+    app.firestore(),
+    experimentId,
+    experimenterId,
+    {collectionName, newName},
+  );
+
+  if (!result.success) {
+    if (result.error === 'not-found') {
+      throw new HttpsError('not-found', `Experiment ${experimentId} not found`);
+    } else if (result.error === 'access-denied') {
+      throw new HttpsError(
+        'permission-denied',
+        'Cannot fork this experiment. Only public experiments or your own experiments can be forked.',
+      );
+    }
+  }
+
+  return {id: result.id};
 });
 
 // ************************************************************************* //
@@ -239,7 +175,7 @@ export const getExperimentTemplate = onCall(async (request) => {
       .collection(data.collectionName)
       .doc(data.experimentId)
       .get()
-  ).data();
+  ).data() as Experiment | undefined;
 
   if (!experiment) {
     throw new HttpsError(

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -1,0 +1,397 @@
+/**
+ * Shared utilities for experiment creation and management
+ */
+
+import {Firestore, Timestamp, Transaction} from 'firebase-admin/firestore';
+import {
+  ExperimentTemplate,
+  StageConfig,
+  UnifiedTimestamp,
+  Visibility,
+  createExperimentConfig,
+  createExperimentTemplate,
+  generateId,
+  VariableScope,
+} from '@deliberation-lab/utils';
+import {getExperimentDownload} from './data';
+import {generateVariablesForScope} from './variables.utils';
+
+/**
+ * Options for writing an experiment from a template
+ */
+export interface WriteExperimentOptions {
+  /** Firestore collection to write to. Defaults to 'experiments' */
+  collectionName?: string;
+}
+
+/**
+ * Write an experiment from a template to Firestore.
+ *
+ * This is the shared logic used by both:
+ * - writeExperiment callable (UI experiment creation)
+ * - forkExperiment REST API endpoint
+ *
+ * @param firestore - Firestore instance
+ * @param template - The experiment template containing experiment config, stages, and agents
+ * @param creatorId - The experimenter ID to set as creator
+ * @param options - Additional options
+ * @returns The created experiment ID, or empty string if experiment already exists
+ */
+export async function writeExperimentFromTemplate(
+  firestore: Firestore,
+  template: ExperimentTemplate,
+  creatorId: string,
+  options: WriteExperimentOptions = {},
+): Promise<string> {
+  const {collectionName = 'experiments'} = options;
+
+  // Set up experiment config with stageIds
+  const experimentConfig = createExperimentConfig(
+    template.stageConfigs,
+    template.experiment,
+  );
+
+  // Define document reference
+  const document = firestore
+    .collection(collectionName)
+    .doc(experimentConfig.id);
+
+  // If experiment exists, do not allow creation
+  if ((await document.get()).exists) {
+    return '';
+  }
+
+  // Set creator
+  experimentConfig.metadata.creator = creatorId;
+
+  // Generate variable values at the experiment level before the transaction
+  // so the experimentConfig has the variableMap when it's written
+  // TODO: Consider deferring experiment-level variable generation to first cohort
+  // creation. This would allow users to fork an experiment, edit variable configs,
+  // and then generate variables when the first cohort is created.
+  experimentConfig.variableMap = await generateVariablesForScope(
+    experimentConfig.variableConfigs ?? [],
+    {scope: VariableScope.EXPERIMENT, experimentId: experimentConfig.id},
+  );
+
+  // Run document write as transaction to ensure consistency
+  await firestore.runTransaction(async (transaction: Transaction) => {
+    // Set the experiment document
+    transaction.set(document, experimentConfig);
+
+    // Add collection of stages
+    for (const stage of template.stageConfigs) {
+      transaction.set(document.collection('stages').doc(stage.id), stage);
+    }
+
+    // Add agent mediators under `agentMediators` collection
+    for (const agent of template.agentMediators) {
+      const doc = document.collection('agentMediators').doc(agent.persona.id);
+      transaction.set(doc, agent.persona);
+      for (const prompt of Object.values(agent.promptMap)) {
+        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
+      }
+    }
+
+    // Add agent participants under `agentParticipants` collection
+    for (const agent of template.agentParticipants) {
+      const doc = document
+        .collection('agentParticipants')
+        .doc(agent.persona.id);
+      transaction.set(doc, agent.persona);
+      for (const prompt of Object.values(agent.promptMap)) {
+        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
+      }
+    }
+  });
+
+  return document.id;
+}
+
+/**
+ * Options for forking an experiment
+ */
+export interface ForkExperimentOptions {
+  /** New name for the forked experiment. Defaults to "Copy of {sourceName}" */
+  newName?: string;
+  /** Firestore collection to write to. Defaults to 'experiments' */
+  collectionName?: string;
+}
+
+/**
+ * Result of forking an experiment
+ */
+export interface ForkExperimentResult {
+  success: boolean;
+  id?: string;
+  error?: 'not-found' | 'access-denied';
+}
+
+/**
+ * Fork an experiment by ID.
+ *
+ * This is the shared logic used by both:
+ * - forkExperiment callable (UI experiment forking)
+ * - forkExperiment REST API endpoint
+ *
+ * Access control: Only allows forking if:
+ * - The experiment has visibility === PUBLIC, OR
+ * - The requester is the creator/owner of the experiment
+ *
+ * @param firestore - Firestore instance
+ * @param sourceExperimentId - The ID of the experiment to fork
+ * @param experimenterId - The experimenter ID requesting the fork (also set as creator of fork)
+ * @param options - Additional options
+ * @returns Result with created experiment ID, or error if not found/access denied
+ */
+export async function forkExperimentById(
+  firestore: Firestore,
+  sourceExperimentId: string,
+  experimenterId: string,
+  options: ForkExperimentOptions = {},
+): Promise<ForkExperimentResult> {
+  const {collectionName = 'experiments', newName} = options;
+
+  // Get full experiment data (stages, agents with prompts)
+  const sourceData = await getExperimentDownload(
+    firestore,
+    sourceExperimentId,
+    {
+      includeParticipantData: false,
+    },
+  );
+
+  if (!sourceData) {
+    return {success: false, error: 'not-found'};
+  }
+
+  // Access check: only allow forking if public OR if requester is the owner
+  const isPublic =
+    sourceData.experiment.permissions?.visibility === Visibility.PUBLIC;
+  const isOwner = sourceData.experiment.metadata?.creator === experimenterId;
+
+  if (!isPublic && !isOwner) {
+    return {success: false, error: 'access-denied'};
+  }
+
+  const timestamp = Timestamp.now() as UnifiedTimestamp;
+
+  // Create new experiment with new ID
+  const newId = generateId();
+  const sourceName = sourceData.experiment.metadata?.name || 'Experiment';
+  const forkName = newName || `Copy of ${sourceName}`;
+
+  // Get stages in order
+  const stageConfigs: StageConfig[] = [];
+  for (const stageId of sourceData.experiment.stageIds || []) {
+    const stage = sourceData.stageMap[stageId];
+    if (stage) {
+      stageConfigs.push(stage);
+    }
+  }
+
+  // Convert agent maps to arrays
+  const agentMediators = Object.values(sourceData.agentMediatorMap || {});
+  const agentParticipants = Object.values(sourceData.agentParticipantMap || {});
+
+  // Build experiment template for the fork
+  const template = createExperimentTemplate({
+    id: newId,
+    experiment: {
+      ...sourceData.experiment,
+      id: newId,
+      metadata: {
+        ...sourceData.experiment.metadata,
+        name: forkName,
+        creator: experimenterId,
+        starred: {},
+        dateCreated: timestamp,
+        dateModified: timestamp,
+      },
+    },
+    stageConfigs,
+    agentMediators,
+    agentParticipants,
+  });
+
+  // Use shared utility to write experiment
+  const createdId = await writeExperimentFromTemplate(
+    firestore,
+    template,
+    experimenterId,
+    {collectionName},
+  );
+
+  if (!createdId) {
+    // This shouldn't happen since we generate a new ID, but handle it gracefully
+    return {success: false, error: 'not-found'};
+  }
+
+  return {success: true, id: createdId};
+}
+
+/**
+ * Options for updating an experiment
+ */
+export interface UpdateExperimentOptions {
+  /** Firestore collection to update in. Defaults to 'experiments' */
+  collectionName?: string;
+}
+
+/**
+ * Result of updating an experiment
+ */
+export interface UpdateExperimentResult {
+  success: boolean;
+  error?: 'not-found' | 'not-owner';
+}
+
+/**
+ * Update an experiment from a template.
+ *
+ * This is the shared logic used by both:
+ * - updateExperiment callable (UI experiment updates)
+ * - updateExperiment REST API endpoint
+ *
+ * @param firestore - Firestore instance
+ * @param template - The experiment template containing experiment config, stages, and agents
+ * @param experimenterId - The experimenter ID requesting the update (for ownership check)
+ * @param options - Additional options
+ * @returns Result indicating success or failure reason
+ */
+export async function updateExperimentFromTemplate(
+  firestore: Firestore,
+  template: ExperimentTemplate,
+  experimenterId: string,
+  options: UpdateExperimentOptions = {},
+): Promise<UpdateExperimentResult> {
+  const {collectionName = 'experiments'} = options;
+
+  // Set up experiment config with stageIds
+  const experimentConfig = createExperimentConfig(
+    template.stageConfigs,
+    template.experiment,
+  );
+
+  // Define document reference
+  const document = firestore
+    .collection(collectionName)
+    .doc(experimentConfig.id);
+
+  // Check if experiment exists
+  const oldExperiment = await document.get();
+  if (!oldExperiment.exists) {
+    return {success: false, error: 'not-found'};
+  }
+
+  // Verify that the experimenter is the creator
+  if (experimenterId !== oldExperiment.data()?.metadata.creator) {
+    return {success: false, error: 'not-owner'};
+  }
+
+  // Regenerate variable values based on current variable configs
+  experimentConfig.variableMap = await generateVariablesForScope(
+    experimentConfig.variableConfigs ?? [],
+    {scope: VariableScope.EXPERIMENT, experimentId: experimentConfig.id},
+  );
+
+  // NOTE: The recursiveDelete calls below are NOT part of the transaction.
+  // They execute immediately and independently. If the transaction fails after
+  // deletions occur, data may be lost. This is a known limitation of Firestore -
+  // recursiveDelete cannot participate in transactions. In practice, transaction
+  // failures after deletion are rare since the experiment doc is the conflict point.
+  await firestore.runTransaction(async (transaction: Transaction) => {
+    transaction.set(document, experimentConfig);
+
+    // Clean up old stages, agents collections
+    await firestore.recursiveDelete(document.collection('stages'));
+    await firestore.recursiveDelete(document.collection('agents')); // legacy
+    await firestore.recursiveDelete(document.collection('agentMediators'));
+    await firestore.recursiveDelete(document.collection('agentParticipants'));
+
+    // Add updated collection of stages
+    for (const stage of template.stageConfigs) {
+      transaction.set(document.collection('stages').doc(stage.id), stage);
+    }
+
+    // Add agent mediators under `agentMediators` collection
+    for (const agent of template.agentMediators) {
+      const doc = document.collection('agentMediators').doc(agent.persona.id);
+      transaction.set(doc, agent.persona);
+      for (const prompt of Object.values(agent.promptMap)) {
+        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
+      }
+    }
+
+    // Add agent participants under `agentParticipants` collection
+    for (const agent of template.agentParticipants) {
+      const doc = document
+        .collection('agentParticipants')
+        .doc(agent.persona.id);
+      transaction.set(doc, agent.persona);
+      for (const prompt of Object.values(agent.promptMap)) {
+        transaction.set(doc.collection('prompts').doc(prompt.id), prompt);
+      }
+    }
+  });
+
+  return {success: true};
+}
+
+/**
+ * Options for deleting an experiment
+ */
+export interface DeleteExperimentOptions {
+  /** Firestore collection to delete from. Defaults to 'experiments' */
+  collectionName?: string;
+}
+
+/**
+ * Result of deleting an experiment
+ */
+export interface DeleteExperimentResult {
+  success: boolean;
+  error?: 'not-found' | 'not-owner';
+}
+
+/**
+ * Delete an experiment by ID.
+ *
+ * This is the shared logic used by both:
+ * - deleteExperiment callable (UI experiment deletion)
+ * - deleteExperiment REST API endpoint
+ *
+ * @param firestore - Firestore instance
+ * @param experimentId - The ID of the experiment to delete
+ * @param experimenterId - The experimenter ID requesting the deletion (for ownership check)
+ * @param options - Additional options
+ * @returns Result indicating success or failure reason
+ */
+export async function deleteExperimentById(
+  firestore: Firestore,
+  experimentId: string,
+  experimenterId: string,
+  options: DeleteExperimentOptions = {},
+): Promise<DeleteExperimentResult> {
+  const {collectionName = 'experiments'} = options;
+
+  // Get experiment document
+  const document = firestore.collection(collectionName).doc(experimentId);
+  const experimentDoc = await document.get();
+
+  // Check if experiment exists
+  if (!experimentDoc.exists) {
+    return {success: false, error: 'not-found'};
+  }
+
+  // Verify ownership
+  const experiment = experimentDoc.data();
+  if (experimenterId !== experiment?.metadata?.creator) {
+    return {success: false, error: 'not-owner'};
+  }
+
+  // Delete experiment and all subcollections
+  await firestore.recursiveDelete(document);
+
+  return {success: true};
+}


### PR DESCRIPTION
This PR consolidates experiment CRUD operations between Firebase callables and REST API endpoints into shared utilities, reducing code duplication.

## Changes

### New Shared Utilities (`functions/src/experiment.utils.ts`)

Created four shared utility functions that handle all experiment management logic:

| Utility | Purpose | Used By |
|---------|---------|---------|
| `writeExperimentFromTemplate` | Create new experiment with stages and agents | `writeExperiment` callable, REST `createExperiment` |
| `updateExperimentFromTemplate` | Update experiment, stages, and agents | `updateExperiment` callable, REST `updateExperiment` |
| `forkExperimentById` | Copy experiment with all stages and agents | `forkExperiment` callable, REST `forkExperiment` |
| `deleteExperimentById` | Delete experiment and all subcollections | `deleteExperiment` callable, REST `deleteExperiment` |

### New `forkExperiment` Callable

Added a new Firebase callable for forking experiments, replacing the previous frontend approach of fetching a template and re-creating it. The frontend now uses `forkExperimentCallable` instead of manually copying.

### REST API Enhancements

- **`createExperiment`**: Now supports two modes:
  - Simple creation: Provide `name`, `description`, `stages`, `prolificConfig`, `agentMediators`, `agentParticipants`
  - Template creation: Provide a complete `ExperimentTemplate`

- **`updateExperiment`**: Now supports two modes:
  - Partial update: Provide individual fields to update (fetches existing, merges, replaces)
  - Template update: Provide complete `ExperimentTemplate` for full replacement

- **`forkExperiment`**: New endpoint at `POST /experiments/:id/fork`

### Bug Fixes

1. **Agent cleanup on update**: The old `updateExperiment` deleted the `stages` and `agents` collections but never deleted `agentMediators` or `agentParticipants` before adding new ones. This left orphaned agent documents when agents were modified. Now properly cleans up all agent collections.

2. **Await on delete**: The old `deleteExperiment` callable didn't `await` the `recursiveDelete` call, returning success before deletion completed.

3. **Variable regeneration on update**: Added variable regeneration when updating experiments, so changes to `variableConfigs` are reflected in `variableMap`.

4. **Variable generation timing**: Moved variable generation before the transaction (not inside) to ensure the `variableMap` is included when the experiment document is written.

5. **REST API variable generation**: The REST API simple creation mode now generates variables (previously missing).

### Template access control clarification

6. **Fork access control**: Added proper access control to `forkExperiment`. Previously, any authenticated experimenter could fork any experiment by ID. Now, forking is only allowed if:
   - The experiment's `permissions.visibility` is `PUBLIC`, OR
   - The requester is the owner/creator of the experiment

   This check is enforced in the shared `forkExperimentById` utility, so both the Firebase callable and REST API endpoint have consistent access control.

### Python Client Updates

Updated `create_experiment` and `update_experiment` methods to support:
- `agent_mediators` and `agent_participants` parameters
- `template` parameter for full template mode

Added new `fork_experiment` method for forking experiments via the REST API.
