### PR TITLE
More npm workflow helpers, get rid of Node v20 tests in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/docs/developers/run-locally.md
+++ b/docs/developers/run-locally.md
@@ -80,6 +80,15 @@ Then, install project dependencies once at the root directory:
 npm install
 ```
 
+> **Important:** This project uses [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces). Always run `npm install` from the repository root, not from subdirectories like `frontend/` or `functions/`.
+>
+> To add a package to a specific workspace:
+> ```bash
+> npm install <package-name> -w frontend   # Add to frontend/
+> npm install <package-name> -w functions  # Add to functions/
+> npm install <package-name> -w utils      # Add to utils/
+> ```
+
 ### 2. Build utils (needed for backend and frontend)
 
 NOTE: The `utils` directory builds as the package `@deliberation-lab/utils`,
@@ -158,6 +167,41 @@ npm run start
 Then, view the app at http://localhost:4201.
 
 ## Troubleshooting tips
+
+### Health check
+
+Run the doctor script to verify your setup:
+
+```bash
+npm run doctor
+```
+
+This checks Node.js version, dependencies, config files, and builds.
+
+### ENOTEMPTY or npm install errors
+
+If you see an error like `ENOTEMPTY: directory not empty` when running `npm install` or `npm ci`:
+
+```bash
+# From the root deliberate-lab directory
+# Delete node_modules and reinstall
+rm -rf node_modules frontend/node_modules functions/node_modules utils/node_modules
+npm cache clean --force
+npm ci
+```
+
+### Wrong Node.js version
+
+This project requires Node.js v22 or higher. If you see engine compatibility errors:
+
+```bash
+# Using nvm
+nvm install 22
+nvm use 22
+
+# Verify
+node -v  # Should show v22.x.x
+```
 
 ### Getting and using your Google Analytics ID
 * If you already own a Google Analytics ID, you can [find it via these instructions](https://support.google.com/analytics/answer/9539598?hl=en). 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "private": true,
   "scripts": {
+    "preinstall": "node -e \"if (process.env.INIT_CWD === process.cwd()) { console.error('\\n\\x1b[31mError: Run npm install from the repository root.\\x1b[0m\\nTo add a package to frontend/, run:\\n  npm install <pkg> -w frontend\\nfrom the root directory.\\n'); process.exit(1); }\"",
     "build": "NODE_OPTIONS='--loader ts-node/esm' webpack --mode development",
     "build:prod": "NODE_OPTIONS='--loader ts-node/esm' webpack --mode production",
     "serve": "NODE_OPTIONS='--loader ts-node/esm' webpack serve  --mode development",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "functions",
   "scripts": {
+    "preinstall": "node -e \"if (process.env.INIT_CWD === process.cwd()) { console.error('\\n\\x1b[31mError: Run npm install from the repository root.\\x1b[0m\\nTo add a package to functions/, run:\\n  npm install <pkg> -w functions\\nfrom the root directory.\\n'); process.exit(1); }\"",
     "lint": "eslint",
     "build": "node build.js",
     "build:watch": "node build.js --watch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,15 @@
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
         "typescript-eslint": "^8.52.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "frontend": {
       "name": "deliberate-lab",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/lit-mobx": "^2.2.2",
@@ -83,6 +87,7 @@
       }
     },
     "functions": {
+      "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.9",
         "@ai-sdk/google": "^3.0.6",
@@ -26278,6 +26283,7 @@
     "utils": {
       "name": "@deliberation-lab/utils",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "jsonrepair": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git+https://github.com/PAIR-code/deliberate-lab.git"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "eslint": "^9.39.2",
@@ -25,6 +28,7 @@
     ]
   },
   "scripts": {
+    "doctor": "node scripts/doctor.js",
     "prepare": "husky",
     "update-schemas": "npm run build --workspace=utils && npx tsx utils/src/export-schemas.ts && npx prettier --write docs/assets/api/schemas.json && cd scripts && uv run datamodel-codegen --input ../docs/assets/api/schemas.json --output deliberate_lab/types.py --input-file-type jsonschema --reuse-model --collapse-root-models --use-union-operator --use-title-as-name --use-one-literal-as-default --output-model-type pydantic_v2.BaseModel --custom-file-header '# pyright: reportInvalidTypeForm=false\n# pylint: disable=missing-module-docstring,missing-class-docstring,invalid-name,too-few-public-methods' && uv run black deliberate_lab/ && uv run pyright deliberate_lab/"
   },

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+/**
+ * Health check script for Deliberate Lab development environment.
+ * Run with: npm run doctor
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { execSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+
+let hasErrors = false;
+let hasWarnings = false;
+
+function success(msg) {
+  console.log(`\x1b[32m✓\x1b[0m ${msg}`);
+}
+
+function warning(msg) {
+  console.log(`\x1b[33m!\x1b[0m ${msg}`);
+  hasWarnings = true;
+}
+
+function error(msg) {
+  console.log(`\x1b[31m✗\x1b[0m ${msg}`);
+  hasErrors = true;
+}
+
+function header(msg) {
+  console.log(`\n\x1b[1m${msg}\x1b[0m`);
+}
+
+function prompt(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase().trim());
+    });
+  });
+}
+
+function fixNodeModules() {
+  const dirs = [
+    path.join(ROOT, 'node_modules'),
+    path.join(ROOT, 'frontend', 'node_modules'),
+    path.join(ROOT, 'functions', 'node_modules'),
+    path.join(ROOT, 'utils', 'node_modules'),
+  ];
+
+  for (const dir of dirs) {
+    if (fs.existsSync(dir)) {
+      console.log(`Deleting ${path.relative(ROOT, dir)}...`);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  console.log('Clearing npm cache...');
+  execSync('npm cache clean --force', { stdio: 'inherit' });
+
+  console.log('\nRunning npm ci...');
+  execSync('npm ci', { stdio: 'inherit', cwd: ROOT });
+}
+
+async function main() {
+  // Check Node version
+  header('Checking Node.js version...');
+  const nodeVersion = process.version;
+  const majorVersion = parseInt(nodeVersion.slice(1).split('.')[0], 10);
+  if (majorVersion >= 22) {
+    success(`Node.js ${nodeVersion} (>= 22 required)`);
+  } else {
+    error(`Node.js ${nodeVersion} - version 22 or higher required`);
+    console.log('  Run: nvm install 22 && nvm use 22');
+  }
+
+  // Check if running from root directory
+  header('Checking working directory...');
+  const cwd = process.cwd();
+  if (cwd === ROOT) {
+    success('Running from repository root');
+  } else {
+    warning(`Running from ${cwd}`);
+    console.log(`  Expected: ${ROOT}`);
+  }
+
+  // Check for node_modules
+  header('Checking dependencies...');
+  const rootNodeModules = path.join(ROOT, 'node_modules');
+  if (fs.existsSync(rootNodeModules)) {
+    success('Root node_modules exists');
+  } else {
+    error('Root node_modules missing');
+    console.log('  Run: npm ci');
+  }
+
+  // Check for required config files
+  header('Checking configuration files...');
+
+  const configFiles = [
+    {
+      path: '.firebaserc',
+      example: '.firebaserc.example',
+    },
+    {
+      path: 'frontend/firebase_config.ts',
+      example: 'frontend/firebase_config.example.ts',
+    },
+    {
+      path: 'frontend/index.html',
+      example: 'frontend/index.example.html',
+    },
+  ];
+
+  for (const { path: filePath, example } of configFiles) {
+    const fullPath = path.join(ROOT, filePath);
+    const examplePath = path.join(ROOT, example);
+    if (fs.existsSync(fullPath)) {
+      success(filePath);
+    } else if (fs.existsSync(examplePath)) {
+      warning(`${filePath} missing`);
+      console.log(`  Run: cp ${example} ${filePath}`);
+    } else {
+      warning(`${filePath} missing (no example found)`);
+    }
+  }
+
+  // Check for utils build
+  header('Checking builds...');
+  const utilsDist = path.join(ROOT, 'utils', 'dist');
+  if (fs.existsSync(utilsDist)) {
+    success('utils/dist exists');
+  } else {
+    warning('utils/dist missing');
+    console.log('  Run: npm run build -w utils');
+  }
+
+  const functionsLib = path.join(ROOT, 'functions', 'lib');
+  if (fs.existsSync(functionsLib)) {
+    success('functions/lib exists');
+  } else {
+    warning('functions/lib missing');
+    console.log('  Run: npm run build -w functions');
+  }
+
+  // Summary
+  header('Summary');
+  if (hasErrors) {
+    console.log('\x1b[31mThere are errors that must be fixed.\x1b[0m\n');
+
+    const answer = await prompt(
+      'Would you like to fix this by reinstalling dependencies? (y/n) '
+    );
+    if (answer === 'y' || answer === 'yes') {
+      console.log('');
+      fixNodeModules();
+      console.log('\n\x1b[32mDone!\x1b[0m\n');
+    }
+
+    process.exit(1);
+  } else if (hasWarnings) {
+    console.log('\x1b[33mThere are warnings you may want to address.\x1b[0m\n');
+    process.exit(0);
+  } else {
+    console.log('\x1b[32mEverything looks good!\x1b[0m\n');
+    process.exit(0);
+  }
+}
+
+main();

--- a/utils/package.json
+++ b/utils/package.json
@@ -6,6 +6,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
+    "preinstall": "node -e \"if (process.env.INIT_CWD === process.cwd()) { console.error('\\n\\x1b[31mError: Run npm install from the repository root.\\x1b[0m\\nTo add a package to utils/, run:\\n  npm install <pkg> -w utils\\nfrom the root directory.\\n'); process.exit(1); }\"",
     "declarations": "tsc --declaration --emitDeclarationOnly",
     "build": "tsup --onSuccess \"npm run declarations\"",
     "build:watch": "tsup --watch --onSuccess \"npm run declarations\"",


### PR DESCRIPTION
This PR makes it easier for new contributors to set up the project and diagnose common issues.

### Changes

**Prevent common mistakes:**
- Added `preinstall` scripts to `frontend/`, `functions/`, and `utils/` that block running `npm install` in subdirectories (must install from root dir)
- Added `.npmrc` with `engine-strict=true` to enforce Node.js 22+ requirement
- Added `engines` field to root `package.json` to specify Node.js 22+ requirement.

**New `npm run doctor` command:**
- Checks Node.js version, dependencies, config files, and builds
- Offers to fix issues by cleaning and reinstalling dependencies

**Improved `run_locally.sh`:**
- Checks Node.js version before running
- Prompts to install dependencies if `node_modules` is missing
- Retries with cleanup if `npm ci` fails (fixes ENOTEMPTY errors)
- Suggests `npm run doctor` if something goes wrong
- Reorganized with helper functions for readability

**Updated documentation:**
- Added npm workspaces explanation and `-w` flag examples
- Added troubleshooting section for ENOTEMPTY errors, wrong Node version
- Documented the new `npm run doctor` command

**CI:**
- Removed Node.js 20 from test matrix (now 22 only)
