### PR TITLE
Improve experiment template ID handling by resetting on creation, validating updates, and using experiment ID for retrieval.

### DIFF
--- a/functions/src/experiment.endpoints.ts
+++ b/functions/src/experiment.endpoints.ts
@@ -64,6 +64,17 @@ export const updateExperiment = onCall(async (request) => {
   await AuthGuard.isExperimenter(request);
   const {data} = request;
 
+  // Validate input
+  const templateId =
+    data.experimentTemplate?.id || data.experimentTemplate?.experiment?.id;
+
+  if (!data.collectionName || !templateId) {
+    throw new HttpsError(
+      'invalid-argument',
+      'collectionName and experimentTemplate.id (or experiment.id) are required',
+    );
+  }
+
   const experimenterId = request.auth?.token.email?.toLowerCase() || '';
 
   // Use shared utility to update experiment
@@ -73,7 +84,7 @@ export const updateExperiment = onCall(async (request) => {
   const document = app
     .firestore()
     .collection(data.collectionName)
-    .doc(data.experimentTemplate.id);
+    .doc(templateId);
 
   // If experiment does not exist, return false
   const oldExperiment = await document.get();
@@ -212,7 +223,7 @@ export const getExperimentTemplate = onCall(async (request) => {
   }
 
   const template = createExperimentTemplate({
-    id: '',
+    id: data.experimentId,
     experiment,
   });
 


### PR DESCRIPTION
This should fix the updateExperiment issue we were facing earlier, as the experimentId can be in a different place than expected.
[edit profof.webm](https://github.com/user-attachments/assets/5ab632fa-7c81-472e-be33-a18a1839b5aa)

- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [ ] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
