### PR TITLE
Fix endless hanging chat messages.

### DIFF
--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -163,7 +163,7 @@ export async function createAgentChatMessageFromPrompt(
       );
       return false;
     }
-    sendAgentPrivateChatMessage(
+    await sendAgentPrivateChatMessage(
       experimentId,
       privateChatParticipantId,
       stageId,
@@ -172,7 +172,7 @@ export async function createAgentChatMessageFromPrompt(
       promptConfig.chatSettings,
     );
   } else {
-    sendAgentGroupChatMessage(
+    await sendAgentGroupChatMessage(
       experimentId,
       cohortId,
       stageId,
@@ -486,7 +486,7 @@ export async function sendAgentGroupChatMessage(
     }
 
     // Otherwise, log response ID as trigger message
-    triggerResponseDoc.set({});
+    await triggerResponseDoc.set({});
   }
 
   // Send chat message
@@ -502,7 +502,7 @@ export async function sendAgentGroupChatMessage(
     .doc(chatMessage.id);
 
   chatMessage.timestamp = Timestamp.now();
-  agentDocument.set(chatMessage);
+  await agentDocument.set(chatMessage);
 
   return true;
 }
@@ -558,7 +558,7 @@ export async function sendAgentPrivateChatMessage(
     }
 
     // Otherwise, log response ID as trigger message
-    triggerResponseDoc.set({});
+    await triggerResponseDoc.set({});
   }
 
   // Send chat message
@@ -574,7 +574,7 @@ export async function sendAgentPrivateChatMessage(
     .doc(chatMessage.id);
 
   chatMessage.timestamp = Timestamp.now();
-  agentDocument.set(chatMessage);
+  await agentDocument.set(chatMessage);
 
   return true;
 }

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -46,7 +46,7 @@ export async function sendErrorPrivateChatMessage(
     .collection('privateChats')
     .doc(chatMessage.id);
 
-  agentDocument.set(chatMessage);
+  await agentDocument.set(chatMessage);
 }
 
 /** Update participant answer ready to end private chat discussion. */


### PR DESCRIPTION
## Fix hanging spinner in private chat when waiting for agent response

### Problem
When `preventCancellation` (#966) is enabled and API retries occur, the chat spinner could get stuck indefinitely even after the backend successfully processed the response.

### Fix
- Added `await` to all Firestore write operations in the chat flow
- Added `runInAction()` wrappers to frontend Firestore listeners for proper MobX reactivity

### Files Changed
- `functions/src/chat/chat.agent.ts` - await send functions and Firestore writes
- `functions/src/chat/chat.utils.ts` - await error message write
- `frontend/src/services/participant.service.ts` - MobX reactivity fix
