### PR TITLE
Allow Agent Participants to correctly complete stages.

### DIFF
--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -159,7 +159,7 @@ export function createStructuredOutputConfig(
   };
   return {
     enabled: config.enabled ?? true,
-    type: config.type ?? StructuredOutputType.JSON_FORMAT,
+    type: config.type ?? StructuredOutputType.JSON_SCHEMA,
     schema: schema,
     appendToPrompt: config.appendToPrompt ?? true,
     shouldRespondField:


### PR DESCRIPTION
## Description

This issue was caused by using JSON_FORMAT instead of JSON_SCHEMA when creating the structuredoutput. JSON_FORMAT is older and makes the request in the prompt, while JSON_SCHEMA relies on actual structured output from the models. 

- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---
<img width="3430" height="1730" alt="image" src="https://github.com/user-attachments/assets/119ebd57-a27c-4e68-bc1c-abc8d30895d7" />

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [x] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #956
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
