### PR TITLE
Fix text CSS in markdown tables (follow global text styling)

### DIFF
--- a/frontend/src/sass/_common.scss
+++ b/frontend/src/sass/_common.scss
@@ -311,6 +311,20 @@
   a {
     color: var(--md-sys-color-primary);
   }
+  table {
+    border-collapse: collapse;
+    color: var(--md-sys-color-on-surface);
+  }
+  th,
+  td {
+    border: 1px solid var(--md-sys-color-outline-variant);
+    padding: $spacing-medium;
+    text-align: left;
+  }
+  th {
+    background-color: var(--md-sys-color-surface-container);
+    font-weight: 500;
+  }
 }
 
 @mixin viewport-medium {


### PR DESCRIPTION
Markdown table text was not respecting global text styling.