### PR TITLE
Implement Templates Gallery Modal & Refine Template Selection UX

### DIFF
--- a/docs/researchers/templates.md
+++ b/docs/researchers/templates.md
@@ -11,11 +11,13 @@ Experiment templates allow you to quickly create new experiments based on pre-de
 
 When building an experiment, you can load a template to populate the stages and settings.
 
-1.  In the experiment builder, click the **Load template** button in the left sidebar.
-2.  Browse the gallery of available templates.
-    *   **Built-in Templates**: Pre-defined templates included with Deliberate Lab.
-    *   **Saved Templates**: Templates you or your team have created and saved.
-3.  Click on a template to apply it to your current experiment. **Warning: This will overwrite your current stages and settings.**
+1.  In the experiment builder, click the **Load template** button in the top header.
+2.  Browse the gallery of available templates:
+    *   **Recommended**: Includes "Quick Start" templates (e.g., Blank, Group Chat, Private Chat) and other default templates.
+    *   **Owned by me**: Templates you have created.
+    *   **Shared with me**: Templates shared with you by other researchers.
+3.  You can search for templates by name or description using the search bar.
+4.  Click on a template card to apply it to your current experiment. **Warning: This will overwrite your current stages and settings.**
 
 ## Saving a new template
 
@@ -27,9 +29,9 @@ You can save your current experiment configuration as a new template for future 
 
 ## Updating a template
 
-If you have loaded a template and made changes, you can update the original template with your new configuration.
+If you have loaded a template that you own and have made changes, you can update the original template.
 
-1.  Load a template.
+1.  Load a template you own.
 2.  Make your desired changes to the stages or settings.
 3.  Click the **Update template** button in the top right corner.
 4.  Confirm the update in the dialog.
@@ -38,7 +40,8 @@ If you have loaded a template and made changes, you can update the original temp
 
 You can delete saved templates that are no longer needed.
 
-1.  Click the **Load template** button in the left sidebar.
-2.  Find the template you want to delete in the **Saved Templates** section.
-3.  Click the delete icon (trash can) on the template card.
-4.  Confirm the deletion.
+1.  Click the **Load template** button in the top header to open the gallery.
+2.  Navigate to the **Owned by me** tab.
+3.  Find the template you want to delete.
+4.  Click the delete icon (trash can) on the template card.
+5.  Confirm the deletion.

--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -73,10 +73,16 @@ service cloud.firestore {
     }
 
     // Experiment templates (experimenter only)
+    // Experiment templates (experimenter only)
     match /experimentTemplates/{templateId} {
       allow list: if isExperimenter();
-      allow get: if isExperimenter() && (isPublic() || isCreator() || isReader() || isAdmin());
-
+      allow get: if isExperimenter() && (
+        resource.data.visibility == "public" || 
+        lowerEquals(resource.data.experiment.metadata.creator, request.auth.token.email) ||
+        (resource.data.sharedWith != null && resource.data.sharedWith.hasAny([request.auth.token.email])) ||
+        isAdmin()
+      );
+      
       // Experiments can use `writeExperiment`, `deleteExperiment` endpoints
       allow write: if false;
     }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -71,6 +71,7 @@ export class App extends MobxLitElement {
           </div>
         `;
       case Pages.EXPERIMENT:
+      case Pages.EXPERIMENT_EDIT:
         if (!this.authService.isExperimenter) {
           return this.render403();
         }
@@ -79,6 +80,8 @@ export class App extends MobxLitElement {
 
         return html` <experiment-dashboard></experiment-dashboard> `;
       case Pages.EXPERIMENT_CREATE:
+      case Pages.TEMPLATE_CREATE:
+      case Pages.TEMPLATE_EDIT:
         if (!this.authService.isExperimenter) {
           return this.render403();
         }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -9,6 +9,7 @@ import './components/login/login';
 import './components/participant_view/cohort_landing';
 import './components/participant_view/participant_view';
 import './components/settings/settings';
+import './components/templates/templates_dialog';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing, TemplateResult} from 'lit';
@@ -55,6 +56,7 @@ export class App extends MobxLitElement {
           <page-header></page-header>
           <quick-start-gallery></quick-start-gallery>
           <home-gallery></home-gallery>
+          <templates-dialog></templates-dialog>
         `;
       case Pages.ADMIN:
         return html`
@@ -63,6 +65,7 @@ export class App extends MobxLitElement {
             <admin-dashboard></admin-dashboard>
           </div>
         `;
+
       case Pages.SETTINGS:
         return html`
           <page-header></page-header>

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -51,6 +51,11 @@ import {
   validateTemplateVariables,
 } from '@deliberation-lab/utils';
 
+import {
+  DEFAULT_TEMPLATES,
+  RESEARCH_TEMPLATES,
+} from '../../shared/default_templates';
+
 import {styles} from './experiment_builder.scss';
 
 enum PanelView {
@@ -88,9 +93,21 @@ export class ExperimentBuilder extends MobxLitElement {
         await this.experimentEditor.loadTemplates();
       }
 
-      const template = this.experimentEditor.savedTemplates.find(
+      let template = this.experimentEditor.savedTemplates.find(
         (t) => t.id === templateId,
       );
+
+      if (!template) {
+        const defaultTemplate = [
+          ...DEFAULT_TEMPLATES,
+          ...RESEARCH_TEMPLATES,
+        ].find((t) => t.id === templateId);
+
+        if (defaultTemplate) {
+          template = defaultTemplate.factory();
+        }
+      }
+
       if (template) {
         this.experimentEditor.loadTemplate(template);
         if (isTemplateEdit) {

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -31,7 +31,7 @@ import './variable_editor';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 
 import '@material/web/checkbox/checkbox.js';
 
@@ -76,6 +76,37 @@ export class ExperimentBuilder extends MobxLitElement {
   private readonly routerService = core.getService(RouterService);
 
   @state() panelView: PanelView = PanelView.STAGES;
+
+  override async firstUpdated() {
+    const params = this.routerService.activeRoute.params;
+    const isTemplateEdit =
+      this.routerService.activePage === Pages.TEMPLATE_EDIT;
+    const templateId = params['template'];
+
+    if (templateId) {
+      if (this.experimentEditor.savedTemplates.length === 0) {
+        await this.experimentEditor.loadTemplates();
+      }
+
+      const template = this.experimentEditor.savedTemplates.find(
+        (t) => t.id === templateId,
+      );
+      if (template) {
+        this.experimentEditor.loadTemplate(template);
+        if (isTemplateEdit) {
+          // TODO: Set a flag in experimentEditor to indicate we are directly editing a template
+          // For now, we just load it. The save button logic needs to know this.
+          this.experimentEditor.setLoadedTemplateId(template.id);
+        }
+
+        if (this.experimentEditor.stages.length > 0) {
+          this.experimentEditor.setCurrentStageId(
+            this.experimentEditor.stages[0].id,
+          );
+        }
+      }
+    }
+  }
 
   override render() {
     return html`

--- a/frontend/src/components/experiment_builder/experiment_builder_nav.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder_nav.ts
@@ -30,9 +30,7 @@ export class ExperimentBuilderNav extends MobxLitElement {
 
   override render() {
     return html`
-      <div class="buttons header">
-        ${this.renderAddStageButton()} ${this.renderLoadTemplateButton()}
-      </div>
+      <div class="buttons header">${this.renderAddStageButton()}</div>
       <div class="nav-items-wrapper">
         ${this.experimentEditor.stages.map((stage, index) =>
           this.renderStageItem(stage, index),
@@ -123,21 +121,6 @@ export class ExperimentBuilderNav extends MobxLitElement {
         }}
       >
         + Add stage
-      </pr-button>
-    `;
-  }
-
-  private renderLoadTemplateButton() {
-    return html`
-      <pr-button
-        color="neutral"
-        variant="default"
-        ?disabled=${!this.experimentEditor.canEditStages}
-        @click=${() => {
-          this.experimentEditor.toggleStageBuilderDialog(true);
-        }}
-      >
-        Load template
       </pr-button>
     `;
   }

--- a/frontend/src/components/gallery/home_gallery.scss
+++ b/frontend/src/components/gallery/home_gallery.scss
@@ -133,16 +133,18 @@ h1 {
     border-style: dashed;
   }
 
-  &:focus,
-  &:hover,
-  &:focus.blank,
-  &:hover.blank {
-    border-color: var(--md-sys-color-secondary);
+  &.outlined {
+    background: none;
+    border-color: transparent;
+    border-style: solid;
   }
+
   &:focus,
   &:hover,
   &:focus.blank,
-  &:hover.blank {
+  &:hover.blank,
+  &:focus.outlined,
+  &:hover.outlined {
     border-color: var(--md-sys-color-secondary);
   }
 }

--- a/frontend/src/components/gallery/home_gallery.scss
+++ b/frontend/src/components/gallery/home_gallery.scss
@@ -139,6 +139,36 @@ h1 {
   &:hover.blank {
     border-color: var(--md-sys-color-secondary);
   }
+  &:focus,
+  &:hover,
+  &:focus.blank,
+  &:hover.blank {
+    border-color: var(--md-sys-color-secondary);
+  }
+}
+
+.template-card-wrapper {
+  @include common.flex-column;
+  width: min-content; // or match card width
+}
+
+.template-actions {
+  @include common.flex-row;
+  justify-content: flex-end;
+  padding-top: common.$spacing-small;
+
+  .edit-button {
+    @include typescale.label-small;
+    @include common.flex-row-align-center;
+    color: var(--md-sys-color-outline);
+    text-decoration: none;
+    gap: 4px;
+
+    &:hover {
+      color: var(--md-sys-color-secondary);
+      cursor: pointer;
+    }
+  }
 }
 
 .gallery-header-row {

--- a/frontend/src/components/gallery/home_gallery.ts
+++ b/frontend/src/components/gallery/home_gallery.ts
@@ -230,23 +230,12 @@ export class HomeGallery extends MobxLitElement {
       this.authService.isAdmin;
 
     const createHref = `#/templates/new_template?template=${experiment.id}`;
-    const editHref = `#/templates/${experiment.id}/edit`;
 
     return html`
       <div class="template-card-wrapper">
         <a href=${createHref} class="gallery-link" title="Use template">
           <gallery-card .item=${item}></gallery-card>
         </a>
-        ${isCreator
-          ? html`
-              <div class="template-actions">
-                <a href=${editHref} class="edit-button">
-                  <pr-icon icon="edit" size="small"></pr-icon>
-                  Edit template
-                </a>
-              </div>
-            `
-          : nothing}
       </div>
     `;
   }

--- a/frontend/src/components/header/header.scss
+++ b/frontend/src/components/header/header.scss
@@ -7,7 +7,8 @@
   position: sticky;
   top: 0;
   width: 100%;
-  z-index: 1;
+  width: 100%;
+  z-index: 10;
 }
 
 .banner {

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -99,6 +99,8 @@ export class Header extends MobxLitElement {
           }
           break;
         case Pages.EXPERIMENT_CREATE:
+        case Pages.TEMPLATE_CREATE:
+        case Pages.TEMPLATE_EDIT:
           this.routerService.navigate(Pages.HOME);
           break;
         case Pages.PARTICIPANT_JOIN_COHORT:

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -533,27 +533,23 @@ export class Header extends MobxLitElement {
             </div>
           `}
       ${this.renderTemplateButtons(errors.some((e) => !e.isApiError))}
-      ${this.renderLoadTemplateButton()}
-      ${!isTemplateCreate
-        ? html`
-            <pr-button
-              ?loading=${this.experimentEditor.isWritingExperiment}
-              ?disabled=${errors.length > 0}
-              @click=${async () => {
-                this.analyticsService.trackButtonClick(
-                  ButtonClick.EXPERIMENT_SAVE_NEW,
-                );
-                const response = await this.experimentEditor.writeExperiment();
-                this.experimentEditor.resetExperiment();
-                this.routerService.navigate(Pages.EXPERIMENT, {
-                  experiment: response.id,
-                });
-              }}
-            >
-              Save experiment
-            </pr-button>
-          `
-        : nothing}
+      ${!isTemplateCreate ? this.renderLoadTemplateButton() : nothing}
+      <pr-button
+        ?loading=${this.experimentEditor.isWritingExperiment}
+        ?disabled=${errors.length > 0}
+        @click=${async () => {
+          this.analyticsService.trackButtonClick(
+            ButtonClick.EXPERIMENT_SAVE_NEW,
+          );
+          const response = await this.experimentEditor.writeExperiment();
+          this.experimentEditor.resetExperiment();
+          this.routerService.navigate(Pages.EXPERIMENT, {
+            experiment: response.id,
+          });
+        }}
+      >
+        ${isTemplateCreate ? 'Create experiment' : 'Save experiment'}
+      </pr-button>
     `;
   }
 

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -12,6 +12,7 @@ import {core} from '../../core/core';
 import {ButtonClick, AnalyticsService} from '../../services/analytics.service';
 import {AuthService} from '../../services/auth.service';
 import {CohortService} from '../../services/cohort.service';
+import {HomeService} from '../../services/home.service';
 import {ExperimentService} from '../../services/experiment.service';
 import {ExperimentEditor} from '../../services/experiment.editor';
 import {ExperimentManager} from '../../services/experiment.manager';
@@ -235,6 +236,18 @@ export class Header extends MobxLitElement {
               @click=${() => {
                 // TODO: Add Analytics tracking for bug report click
                 window.open(BUG_REPORT_URL, '_blank');
+              }}
+            >
+            </pr-icon-button>
+          </pr-tooltip>
+          <pr-tooltip text="View templates" position="BOTTOM_END">
+            <pr-icon-button
+              icon="dataset"
+              color="secondary"
+              variant="default"
+              @click=${() => {
+                const homeService = core.getService(HomeService);
+                homeService.setTemplatesOpen(true);
               }}
             >
             </pr-icon-button>

--- a/frontend/src/components/header/header.ts
+++ b/frontend/src/components/header/header.ts
@@ -240,18 +240,7 @@ export class Header extends MobxLitElement {
             >
             </pr-icon-button>
           </pr-tooltip>
-          <pr-tooltip text="View templates" position="BOTTOM_END">
-            <pr-icon-button
-              icon="dataset"
-              color="secondary"
-              variant="default"
-              @click=${() => {
-                const homeService = core.getService(HomeService);
-                homeService.setTemplatesOpen(true);
-              }}
-            >
-            </pr-icon-button>
-          </pr-tooltip>
+
           <pr-tooltip text="View experimenter settings" position="BOTTOM_END">
             <pr-icon-button
               icon="settings"

--- a/frontend/src/components/templates/template_gallery.scss
+++ b/frontend/src/components/templates/template_gallery.scss
@@ -1,0 +1,76 @@
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+// Include home gallery styles as base
+@use '../gallery/home_gallery.scss';
+
+:host {
+  @include common.flex-column;
+  align-items: center;
+  width: 100%;
+}
+
+.card {
+  @include common.flex-column;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: common.$spacing-medium;
+  cursor: pointer;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-large;
+  width: 280px;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+
+  &:focus,
+  &:hover {
+    background: var(--md-sys-color-surface-variant);
+    border-color: var(--md-sys-color-secondary);
+  }
+
+  &.template-card {
+    min-height: 150px;
+  }
+
+  .card-content {
+    @include common.flex-column;
+    height: 100%;
+    gap: common.$spacing-medium;
+  }
+
+  .title {
+    @include typescale.title-small;
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .description {
+    @include typescale.body-small;
+    color: var(--md-sys-color-on-surface-variant);
+    // Remove flex-grow from description if we want footer at bottom regardless of description height
+    // But description has valid clamp.
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .template-footer {
+    @include common.flex-row;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: auto;
+
+    .creator {
+      @include typescale.label-small;
+      color: var(--md-sys-color-outline);
+    }
+  }
+}
+
+.gallery-link {
+  text-decoration: none;
+  color: inherit;
+  display: contents;
+}

--- a/frontend/src/components/templates/template_gallery.ts
+++ b/frontend/src/components/templates/template_gallery.ts
@@ -1,0 +1,315 @@
+import '../../pair-components/button';
+import '../../pair-components/icon';
+import '../../pair-components/menu';
+import '../../pair-components/textarea';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, state} from 'lit/decorators.js';
+import {repeat} from 'lit/directives/repeat.js';
+
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth.service';
+import {ExperimentEditor} from '../../services/experiment.editor';
+import {HomeService} from '../../services/home.service';
+import {RouterService, Pages} from '../../services/router.service';
+
+import {
+  Experiment,
+  ExperimentTemplate,
+  SortMode,
+  sortLabel,
+  sortExperiments,
+  Visibility,
+} from '@deliberation-lab/utils';
+
+import {
+  CodeBasedTemplate,
+  DEFAULT_TEMPLATES,
+  RESEARCH_TEMPLATES,
+} from '../../shared/default_templates';
+import {styles} from './template_gallery.scss';
+
+enum TemplateTab {
+  OWNED_BY_ME = 'owned_by_me',
+  SHARED_WITH_ME = 'shared_with_me',
+  DEFAULT = 'default_from_app',
+}
+
+@customElement('template-gallery')
+export class TemplateGallery extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly authService = core.getService(AuthService);
+  private readonly homeService = core.getService(HomeService);
+  private readonly routerService = core.getService(RouterService);
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  @state() private activeTab: TemplateTab = TemplateTab.DEFAULT;
+  @state() private sortMode: SortMode = SortMode.NEWEST;
+  @state() private searchQuery = '';
+  @state() private refreshing = false;
+
+  private async setSort(mode: SortMode) {
+    this.sortMode = mode;
+    this.refreshing = true;
+    await new Promise((r) => setTimeout(r, 120));
+    this.refreshing = false;
+  }
+
+  private renderControls() {
+    const renderSortItem = (mode: SortMode, label: string) => {
+      // Sort is only relevant for non-default templates or if we implement sort for default ones
+      return html`
+        <div class="menu-item" @click=${() => this.setSort(mode)}>
+          ${label}
+          ${this.sortMode === mode
+            ? html`<span class="checkmark">✔</span>`
+            : nothing}
+        </div>
+      `;
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        (e.target as HTMLTextAreaElement).blur();
+      }
+    };
+
+    const clearSearch = () => {
+      this.searchQuery = '';
+    };
+
+    return html`
+      <div class="controls">
+        <div class="search-container">
+          <pr-icon icon="search" size="small"></pr-icon>
+          <pr-textarea
+            placeholder="Search templates"
+            .value=${this.searchQuery}
+            @input=${(e: InputEvent) => {
+              this.searchQuery = (e.target as HTMLTextAreaElement).value;
+            }}
+            @keydown=${handleKeyDown}
+          ></pr-textarea>
+          ${this.searchQuery
+            ? html`<pr-icon
+                icon="close"
+                size="small"
+                class="clear-button"
+                @click=${clearSearch}
+              ></pr-icon>`
+            : nothing}
+        </div>
+
+        ${this.activeTab !== TemplateTab.DEFAULT
+          ? html`
+              <pr-menu
+                name=${sortLabel(this.sortMode)}
+                icon="sort"
+                color="neutral"
+              >
+                <div class="menu-wrapper">
+                  ${renderSortItem(SortMode.NEWEST, 'Newest first')}
+                  ${renderSortItem(SortMode.OLDEST, 'Oldest first')}
+                  ${renderSortItem(SortMode.ALPHA_ASC, 'Alphabetical (A–Z)')}
+                  ${renderSortItem(SortMode.ALPHA_DESC, 'Alphabetical (Z–A)')}
+                </div>
+              </pr-menu>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  override render() {
+    const list = this.getList();
+
+    return html`
+      <div class="gallery-header-row">
+        <div class="gallery-tabs">
+          <div
+            class="gallery-tab ${this.activeTab === TemplateTab.DEFAULT
+              ? 'active'
+              : ''}"
+            @click=${() => (this.activeTab = TemplateTab.DEFAULT)}
+          >
+            Recommended
+          </div>
+          <div
+            class="gallery-tab ${this.activeTab === TemplateTab.OWNED_BY_ME
+              ? 'active'
+              : ''}"
+            @click=${() => (this.activeTab = TemplateTab.OWNED_BY_ME)}
+          >
+            Owned by me
+          </div>
+          <div
+            class="gallery-tab ${this.activeTab === TemplateTab.SHARED_WITH_ME
+              ? 'active'
+              : ''}"
+            @click=${() => (this.activeTab = TemplateTab.SHARED_WITH_ME)}
+          >
+            Shared with me
+          </div>
+        </div>
+        <div slot="gallery-controls">${this.renderControls()}</div>
+      </div>
+
+      <div class="gallery-wrapper ${this.refreshing ? 'hidden' : ''}">
+        ${this.renderEmptyMessage(list)}
+        ${this.activeTab === TemplateTab.DEFAULT
+          ? this.renderDefaultList(list as CodeBasedTemplate[])
+          : this.renderExperimentList(list as ExperimentTemplate[])}
+      </div>
+    `;
+  }
+
+  private renderEmptyMessage(list: unknown[]) {
+    if (list.length > 0) return nothing;
+    return html`<div class="empty-message">No templates found</div>`;
+  }
+
+  private renderDefaultList(list: CodeBasedTemplate[]) {
+    return repeat(
+      list,
+      (t) => t.id,
+      (t) => html`
+        <div class="card template-card">
+          <div
+            class="card-content"
+            @click=${() => {
+              this.loadDefaultTemplate(t);
+            }}
+          >
+            <div class="title">${t.name}</div>
+            <div class="description">${t.description}</div>
+            <div class="template-footer">
+              <div class="chip secondary">Default</div>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+  }
+
+  private loadDefaultTemplate(t: CodeBasedTemplate) {
+    const template = t.factory();
+    this.experimentEditor.loadTemplate(template);
+    this.routerService.navigate(Pages.EXPERIMENT_CREATE);
+  }
+
+  private renderExperimentList(list: ExperimentTemplate[]) {
+    return repeat(
+      list,
+      (t) => t.id,
+      (t) => this.renderTemplateCard(t),
+    );
+  }
+
+  private renderTemplateCard(template: ExperimentTemplate) {
+    const metadata = template.experiment.metadata;
+
+    const createHref = `#/templates/new_template?template=${template.id}`;
+
+    return html`
+      <div class="card template-card">
+        <a href="${createHref}" class="gallery-link" title="Use template">
+          <div class="card-content">
+            <div class="title">${metadata.name}</div>
+            <div class="description">${metadata.description}</div>
+            <div class="template-footer">
+              <div class="creator">
+                By ${this.homeService.getExperimenterName(metadata.creator)}
+              </div>
+              ${template.visibility === Visibility.PUBLIC
+                ? html`<div class="chip">Public</div>`
+                : nothing}
+            </div>
+          </div>
+        </a>
+      </div>
+    `;
+  }
+
+  private getList(): (ExperimentTemplate | CodeBasedTemplate)[] {
+    const q = this.searchQuery.toLowerCase().trim();
+
+    if (this.activeTab === TemplateTab.DEFAULT) {
+      let list = [...DEFAULT_TEMPLATES];
+      if (this.authService.hasResearchTemplateAccess) {
+        list = [...list, ...RESEARCH_TEMPLATES];
+      }
+      if (q) {
+        list = list.filter(
+          (t) =>
+            t.name.toLowerCase().includes(q) ||
+            t.description.toLowerCase().includes(q),
+        );
+      }
+      return list;
+    }
+
+    let templates = this.homeService.experimentTemplates;
+
+    if (this.activeTab === TemplateTab.OWNED_BY_ME) {
+      templates = templates.filter(
+        (t) => t.experiment.metadata.creator === this.authService.userEmail,
+      );
+    } else if (this.activeTab === TemplateTab.SHARED_WITH_ME) {
+      templates = templates.filter(
+        (t) => t.experiment.metadata.creator !== this.authService.userEmail,
+      );
+    }
+
+    if (q) {
+      templates = templates.filter(
+        (t) =>
+          t.experiment.metadata.name.toLowerCase().includes(q) ||
+          t.experiment.metadata.description.toLowerCase().includes(q),
+      );
+    }
+
+    // Sort
+    templates = [...templates]; // Copy before sort
+    // Mapping SortMode to sort logic
+    // Using simple sort adaptation
+    templates.sort((a, b) => {
+      const getVal = (t: ExperimentTemplate) => {
+        if (
+          this.sortMode === SortMode.NEWEST ||
+          this.sortMode === SortMode.OLDEST
+        ) {
+          const d = t.experiment.metadata.dateModified;
+          // Handle Timestamp or date string or number
+          if (typeof d === 'object' && 'seconds' in d)
+            return (d as {seconds: number}).seconds;
+          return new Date(d).getTime();
+        }
+        return t.experiment.metadata.name.toLowerCase();
+      };
+
+      const valA = getVal(a);
+      const valB = getVal(b);
+
+      if (this.sortMode === SortMode.NEWEST)
+        return (valB as number) - (valA as number);
+      if (this.sortMode === SortMode.OLDEST)
+        return (valA as number) - (valB as number);
+      if (this.sortMode === SortMode.ALPHA_ASC)
+        return String(valA).localeCompare(String(valB));
+      if (this.sortMode === SortMode.ALPHA_DESC)
+        return String(valB).localeCompare(String(valA));
+      return 0;
+    });
+
+    return templates;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'template-gallery': TemplateGallery;
+  }
+}

--- a/frontend/src/components/templates/templates_dialog.scss
+++ b/frontend/src/components/templates/templates_dialog.scss
@@ -1,0 +1,43 @@
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
+
+:host {
+  @include common.overlay;
+  position: fixed;
+  z-index: 1000;
+}
+
+.dialog {
+  @include common.dialog;
+  height: 80vh;
+  width: 80vw;
+  max-width: 1200px;
+  max-height: 900px;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  @include typescale.title-medium;
+  @include common.flex-row-align-center;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+  gap: common.$spacing-medium;
+  height: common.$header-height;
+  justify-content: space-between;
+  padding: 0 common.$main-content-padding;
+}
+
+.body {
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+template-gallery {
+  flex-grow: 1;
+  overflow: auto;
+  padding: common.$main-content-padding;
+}

--- a/frontend/src/components/templates/templates_dialog.ts
+++ b/frontend/src/components/templates/templates_dialog.ts
@@ -1,0 +1,53 @@
+import '../../pair-components/icon_button';
+import './template_gallery';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {HomeService} from '../../services/home.service';
+import {styles} from './templates_dialog.scss';
+
+@customElement('templates-dialog')
+export class TemplatesDialog extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly homeService = core.getService(HomeService);
+
+  private onClose() {
+    this.homeService.setTemplatesOpen(false);
+  }
+
+  override updated() {
+    this.style.display = this.homeService.isTemplatesOpen ? 'flex' : 'none';
+  }
+
+  override render() {
+    if (!this.homeService.isTemplatesOpen) return html``;
+
+    return html`
+      <div class="dialog">
+        <div class="header">
+          <div>Experiment Templates</div>
+          <pr-icon-button
+            icon="close"
+            color="neutral"
+            variant="default"
+            @click=${() => this.onClose()}
+          >
+          </pr-icon-button>
+        </div>
+        <div class="body">
+          <template-gallery></template-gallery>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'templates-dialog': TemplatesDialog;
+  }
+}

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -212,6 +212,10 @@ export class ExperimentEditor extends Service {
     this.loadedTemplateId = template.id;
   }
 
+  setLoadedTemplateId(id: string | undefined) {
+    this.loadedTemplateId = id;
+  }
+
   async saveTemplate(
     name?: string,
     description?: string,

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -185,7 +185,9 @@ export class ExperimentManager extends Service {
   @computed get canEditExperimentStages() {
     return (
       (this.isCreator && Object.keys(this.cohortMap).length === 0) ||
-      this.sp.routerService.activePage === Pages.EXPERIMENT_CREATE
+      this.sp.routerService.activePage === Pages.EXPERIMENT_CREATE ||
+      this.sp.routerService.activePage === Pages.TEMPLATE_CREATE ||
+      this.sp.routerService.activePage === Pages.TEMPLATE_EDIT
     );
   }
 

--- a/frontend/src/services/home.service.ts
+++ b/frontend/src/services/home.service.ts
@@ -39,7 +39,6 @@ interface ServiceProvider {
 export enum HomeTab {
   MY_EXPERIMENTS = 'my_experiments',
   SHARED_WITH_ME = 'shared_with_me',
-  TEMPLATES = 'experiment_templates',
 }
 
 export class HomeService extends Service {
@@ -212,6 +211,12 @@ export class HomeService extends Service {
     this.activeTab = showMyExperiments
       ? HomeTab.MY_EXPERIMENTS
       : HomeTab.SHARED_WITH_ME;
+  }
+
+  @observable isTemplatesOpen = false;
+
+  setTemplatesOpen(isOpen: boolean) {
+    this.isTemplatesOpen = isOpen;
   }
 
   setSearchQuery(searchQuery: string) {

--- a/frontend/src/services/router.service.ts
+++ b/frontend/src/services/router.service.ts
@@ -43,6 +43,7 @@ export class RouterService extends Service {
       name: Pages.SETTINGS,
       path: '/settings',
     },
+
     {
       name: Pages.EXPERIMENT,
       path: '/e/:experiment',
@@ -247,6 +248,7 @@ export const NAV_ITEMS: NavItem[] = [
     isParticipantPage: false,
     isPrimaryPage: true,
   },
+
   {
     page: Pages.EXPERIMENT_CREATE,
     title: 'New experiment',

--- a/frontend/src/services/router.service.ts
+++ b/frontend/src/services/router.service.ts
@@ -126,14 +126,11 @@ export class RouterService extends Service {
   private loadDataForRoute() {
     const params = this.activeRoute.params;
 
-    // Reset services first if needed (though some might need to persist, usually better to update)
-    // For now, let's keep the logic simple: update if params exist.
-
     if (params['experiment'] && params['participant']) {
       this.sp.participantService.updateForRoute(
         params['experiment'],
         params['participant'],
-        params['stage'], // if defined, this sets current stage viewed
+        params['stage'],
       );
       this.sp.experimentManager.updateForRoute(params['experiment']);
       this.sp.experimentService.updateForRoute(params['experiment']);
@@ -142,18 +139,9 @@ export class RouterService extends Service {
       this.sp.experimentService.updateForRoute(params['experiment']);
       this.sp.participantService.reset();
 
-      // Handle Edit Mode
       if (this.activePage === Pages.EXPERIMENT_EDIT) {
         this.sp.experimentManager.setIsEditing(true);
       }
-    } else if (this.activePage === Pages.TEMPLATE_EDIT && params['template']) {
-      // Template Edit Route
-      // We don't have a dedicated "TemplateManager" yet, so we likely use ExperimentEditor
-      // Logic for this will be handled in ExperimentBuilder (or we adding a method here?)
-      // Use ExperimentService/Manager reset to be safe
-      this.sp.experimentManager.reset();
-      this.sp.experimentService.reset();
-      this.sp.participantService.reset();
     } else {
       this.sp.experimentManager.reset();
       this.sp.experimentService.reset();

--- a/frontend/src/services/router.service.ts
+++ b/frontend/src/services/router.service.ts
@@ -52,6 +52,18 @@ export class RouterService extends Service {
       path: '/new_experiment',
     },
     {
+      name: Pages.TEMPLATE_CREATE,
+      path: '/templates/new_template',
+    },
+    {
+      name: Pages.TEMPLATE_EDIT,
+      path: '/templates/:template/edit',
+    },
+    {
+      name: Pages.EXPERIMENT_EDIT,
+      path: '/e/:experiment/edit',
+    },
+    {
       name: Pages.PARTICIPANT,
       path: '/e/:experiment/p/:participant',
     },
@@ -113,6 +125,9 @@ export class RouterService extends Service {
   private loadDataForRoute() {
     const params = this.activeRoute.params;
 
+    // Reset services first if needed (though some might need to persist, usually better to update)
+    // For now, let's keep the logic simple: update if params exist.
+
     if (params['experiment'] && params['participant']) {
       this.sp.participantService.updateForRoute(
         params['experiment'],
@@ -124,6 +139,19 @@ export class RouterService extends Service {
     } else if (params['experiment']) {
       this.sp.experimentManager.updateForRoute(params['experiment']);
       this.sp.experimentService.updateForRoute(params['experiment']);
+      this.sp.participantService.reset();
+
+      // Handle Edit Mode
+      if (this.activePage === Pages.EXPERIMENT_EDIT) {
+        this.sp.experimentManager.setIsEditing(true);
+      }
+    } else if (this.activePage === Pages.TEMPLATE_EDIT && params['template']) {
+      // Template Edit Route
+      // We don't have a dedicated "TemplateManager" yet, so we likely use ExperimentEditor
+      // Logic for this will be handled in ExperimentBuilder (or we adding a method here?)
+      // Use ExperimentService/Manager reset to be safe
+      this.sp.experimentManager.reset();
+      this.sp.experimentService.reset();
       this.sp.participantService.reset();
     } else {
       this.sp.experimentManager.reset();
@@ -183,7 +211,10 @@ export enum Pages {
   ADMIN = 'ADMIN',
   HOME = 'HOME',
   EXPERIMENT = 'EXPERIMENT',
+  EXPERIMENT_EDIT = 'EXPERIMENT_EDIT',
   EXPERIMENT_CREATE = 'EXPERIMENT_CREATE',
+  TEMPLATE_CREATE = 'TEMPLATE_CREATE',
+  TEMPLATE_EDIT = 'TEMPLATE_EDIT',
   PARTICIPANT = 'PARTICIPANT',
   PARTICIPANT_JOIN_COHORT = 'PARTICIPANT_JOIN_COHORT',
   // Deprecated (but included for backwards compatibility):

--- a/frontend/src/shared/default_templates.ts
+++ b/frontend/src/shared/default_templates.ts
@@ -1,10 +1,11 @@
 import {
-  Experiment,
   ExperimentTemplate,
   MetadataConfig,
   StageConfig,
   Visibility,
   createExperimentTemplate,
+  createExperimentConfig,
+  createMetadataConfig,
 } from '@deliberation-lab/utils';
 
 import {
@@ -59,8 +60,13 @@ import {
 import {
   getQuickstartAgentGroupChatTemplate,
   getQuickstartGroupChatTemplate,
+  QUICKSTART_AGENT_CHAT_METADATA,
+  QUICKSTART_GROUP_CHAT_METADATA,
 } from './templates/quickstart_group_chat';
-import {getQuickstartPrivateChatTemplate} from './templates/quickstart_private_chat';
+import {
+  getQuickstartPrivateChatTemplate,
+  QUICKSTART_PRIVATE_CHAT_METADATA,
+} from './templates/quickstart_private_chat';
 
 // Interface for code-based templates to be displayed in the gallery
 export interface CodeBasedTemplate {
@@ -78,52 +84,22 @@ function createTemplate(
   metadata: Partial<MetadataConfig>,
   stages: StageConfig[],
 ): ExperimentTemplate {
-  return {
-    id: '', // Placeholder, logic usually allows empty ID for new templates or code templates don't track ID
+  return createExperimentTemplate({
     visibility: Visibility.PUBLIC,
     stageConfigs: stages,
-    agentMediators: [],
-    // cast to unknown to avoid strict Experiment interface checks for fields we don't care about in templates (like IDs that get regenerated)
-    // or better, fill defaults.
-    experiment: {
-      id: '',
-      versionId: 19,
+    experiment: createExperimentConfig(stages, {
       metadata: {
-        creator: 'system',
-        dateCreated: new Date().toISOString(),
-        dateModified: new Date().toISOString(),
-        publicMetadata: {},
-        starred: {},
-        tags: [],
+        ...createMetadataConfig(),
         ...metadata,
       },
-      permissions: {
-        visibility: Visibility.PUBLIC,
-        readers: [],
-        editors: [],
-      },
-      stageIds: stages.map((s) => s.id),
       defaultCohortConfig: {
-        minParticipantsPerCohort: 1, // Default to 1 to compile, logic might overwrite
+        minParticipantsPerCohort: 1,
         maxParticipantsPerCohort: 100,
         includeAllParticipantsInCohortCount: false,
         botProtection: false,
       },
-      prolificConfig: {
-        enableProlificIntegration: false,
-        attentionFailRedirectCode: '',
-        defaultRedirectCode: '',
-        bootedRedirectCode: '',
-      },
-      agentConfig: {
-        agentEndpoints: {},
-      },
-      cohortLockMap: {},
-      variableConfigs: [],
-      variableMap: {},
-    } as unknown as Experiment,
-    agentParticipants: [],
-  };
+    }),
+  });
 }
 
 export const DEFAULT_TEMPLATES: CodeBasedTemplate[] = [
@@ -135,20 +111,20 @@ export const DEFAULT_TEMPLATES: CodeBasedTemplate[] = [
   },
   {
     id: 'quickstart_agent_chat',
-    name: 'Group chat with agent mediator',
-    description: 'A group chat facilitated by an LLM agent.',
+    name: QUICKSTART_AGENT_CHAT_METADATA.name,
+    description: QUICKSTART_AGENT_CHAT_METADATA.description,
     factory: getQuickstartAgentGroupChatTemplate,
   },
   {
     id: 'quickstart_private_chat',
-    name: 'Private chat with agent',
-    description: '1:1 chat between a participant and an agent.',
+    name: QUICKSTART_PRIVATE_CHAT_METADATA.name,
+    description: QUICKSTART_PRIVATE_CHAT_METADATA.description,
     factory: getQuickstartPrivateChatTemplate,
   },
   {
     id: 'quickstart_group_chat',
-    name: 'Group chat with no agents',
-    description: 'A standard group chat without AI mediation.',
+    name: QUICKSTART_GROUP_CHAT_METADATA.name,
+    description: QUICKSTART_GROUP_CHAT_METADATA.description,
     factory: getQuickstartGroupChatTemplate,
   },
   {

--- a/frontend/src/shared/default_templates.ts
+++ b/frontend/src/shared/default_templates.ts
@@ -1,0 +1,267 @@
+import {
+  Experiment,
+  ExperimentTemplate,
+  MetadataConfig,
+  StageConfig,
+  Visibility,
+  createExperimentTemplate,
+} from '@deliberation-lab/utils';
+
+import {
+  LAS_METADATA,
+  ANON_LAS_METADATA,
+  getLASStageConfigs,
+  getAnonLASStageConfigs,
+} from './templates/lost_at_sea';
+import {
+  getChipMetadata,
+  getChipNegotiationStageConfigs,
+} from './templates/chip_negotiation';
+import {
+  getCharityDebateTemplate,
+  createCharityDebateConfig,
+  CHARITY_DEBATE_METADATA,
+} from './templates/charity_allocations';
+import {
+  getOOTBCharityDebateTemplate,
+  OOTB_CHARITY_DEBATE_METADATA,
+} from './templates/charity_allocations_ootb';
+import {
+  CONSENSUS_METADATA,
+  getConsensusTopicTemplate,
+} from './templates/debate_topics';
+import {
+  FRUIT_TEST_METADATA,
+  getFruitTestExperimentTemplate,
+} from './templates/fruit_test';
+import {
+  STOCKINFO_GAME_METADATA,
+  getStockInfoGameStageConfigs,
+} from './templates/stockinfo_template';
+import {
+  FLIPCARD_TEMPLATE_METADATA,
+  getFlipCardExperimentTemplate,
+} from './templates/flipcard';
+import {
+  ASSET_ALLOCATION_TEMPLATE_METADATA,
+  getAssetAllocationTemplate,
+} from './templates/asset_allocation_template';
+import {
+  CONDITIONAL_SURVEY_TEMPLATE_METADATA,
+  getConditionalSurveyTemplate,
+} from './templates/conditional_survey_template';
+import {POLICY_METADATA, getPolicyExperimentTemplate} from './templates/policy';
+import {
+  INTEGRATION_METADATA,
+  getAgentParticipantIntegrationTemplate,
+} from './templates/agent_participant_integration_template';
+
+import {
+  getQuickstartAgentGroupChatTemplate,
+  getQuickstartGroupChatTemplate,
+} from './templates/quickstart_group_chat';
+import {getQuickstartPrivateChatTemplate} from './templates/quickstart_private_chat';
+
+// Interface for code-based templates to be displayed in the gallery
+export interface CodeBasedTemplate {
+  id: string; // concise ID for tracking/keys
+  name: string;
+  description: string;
+  // If true, this is a research template (gated)
+  isResearch?: boolean;
+  // Function to generate the template
+  factory: () => ExperimentTemplate;
+}
+
+// Helper to convert stage-list templates to full ExperimentTemplate
+function createTemplate(
+  metadata: Partial<MetadataConfig>,
+  stages: StageConfig[],
+): ExperimentTemplate {
+  return {
+    id: '', // Placeholder, logic usually allows empty ID for new templates or code templates don't track ID
+    visibility: Visibility.PUBLIC,
+    stageConfigs: stages,
+    agentMediators: [],
+    // cast to unknown to avoid strict Experiment interface checks for fields we don't care about in templates (like IDs that get regenerated)
+    // or better, fill defaults.
+    experiment: {
+      id: '',
+      versionId: 19,
+      metadata: {
+        creator: 'system',
+        dateCreated: new Date().toISOString(),
+        dateModified: new Date().toISOString(),
+        publicMetadata: {},
+        starred: {},
+        tags: [],
+        ...metadata,
+      },
+      permissions: {
+        visibility: Visibility.PUBLIC,
+        readers: [],
+        editors: [],
+      },
+      stageIds: stages.map((s) => s.id),
+      defaultCohortConfig: {
+        minParticipantsPerCohort: 1, // Default to 1 to compile, logic might overwrite
+        maxParticipantsPerCohort: 100,
+        includeAllParticipantsInCohortCount: false,
+        botProtection: false,
+      },
+      prolificConfig: {
+        enableProlificIntegration: false,
+        attentionFailRedirectCode: '',
+        defaultRedirectCode: '',
+        bootedRedirectCode: '',
+      },
+      agentConfig: {
+        agentEndpoints: {},
+      },
+      cohortLockMap: {},
+      variableConfigs: [],
+      variableMap: {},
+    } as unknown as Experiment,
+    agentParticipants: [],
+  };
+}
+
+export const DEFAULT_TEMPLATES: CodeBasedTemplate[] = [
+  {
+    id: 'blank',
+    name: 'Build experiment from scratch',
+    description: 'Start with an empty experiment configuration.',
+    factory: () => createExperimentTemplate({}),
+  },
+  {
+    id: 'quickstart_agent_chat',
+    name: 'Group chat with agent mediator',
+    description: 'A group chat facilitated by an LLM agent.',
+    factory: getQuickstartAgentGroupChatTemplate,
+  },
+  {
+    id: 'quickstart_private_chat',
+    name: 'Private chat with agent',
+    description: '1:1 chat between a participant and an agent.',
+    factory: getQuickstartPrivateChatTemplate,
+  },
+  {
+    id: 'quickstart_group_chat',
+    name: 'Group chat with no agents',
+    description: 'A standard group chat without AI mediation.',
+    factory: getQuickstartGroupChatTemplate,
+  },
+  {
+    id: 'flipcard',
+    name: FLIPCARD_TEMPLATE_METADATA.name,
+    description: FLIPCARD_TEMPLATE_METADATA.description,
+    factory: getFlipCardExperimentTemplate,
+  },
+  {
+    id: 'fruit_test',
+    name: FRUIT_TEST_METADATA.name,
+    description: FRUIT_TEST_METADATA.description,
+    factory: getFruitTestExperimentTemplate,
+  },
+  {
+    id: 'conditional_survey',
+    name: CONDITIONAL_SURVEY_TEMPLATE_METADATA.name,
+    description: CONDITIONAL_SURVEY_TEMPLATE_METADATA.description,
+    factory: () =>
+      createTemplate(
+        CONDITIONAL_SURVEY_TEMPLATE_METADATA,
+        getConditionalSurveyTemplate(),
+      ),
+  },
+  {
+    id: 'stock_info',
+    name: STOCKINFO_GAME_METADATA.name,
+    description: STOCKINFO_GAME_METADATA.description,
+    factory: () =>
+      createTemplate(STOCKINFO_GAME_METADATA, getStockInfoGameStageConfigs()),
+  },
+  {
+    id: 'asset_allocation',
+    name: ASSET_ALLOCATION_TEMPLATE_METADATA.name,
+    description: ASSET_ALLOCATION_TEMPLATE_METADATA.description,
+    factory: () =>
+      createTemplate(
+        ASSET_ALLOCATION_TEMPLATE_METADATA,
+        getAssetAllocationTemplate(),
+      ),
+  },
+  {
+    id: 'policy',
+    name: POLICY_METADATA.name,
+    description: POLICY_METADATA.description,
+    factory: getPolicyExperimentTemplate,
+  },
+  {
+    id: 'agent_integration',
+    name: INTEGRATION_METADATA.name,
+    description: INTEGRATION_METADATA.description,
+    factory: getAgentParticipantIntegrationTemplate,
+  },
+];
+
+export const RESEARCH_TEMPLATES: CodeBasedTemplate[] = [
+  {
+    id: 'lost_at_sea',
+    name: LAS_METADATA.name,
+    description: LAS_METADATA.description,
+    isResearch: true,
+    factory: () => createTemplate(LAS_METADATA, getLASStageConfigs()),
+  },
+  {
+    id: 'lost_at_sea_anon',
+    name: ANON_LAS_METADATA.name,
+    description: ANON_LAS_METADATA.description,
+    isResearch: true,
+    factory: () => createTemplate(ANON_LAS_METADATA, getAnonLASStageConfigs()),
+  },
+  {
+    id: 'chip_negotiation_2',
+    name: getChipMetadata(2).name,
+    description: getChipMetadata(2).description,
+    isResearch: true,
+    factory: () =>
+      createTemplate(getChipMetadata(2), getChipNegotiationStageConfigs(2)),
+  },
+  {
+    id: 'chip_negotiation_3',
+    name: getChipMetadata(3).name,
+    description: getChipMetadata(3).description,
+    isResearch: true,
+    factory: () =>
+      createTemplate(getChipMetadata(3), getChipNegotiationStageConfigs(3)),
+  },
+  {
+    id: 'chip_negotiation_4',
+    name: getChipMetadata(4).name,
+    description: getChipMetadata(4).description,
+    isResearch: true,
+    factory: () =>
+      createTemplate(getChipMetadata(4), getChipNegotiationStageConfigs(4)),
+  },
+  {
+    id: 'consensus_debate',
+    name: CONSENSUS_METADATA.name + ' (Default Topic: Climate Change)',
+    description: CONSENSUS_METADATA.description,
+    isResearch: true,
+    factory: () => getConsensusTopicTemplate('Climate Change'),
+  },
+  {
+    id: 'charity_debate',
+    name: CHARITY_DEBATE_METADATA.name,
+    description: CHARITY_DEBATE_METADATA.description,
+    isResearch: true,
+    factory: () => getCharityDebateTemplate(createCharityDebateConfig()),
+  },
+  {
+    id: 'charity_debate_ootb',
+    name: OOTB_CHARITY_DEBATE_METADATA.name,
+    description: OOTB_CHARITY_DEBATE_METADATA.description,
+    isResearch: true,
+    factory: () => getOOTBCharityDebateTemplate(createCharityDebateConfig()),
+  },
+];

--- a/frontend/src/shared/templates/quickstart_group_chat.ts
+++ b/frontend/src/shared/templates/quickstart_group_chat.ts
@@ -1,7 +1,5 @@
 import {
-  createAgentChatSettings,
   createAgentMediatorPersonaConfig,
-  createAgentParticipantPersonaConfig,
   createChatPromptConfig,
   createChatStage,
   createExperimentConfig,
@@ -11,11 +9,8 @@ import {
   createProfileStage,
   createDefaultMediatorGroupChatPrompt,
   AgentMediatorTemplate,
-  AgentParticipantTemplate,
-  AgentPersonaType,
   ExperimentTemplate,
   MediatorPromptConfig,
-  ParticipantPromptConfig,
   ProfileType,
   StageConfig,
   StageKind,
@@ -24,13 +19,15 @@ import {
 // ****************************************************************************
 // Experiment config
 // ****************************************************************************
+export const QUICKSTART_GROUP_CHAT_METADATA = createMetadataConfig({
+  name: 'Group Chat Experiment',
+  publicName: 'Group Chat',
+  description: 'Template experiment: group chat, no agents.',
+});
+
 export function getQuickstartGroupChatTemplate(): ExperimentTemplate {
   const stageConfigs = getStageConfigs(false);
-  const metadata = createMetadataConfig({
-    name: 'Group Chat Experiment',
-    publicName: 'Group Chat',
-    description: 'Template experiment: group chat, no agents.',
-  });
+  const metadata = QUICKSTART_GROUP_CHAT_METADATA;
 
   return createExperimentTemplate({
     experiment: createExperimentConfig(stageConfigs, {metadata}),
@@ -40,13 +37,15 @@ export function getQuickstartGroupChatTemplate(): ExperimentTemplate {
   });
 }
 
+export const QUICKSTART_AGENT_CHAT_METADATA = createMetadataConfig({
+  name: 'Mediated Group Chat Experiment',
+  publicName: 'Group Chat',
+  description: 'Template experiment with agent-mediated group chat',
+});
+
 export function getQuickstartAgentGroupChatTemplate(): ExperimentTemplate {
   const stageConfigs = getStageConfigs(true);
-  const metadata = createMetadataConfig({
-    name: 'Mediated Group Chat Experiment',
-    publicName: 'Group Chat',
-    description: 'Template experiment with agent-mediated group chat',
-  });
+  const metadata = QUICKSTART_AGENT_CHAT_METADATA;
 
   return createExperimentTemplate({
     experiment: createExperimentConfig(stageConfigs, {metadata}),

--- a/frontend/src/shared/templates/quickstart_private_chat.ts
+++ b/frontend/src/shared/templates/quickstart_private_chat.ts
@@ -1,9 +1,6 @@
 import {
-  createAgentChatSettings,
   createAgentMediatorPersonaConfig,
-  createAgentParticipantPersonaConfig,
   createChatPromptConfig,
-  createChatStage,
   createExperimentConfig,
   createExperimentTemplate,
   createMetadataConfig,
@@ -12,12 +9,8 @@ import {
   createProfileStage,
   createDefaultPromptFromText,
   AgentMediatorTemplate,
-  AgentParticipantTemplate,
-  AgentPersonaType,
   ExperimentTemplate,
   MediatorPromptConfig,
-  ParticipantPromptConfig,
-  ProfileType,
   StageConfig,
   StageKind,
 } from '@deliberation-lab/utils';
@@ -25,13 +18,15 @@ import {
 // ****************************************************************************
 // Experiment config
 // ****************************************************************************
+export const QUICKSTART_PRIVATE_CHAT_METADATA = createMetadataConfig({
+  name: 'Private Chat Experiment',
+  publicName: 'Private Chat',
+  description: 'Template experiment with private chat between user and agent',
+});
+
 export function getQuickstartPrivateChatTemplate(): ExperimentTemplate {
   const stageConfigs = getStageConfigs();
-  const metadata = createMetadataConfig({
-    name: 'Private Chat Experiment',
-    publicName: 'Private Chat',
-    description: 'Template experiment with private chat between user and agent',
-  });
+  const metadata = QUICKSTART_PRIVATE_CHAT_METADATA;
 
   return createExperimentTemplate({
     experiment: createExperimentConfig(stageConfigs, {metadata}),


### PR DESCRIPTION
## Description

Templates is now a modal that pops up and can be searched. And the templates route is different than experiments -- templates/new_template?template=09d020b3-7d01-42cc-a982-ef9455e5ec3d

[Example of templates.webm](https://github.com/user-attachments/assets/8f690c08-3427-48ce-bff8-a92b0755e529)


- [x] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

---
