### PR TITLE
fix: Remove extra set of Markdown triple backticks in run-locally.md.

### DIFF
--- a/docs/developers/run-locally.md
+++ b/docs/developers/run-locally.md
@@ -126,10 +126,8 @@ npx firebase login
 
 Finally, to run the emulators:
 ```bash
-```bash
 # Start the emulators and load the `emulator_test_config` settings
 npx firebase emulators:start --import ./emulator_test_config
-```
 ```
 
 > Note: The emulator test config sets up two profiles (experimenter@


### PR DESCRIPTION
Like #934, this PR removes an extra set of `bash` triple-backticks that otherwise breaks Markdown rendering.