### PR TITLE
Fix default field population when creating experiments via API.

### DIFF
--- a/scripts/deliberate_lab/client.py
+++ b/scripts/deliberate_lab/client.py
@@ -184,7 +184,9 @@ class Client:
 
         # Full template creation takes precedence
         if template is not None:
-            data["template"] = template.model_dump(by_alias=True, exclude_none=True)
+            data["template"] = template.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
         else:
             # Simple creation mode
             if name is None:
@@ -197,20 +199,21 @@ class Client:
             if stages is not None:
                 # Convert Pydantic models to dicts for JSON serialization
                 data["stages"] = [
-                    s.model_dump(by_alias=True, exclude_none=True) for s in stages
+                    s.model_dump(mode="json", by_alias=True, exclude_none=True)
+                    for s in stages
                 ]
             if prolific_config is not None:
                 data["prolificConfig"] = prolific_config.model_dump(
-                    by_alias=True, exclude_none=True
+                    mode="json", by_alias=True, exclude_none=True
                 )
             if agent_mediators is not None:
                 data["agentMediators"] = [
-                    a.model_dump(by_alias=True, exclude_none=True)
+                    a.model_dump(mode="json", by_alias=True, exclude_none=True)
                     for a in agent_mediators
                 ]
             if agent_participants is not None:
                 data["agentParticipants"] = [
-                    a.model_dump(by_alias=True, exclude_none=True)
+                    a.model_dump(mode="json", by_alias=True, exclude_none=True)
                     for a in agent_participants
                 ]
 
@@ -271,7 +274,9 @@ class Client:
 
         # Full template update takes precedence
         if template is not None:
-            data["template"] = template.model_dump(by_alias=True, exclude_none=True)
+            data["template"] = template.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
         else:
             # Partial update mode
             if name is not None:
@@ -280,20 +285,21 @@ class Client:
                 data["description"] = description
             if stages is not None:
                 data["stages"] = [
-                    s.model_dump(by_alias=True, exclude_none=True) for s in stages
+                    s.model_dump(mode="json", by_alias=True, exclude_none=True)
+                    for s in stages
                 ]
             if prolific_config is not None:
                 data["prolificConfig"] = prolific_config.model_dump(
-                    by_alias=True, exclude_none=True
+                    mode="json", by_alias=True, exclude_none=True
                 )
             if agent_mediators is not None:
                 data["agentMediators"] = [
-                    a.model_dump(by_alias=True, exclude_none=True)
+                    a.model_dump(mode="json", by_alias=True, exclude_none=True)
                     for a in agent_mediators
                 ]
             if agent_participants is not None:
                 data["agentParticipants"] = [
-                    a.model_dump(by_alias=True, exclude_none=True)
+                    a.model_dump(mode="json", by_alias=True, exclude_none=True)
                     for a in agent_participants
                 ]
 
@@ -435,7 +441,7 @@ class Client:
             data["description"] = description
         if participant_config is not None:
             data["participantConfig"] = participant_config.model_dump(
-                by_alias=True, exclude_none=True
+                mode="json", by_alias=True, exclude_none=True
             )
 
         response = self._session.post(
@@ -473,7 +479,7 @@ class Client:
             data["description"] = description
         if participant_config is not None:
             data["participantConfig"] = participant_config.model_dump(
-                by_alias=True, exclude_none=True
+                mode="json", by_alias=True, exclude_none=True
             )
 
         response = self._session.put(

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -96,12 +96,13 @@ export function createExperimentConfig(
   config: Partial<Experiment> = {},
 ): Experiment {
   return {
-    id: config.id ?? generateId(),
+    id: config.id || generateId(),
     versionId: EXPERIMENT_VERSION_ID,
     metadata: config.metadata ?? createMetadataConfig(),
     permissions: config.permissions ?? createPermissionsConfig(),
-    defaultCohortConfig:
-      config.defaultCohortConfig ?? createCohortParticipantConfig(),
+    defaultCohortConfig: createCohortParticipantConfig(
+      config.defaultCohortConfig,
+    ),
     prolificConfig: config.prolificConfig ?? createProlificConfig(),
     stageIds: stages.map((stage) => stage.id),
     cohortLockMap: config.cohortLockMap ?? {},
@@ -115,7 +116,7 @@ export function createExperimentTemplate(
   config: Partial<ExperimentTemplate>,
 ): ExperimentTemplate {
   return {
-    id: config.id ?? generateId(),
+    id: config.id || generateId(),
     experiment: config.experiment ?? createExperimentConfig(),
     stageConfigs: config.stageConfigs ?? [],
     agentMediators: config.agentMediators ?? [],


### PR DESCRIPTION
Fixes issues when creating experiments via the Python REST API. If certain fields weren't populated when creating an experiment via the API, the backend would not populate them with defaults, leading to errors. This happened automatically when creating things via the frontend, but not via the backend. Now passed parameters are merged with defaults as expected.

## Changes
- **`client.py`**: Added `mode="json"` to `model_dump()` calls to properly serialize enums
- **`utils/src/experiment.ts`**:
  - Changed `??` to `||` for ID generation (empty strings now trigger ID generation)
  - `defaultCohortConfig` now always merges with defaults via `createCohortParticipantConfig()`
- **`functions/src/experiment.utils.ts`**:
  - Set timestamps when creating or updating experiments (this happened automatically when updating from the frontend, but the backend did not independently do this if timestamps weren't set by the frontend).
  - Agent personas are merged with defaults via `createAgentMediatorPersonaConfig()` / `createAgentParticipantPersonaConfig()`
