### PR TITLE
Fix CI permissions for schema updates.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,9 @@ jobs:
     # Only run on push to main/master, not on PRs
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
I forgot to re-generate Python types in #914.  CI fails here:
https://github.com/PAIR-code/deliberate-lab/actions/runs/20246909547/job/58129216321
```
Run git config user.name "github-actions[bot]"
→ lint-staged could not find any staged files matching configured tasks.
[main ca0c488] chore: update generated schemas and Python types
 1 file changed, 1 insertion(+)
remote: Permission to PAIR-code/deliberate-lab.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/PAIR-code/deliberate-lab/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```