### PR TITLE
Fix variable editor schema handling for multi-value configs.

### DIFF
--- a/utils/src/variables.ts
+++ b/utils/src/variables.ts
@@ -7,6 +7,19 @@ export type VariableConfig =
   | RandomPermutationVariableConfig
   | BalancedAssignmentVariableConfig;
 
+/**
+ * Union of config types that have multiple values to choose from or assign.
+ * These configs have a `values: string[]` array where each value
+ * represents one item from the pool.
+ *
+ * Note: This is a type union for type-checking, not a config to instantiate.
+ * The schema for these types is stored as Array(ItemType), but users
+ * work with individual items directly in the editor.
+ */
+export type MultiValueVariableConfigType =
+  | RandomPermutationVariableConfig
+  | BalancedAssignmentVariableConfig;
+
 export enum VariableScope {
   EXPERIMENT = 'experiment',
   COHORT = 'cohort',


### PR DESCRIPTION
Fix variable editor schema handling for multi-value configs (e.g. RANDOM_PERMUTATION, BALANCED_ASSIGNMENT)

### Problem

When editing BALANCED_ASSIGNMENT variables in the experiment builder:
1. Creating an "Array of Object" as a nested property would incorrectly collapse to just "Object"
2. The editor showed "Array items: X" instead of "Type: X" for the root item type, inconsistent with loaded templates
3. BALANCED_ASSIGNMENT wasn't handled the same as RANDOM_PERMUTATION for multi-value config operations

### Issue & fix
The core issue was in `updateSchemaAtPath`: when updating a property that was an array (e.g., `charities: Array(Object({}))`), and the path ended at that property, it replaced the entire property with the new schema instead of updating the array's items schema. This caused nested arrays to lose their `Array()` wrapper.

**Core fix in `updateSchemaAtPath`**: When the target property is an array and we're passing a non-array schema, preserve the `Array()` wrapper (we're updating items, not replacing the array). Only replace entirely when passing an array schema (type change).

### Other changes / improvements
**Unified multi-value config handling**: Added helper functions that handle the implicit root array wrapper for both RANDOM_PERMUTATION and BALANCED_ASSIGNMENT:
   - `isMultiValueConfig()` - type guard for configs with multiple values
   - `getItemSchemaIfArray()` - extracts item schema from array (DRY)
   - `updateSchemaForConfig()` - unwraps root array, updates, rewraps
   - `setValueForConfig()` - operates on item schema for value updates
   - `renamePropertyForConfig()` - operates on item schema for renames

3. **Consistent UI**: For multi-value configs at root, extract the item schema and show "Type: X" directly instead of "Array items: X". Uses `rootArrayUnwrapped` flag to prevent over-extraction for nested arrays.

### Limitations

Deeply nested arrays (3+ levels) may not update correctly because the path doesn't change when entering array items. A future fix could add `[]` notation to paths and handle it in `updateSchemaAtPath`.
