### PR TITLE
Standardize and fix z-indexes to 10,20,30,40,50

### DIFF
--- a/frontend/src/components/experiment_builder/experiment_builder.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder.scss
@@ -26,7 +26,7 @@
   padding: 0 common.$sidenav-padding;
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
 }
 
 .sidenav-items {
@@ -113,7 +113,7 @@
   padding: 0 common.$main-content-padding;
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
 
   .left,
   .right {

--- a/frontend/src/components/experiment_builder/experiment_builder_nav.scss
+++ b/frontend/src/components/experiment_builder/experiment_builder_nav.scss
@@ -41,7 +41,7 @@
   padding: 0 common.$sidenav-padding;
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
 }
 
 .primary {

--- a/frontend/src/components/experiment_dashboard/cohort_summary.scss
+++ b/frontend/src/components/experiment_dashboard/cohort_summary.scss
@@ -20,7 +20,6 @@
   justify-content: space-between;
   padding: common.$spacing-medium common.$spacing-large;
   position: relative;
-  z-index: 2;
 
   &:focus,
   &:hover {

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -304,7 +304,7 @@ pr-button pr-icon {
   padding: common.$spacing-medium;
   position: fixed;
   right: common.$spacing-large;
-  z-index: 1000;
+  z-index: 40;
 
   .content {
     @include common.flex-row-align-center;

--- a/frontend/src/components/header/header.scss
+++ b/frontend/src/components/header/header.scss
@@ -7,7 +7,7 @@
   position: sticky;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 10;
 }
 
 .banner {

--- a/frontend/src/pair-components/menu.scss
+++ b/frontend/src/pair-components/menu.scss
@@ -19,7 +19,7 @@
   height: 0;
   overflow: hidden;
   width: 0;
-  z-index: 1;
+  z-index: 30;
 
   &.show-menu {
     overflow: visible;

--- a/frontend/src/pair-components/tooltip.css
+++ b/frontend/src/pair-components/tooltip.css
@@ -1,6 +1,6 @@
 /* Tooltip */
 :host {
-  --z-index: var(--pr-tooltip-z-index, 1);
+  --z-index: var(--pr-tooltip-z-index, 30);
   --anchor-display-mode: var(--pr-tooltip-display, inline-block);
 }
 

--- a/frontend/src/sass/_common.scss
+++ b/frontend/src/sass/_common.scss
@@ -199,7 +199,7 @@
   justify-content: center;
   padding: calc($main-content-padding * 2);
   position: absolute;
-  z-index: 2; // above app header
+  z-index: 20; // above app header
 }
 
 @mixin dialog {


### PR DESCRIPTION
## Description

Menus should be visible in the correct way

[fix z index.webm](https://github.com/user-attachments/assets/8347428b-7d8b-4fb5-9405-dbdf1af0f108)


- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---


## Verification
- [ ] *Screenshots or videos* included (if applicable)
- [ ] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
