### PR TITLE
Check for empty agent participant ID before attempting to fetch prompt

### DIFF
--- a/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.ts
+++ b/frontend/src/components/experiment_dashboard/agent_participant_configuration_dialog.ts
@@ -17,6 +17,7 @@ import {
   ApiKeyType,
   AgentPersonaType,
   createAgentModelSettings,
+  DEFAULT_AGENT_PARTICIPANT_ID,
 } from '@deliberation-lab/utils';
 
 import {styles} from './cohort_settings_dialog.scss';
@@ -86,7 +87,7 @@ export class AgentParticipantDialog extends MobxLitElement {
             );
             if (this.cohort && this.model) {
               this.experimentEditor.addAgentParticipant();
-              this.agentId = ''; //Make agent ID blank for agents added from cohort panel that use default prompts
+              this.agentId = DEFAULT_AGENT_PARTICIPANT_ID;
               const modelSettings = createAgentModelSettings({
                 apiType: ApiKeyType.GEMINI_API_KEY,
                 modelName: this.model,

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -388,6 +388,10 @@ export async function getAgentParticipantPrompt(
   stageId: string,
   agentId: string,
 ): Promise<ParticipantPromptConfig | null> {
+  if (!agentId) {
+    return null;
+  }
+
   const prompt = await app
     .firestore()
     .collection('experiments')

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -179,6 +179,9 @@ export const DEFAULT_AGENT_MODEL_SETTINGS: AgentModelSettings = {
   modelName: DEFAULT_AGENT_API_MODEL,
 };
 
+// Use this ID when defining agent participants in experiment dashboard
+export const DEFAULT_AGENT_PARTICIPANT_ID = '';
+
 // ************************************************************************* //
 // FUNCTIONS                                                                 //
 // ************************************************************************* //


### PR DESCRIPTION
This was causing an issue (and breaking agent participants) when experimenters explicitly specified an empty ID in order to use the fallback prompt(s).

Also, add a constant for `DEFAULT_AGENT_PARTICIPANT_ID` in case we decide to default to a specific agent configuration (rather than empty ID --> fallback) when creating agent participants from dashboard.