### PR TITLE
Add frontend deployment steps to Google Cloud Build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -414,9 +414,9 @@ steps:
   waitFor: ['TestFunctions']
   dir: '.'
 
-# Deploy Rules Step
+# Deploy Firestore Rules Step
 - name: 'node:22'
-  id: DeployFirebaseRules
+  id: DeployFirebaseFirestoreRules
   env:
     - 'DEPLOYMENT_TYPES=" all rules "'
   script: |
@@ -424,24 +424,88 @@ steps:
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
-        echo "Deploying Rules (Firestore, Database)..."
+        echo "Deploying Firestore Rules..."
         npx firebase deploy \
           --config=firebase-prod.json \
-          --only firestore:rules,database:rules,storage \
+          --only firestore:rules \
           --project ${PROJECT_ID} \
           --non-interactive \
           --force
       else
-        echo "Dry-run: Deploying Rules (Firestore, Database)..."
+        echo "Dry-run: Deploying Firestore Rules..."
         npx firebase deploy \
           --config=firebase-prod.json \
-          --only firestore:rules,database:rules,storage \
+          --only firestore:rules \
           --project ${PROJECT_ID} \
           --non-interactive \
           --dry-run
       fi
     else
-      echo "Skipping Firebase rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
+      echo "Skipping Firestore rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['TestFunctions']
+  dir: '.'
+
+# Deploy Database Rules Step
+- name: 'node:22'
+  id: DeployFirebaseDatabaseRules
+  env:
+    - 'DEPLOYMENT_TYPES=" all rules "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        echo "Deploying Database Rules..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only database:rules \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --force
+      else
+        echo "Dry-run: Deploying Database Rules..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only database:rules \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --dry-run
+      fi
+    else
+      echo "Skipping Database rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['TestFunctions']
+  dir: '.'
+
+# Deploy Storage Rules Step
+- name: 'node:22'
+  id: DeployFirebaseStorageRules
+  env:
+    - 'DEPLOYMENT_TYPES=" all rules "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        echo "Deploying Storage Rules..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only storage \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --force
+      else
+        echo "Dry-run: Deploying Storage Rules..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only storage \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --dry-run
+      fi
+    else
+      echo "Skipping Storage rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['TestFunctions']
   dir: '.'
@@ -530,5 +594,7 @@ steps:
     - 'BuildProdFrontend'
     - 'DeployFirebaseFunctions'
     - 'DeployFirebaseIndexes'
-    - 'DeployFirebaseRules'
+    - 'DeployFirebaseFirestoreRules'
+    - 'DeployFirebaseDatabaseRules'
+    - 'DeployFirebaseStorageRules'
   dir: '.'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# cloudbuild.yaml for Deliberate Lab Backend Deployments
+# cloudbuild.yaml for Deliberate Lab Deployments
 #
 # This build config supports multiple deployment types controlled by the
 # substitution variable `_DEPLOYMENT_TYPE`.
@@ -8,7 +8,7 @@
 #
 # Allowed Values for `_DEPLOYMENT_TYPE`:
 #   - test:
-#       Runs linting, formatting checks, and unit tests for utils and functions.
+#       Runs linting, formatting checks, and unit tests for all workspaces.
 #       Does NOT deploy anything.
 #   - functions:
 #       Runs validation (lint/test) and builds the project.
@@ -18,12 +18,23 @@
 #   - indexes:
 #       Deploys Firestore indexes.
 #       Includes a safety mechanism to backup existing indexes before deploying.
+#   - frontend:
+#       Runs validation (lint/test) and builds the project.
+#       Deploys Cloud App Engine frontend.
 #   - all:
 #       Runs the full pipeline: validation, build, test, and deployment of
-#       functions, rules, and indexes.
+#       functions, rules, indexes and frontend.
 
 substitutions:
-  _DEPLOYMENT_TYPE: '' # Default value, MUST be overridden by trigger.
+  _DEPLOYMENT_TYPE: ''       # Default value, MUST be overridden by trigger.
+  # Frontend configuration.
+  _FIREBASE_APP_ID: ''       # Unique Firebase application id. 
+  _FIREBASE_API_KEY: ''      # API key frontend will use to connect to Firebase.
+  _FIREBASE_AUTH_DOMAIN: ''  # Domain from which Firebase client may connect.
+  _PROJECT_ID: ''            # Unique Firebase/Cloud project id.
+  _STORAGE_BUCKET: ''        # Default Cloud Storage bucket name.
+  _MESSAGING_SENDER_ID: ''   # Firebase Cloud Messaging sender id.
+  _MEASUREMENT_ID: ''        # Google Analytics id.
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -34,19 +45,35 @@ steps:
 - name: 'node:22'
   id: ValidateSubstitutionValues
   env:
-    - 'DEPLOYMENT_TYPES=" all functions indexes rules test "'
+    - 'DEPLOYMENT_TYPES=" all frontend functions indexes rules test "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ -z "${_DEPLOYMENT_TYPE}" ]]; then
-       echo "Validation Failed: '_DEPLOYMENT_TYPE' Substitution Value MUST be specified"
-       exit 1
+      echo "Validation Failed: '_DEPLOYMENT_TYPE' Substitution Value MUST be specified"
+      exit 1
     fi
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-       echo "Validation Passed: '${_DEPLOYMENT_TYPE}' is in list: [${DEPLOYMENT_TYPES}]"
+      echo "Validation Passed: '${_DEPLOYMENT_TYPE}' is in list: [${DEPLOYMENT_TYPES}]"
     else
-       echo "Validation Failed: '${_DEPLOYMENT_TYPE}' is not in list: [${DEPLOYMENT_TYPES}]"
-       exit 1
+      echo "Validation Failed: '${_DEPLOYMENT_TYPE}' is not in list: [${DEPLOYMENT_TYPES}]"
+      exit 1
+    fi
+    if [[ " all frontend " == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      MISSING_VARS=""
+      if [[ -z "${_FIREBASE_APP_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_APP_ID"; fi
+      if [[ -z "${_FIREBASE_API_KEY}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_API_KEY"; fi
+      if [[ -z "${_FIREBASE_AUTH_DOMAIN}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_AUTH_DOMAIN"; fi
+      if [[ -z "${_PROJECT_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _PROJECT_ID"; fi
+      if [[ -z "${_STORAGE_BUCKET}" ]]; then MISSING_VARS="${MISSING_VARS} _STORAGE_BUCKET"; fi
+      if [[ -z "${_MESSAGING_SENDER_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _MESSAGING_SENDER_ID"; fi
+      if [[ -z "${_MEASUREMENT_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _MEASUREMENT_ID"; fi
+
+      if [[ -n "${MISSING_VARS}" ]]; then
+        echo "Validation Failed: The following substitution values are missing for '${_DEPLOYMENT_TYPE}' deployment:${MISSING_VARS}"
+        exit 1
+      fi
+      echo "Validation Passed: All Frontend configuration values are present."
     fi
   dir: '.'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -174,20 +174,56 @@ steps:
   waitFor: ['PrepareFirebaseProdConfig']
   dir: '.'
 
-# Lint & Format Check
+# Lint & Format Check Utils
 - name: 'node:22'
-  id: LintCheck
+  id: LintUtils
   env:
     - 'DEPLOYMENT_TYPES=" all frontend functions test "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      echo "Running Lint/Format Check..."
-      npx prettier --check "**/*.ts"
-      npx eslint --quiet "**/*.ts"
+      echo "Running Utils Lint/Format utils..."
+      npx prettier --check "utils/**/*.ts"
+      npx eslint --quiet "utils/**/*.ts"
     else
-      echo "Skipping Lint/Format Check for '${_DEPLOYMENT_TYPE}' deployment."
+      echo "Skipping Utils Lint/Format Check for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['NpmCI']
+  dir: '.'
+
+# Lint & Format Check Functions
+- name: 'node:22'
+  id: LintFunctions
+  env:
+    - 'DEPLOYMENT_TYPES=" all functions test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Running Functions Lint/Format utils..."
+      npx prettier --check "functions/**/*.ts"
+      npx eslint --quiet "functions/**/*.ts"
+    else
+      echo "Skipping Functions Lint/Format Check for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['NpmCI']
+  dir: '.'
+
+# Lint & Format Check Frontend
+- name: 'node:22'
+  id: LintFrontend
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Running Frontend Lint/Format utils..."
+      npx prettier --check "frontend/**/*.ts"
+      npx eslint --quiet "frontend/**/*.ts"
+    else
+      echo "Skipping Frontend Lint/Format Check for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['NpmCI']
   dir: '.'
@@ -206,7 +242,7 @@ steps:
     else
       echo "Skipping Build Utils for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['LintCheck']
+  waitFor: ['LintUtils']
   dir: '.'
 
 # Build Functions Workspace
@@ -223,7 +259,7 @@ steps:
     else
       echo "Skipping Build Functions for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['BuildUtils']
+  waitFor: ['LintFunctions','BuildUtils']
   dir: '.'
 
 # Build Frontend Workspace (Development Mode)
@@ -244,7 +280,7 @@ steps:
     else
       echo "Skipping Build frontend for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['BuildUtils']
+  waitFor: ['LintFrontend','BuildUtils']
   dir: '.'
 
 # Run Utils Tests

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -282,6 +282,16 @@ steps:
       echo "Generating firebase_config.ts from substitution variables..."
       echo "import {FirebaseOptions} from 'firebase/app';" > ./frontend/firebase_config.ts
       echo "export const FIREBASE_CONFIG: FirebaseOptions = ${_FIREBASE_CONFIG};" >> ./frontend/firebase_config.ts
+
+      echo "Extracting MEASUREMENT_ID for Webpack..."
+      export MEASUREMENT_ID=$(
+        echo "${_FIREBASE_CONFIG}" | \
+        node -p 'JSON.parse(require("fs").readFileSync(0)).measurementId'
+      )
+
+      echo "Preparing index.html from index.example.html..."
+      cp ./frontend/index.example.html ./frontend/index.html
+
       echo "Building frontend workspace for production..."
       npm run build:prod --workspace=frontend
     else

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -126,7 +126,9 @@ steps:
   dir: '.'
 
 # Install Java 21 for Firebase Emulators
-- name: 'node:22'
+# NOTE: The image used here doesn't matter here for the step itself. Using the
+# Cloud SDK image warms the cache for the DeployFrontend step.
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   id: InstallJava
   env:
     - 'DEPLOYMENT_TYPES=" all functions test "'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -194,19 +194,19 @@ steps:
   waitFor: ['BuildUtils']
   dir: '.'
 
-# Build Frontend Workspace
+# Build Frontend Workspace (Development Mode)
 - name: 'node:22'
-  id: BuildFrontend
+  id: BuildDevFrontend
   env:
     - 'DEPLOYMENT_TYPES=" all frontend test "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      echo "Building frontend workspace..."
+      echo "Building frontend workspace in development mode..."
       npm run build --workspace=frontend
     else
-      echo "Skipping Build Frontend for '${_DEPLOYMENT_TYPE}' deployment."
+      echo "Skipping Build frontend for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['BuildUtils']
   dir: '.'
@@ -256,12 +256,29 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      echo "Running Frontend Tests..."
+      echo "Running Frontend tests against dev build..."
       npm test --workspace=frontend
     else
       echo "Skipping Frontend tests for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['BuildUtils']
+  waitFor: ['BuildDevFrontend']
+  dir: '.'
+
+# Build Frontend Workspace (Production mode)
+- name: 'node:22'
+  id: BuildProdFrontend
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Building frontend workspace for production..."
+      npm run build:prod --workspace=frontend
+    else
+      echo "Skipping Build Frontend for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['TestFrontend'] # Must be finished using dev build.
   dir: '.'
 
 # Deploy Functions Step

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -203,6 +203,8 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Copying example Firebase config..."
+      cp ./frontend/firebase_config.example.ts ./frontend/firebase_config.ts
       echo "Building frontend workspace in development mode..."
       npm run build --workspace=frontend
     else
@@ -268,11 +270,24 @@ steps:
 - name: 'node:22'
   id: BuildProdFrontend
   env:
-    - 'DEPLOYMENT_TYPES=" all frontend test "'
+    - 'DEPLOYMENT_TYPES=" all frontend "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Generating firebase_config.ts from substitution variables..."
+      cat <<EOF > ./frontend/firebase_config.ts
+    import {FirebaseOptions} from 'firebase/app';
+    export const FIREBASE_CONFIG: FirebaseOptions = {
+      apiKey: '${_FIREBASE_API_KEY}',
+      authDomain: '${_FIREBASE_AUTH_DOMAIN}',
+      projectId: '${_PROJECT_ID}',
+      storageBucket: '${_STORAGE_BUCKET}',
+      messagingSenderId: '${_MESSAGING_SENDER_ID}',
+      appId: '${_FIREBASE_APP_ID}',
+      measurementId: '${_MEASUREMENT_ID}',
+    };
+    EOF
       echo "Building frontend workspace for production..."
       npm run build:prod --workspace=frontend
     else

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -209,6 +209,8 @@ steps:
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Copying example Firebase config..."
       cp ./frontend/firebase_config.example.ts ./frontend/firebase_config.ts
+      echo "Copying index.example.html to index.html..."
+      cp ./frontend/index.example.html ./frontend/index.html
       echo "Building frontend workspace in development mode..."
       npm run build --workspace=frontend
     else
@@ -289,7 +291,7 @@ steps:
         node -p 'JSON.parse(require("fs").readFileSync(0)).measurementId'
       )
 
-      echo "Preparing index.html from index.example.html..."
+      echo "Copying index.example.html to index.html..."
       cp ./frontend/index.example.html ./frontend/index.html
 
       echo "Building frontend workspace for production..."

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -419,7 +419,7 @@ steps:
   dir: '.'
 
 # Deploy Frontend
-- name: 'node:22'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   id: DeployFrontend
   env:
     - 'DEPLOYMENT_TYPES=" all frontend "'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,6 +24,17 @@ substitutions:
   #       functions, rules, indexes and frontend.
   _DEPLOYMENT_TYPE: ''
 
+  # Gatekeeper boolean. Commands with external effects will ONLY be performed if
+  # `_DEPLOY` is set to "true".
+  # Allowed values:
+  #   - true:
+  #       Potentially destructive commands like `firebase deploy` (without
+  #       `--dry-run`) and `gcloud app deploy` WILL be executed.
+  #   - false:
+  #       Destructive commands WILL NOT be run. Alternative safe commands may be
+  #       run instead, such as `firebase deploy --dry-run`.
+  _DEPLOY: 'false'
+
   # When `_DEPLOYMENT_TYPE` is 'all' or 'frontend', this value MUST also be set
   # to a JSON string containing an object of the form:
   #
@@ -74,6 +85,10 @@ steps:
       echo "Validation Passed: '${_DEPLOYMENT_TYPE}' is in list: [${DEPLOYMENT_TYPES}]"
     else
       echo "Validation Failed: '${_DEPLOYMENT_TYPE}' is not in list: [${DEPLOYMENT_TYPES}]"
+      exit 1
+    fi
+    if [[ "${_DEPLOY}" != "true" && "${_DEPLOY}" != "false" ]]; then
+      echo "Validation Failed: '_DEPLOY' must be strictly 'true' or 'false'. Got: '${_DEPLOY}'"
       exit 1
     fi
     if [[ " all frontend " == *" ${_DEPLOYMENT_TYPE} "* ]]; then
@@ -376,13 +391,23 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      echo "Deploying Functions..."
-      npx firebase deploy \
-        --config=firebase-prod.json \
-        --only functions \
-        --project ${PROJECT_ID} \
-        --non-interactive \
-        --force
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        echo "Deploying Functions..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only functions \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --force
+      else
+        echo "Dry-run: Deploying Functions..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only functions \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --dry-run
+      fi
     else
       echo "Skipping backend deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
@@ -398,13 +423,23 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      echo "Deploying Rules (Firestore, Database)..."
-      npx firebase deploy \
-        --config=firebase-prod.json \
-        --only firestore:rules,database:rules,storage \
-        --project ${PROJECT_ID} \
-        --non-interactive \
-        --force
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        echo "Deploying Rules (Firestore, Database)..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only firestore:rules,database:rules,storage \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --force
+      else
+        echo "Dry-run: Deploying Rules (Firestore, Database)..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only firestore:rules,database:rules,storage \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --dry-run
+      fi
     else
       echo "Skipping Firebase rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
@@ -428,23 +463,35 @@ steps:
       cat existing_firestore_indexes.json
       echo "--- EXISTING FIRESTORE INDEXES BACKUP: END ---"
 
-      echo "Deploying Firestore Indexes..."
-      npx firebase deploy \
-        --config=firebase-prod.json \
-        --only firestore:indexes \
-        --project ${PROJECT_ID} \
-        --non-interactive \
-        --force
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        echo "Deploying Firestore Indexes..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only firestore:indexes \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --force
 
-      echo "Fetching deployed production indexes..."
-      npx firebase firestore:indexes --project ${PROJECT_ID} > deployed_firestore_indexes.json
-      
-      if cmp -s "existing_firestore_indexes.json" "deployed_firestore_indexes.json"; then
-        echo "Deployed Firestore Indexes match existing (no change)."
+        echo "Fetching deployed production indexes..."
+        npx firebase firestore:indexes --project ${PROJECT_ID} > deployed_firestore_indexes.json
+        
+        if cmp -s "existing_firestore_indexes.json" "deployed_firestore_indexes.json"; then
+          echo "Deployed Firestore Indexes match existing (no change)."
+        else
+          echo "--- DEPLOYED FIRESTORE INDEXES BACKUP: START ---"
+          cat deployed_firestore_indexes.json
+          echo "--- DEPLOYED FIRESTORE INDEXES BACKUP: END ---"
+        fi
       else
-        echo "--- DEPLOYED FIRESTORE INDEXES BACKUP: START ---"
-        cat deployed_firestore_indexes.json
-        echo "--- DEPLOYED FIRESTORE INDEXES BACKUP: END ---"
+        echo "Dry-run: Deploying Firestore Indexes..."
+        npx firebase deploy \
+          --config=firebase-prod.json \
+          --only firestore:indexes \
+          --project ${PROJECT_ID} \
+          --non-interactive \
+          --dry-run
+
+        echo "Skipping post-deploy verification in dry-run mode."
       fi
 
     else
@@ -462,14 +509,20 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      APP_DEPLOY_FLAGS="--no-promote"
-      if [[ "${_AUTO_PROMOTE}" == "true" ]]; then
-        echo "Auto-promotion enabled."
-        APP_DEPLOY_FLAGS=""
+      if [[ "${_DEPLOY}" == "true" ]]; then
+        APP_DEPLOY_FLAGS="--no-promote"
+        if [[ "${_AUTO_PROMOTE}" == "true" ]]; then
+          echo "Auto-promotion enabled."
+          APP_DEPLOY_FLAGS=""
+        else
+          echo "Auto-promotion disabled."
+        fi
+        (cd ./frontend && gcloud app deploy ./app.yaml ${APP_DEPLOY_FLAGS})
       else
-        echo "Auto-promotion disabled."
+        echo "Dry-run: Skipping Frontend deploy."
+        echo "Verifying App Engine state..."
+        gcloud app describe
       fi
-      (cd ./frontend && gcloud app deploy ./app.yaml ${APP_DEPLOY_FLAGS})
     else
       echo "Skipping Frontend deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,15 +26,8 @@
 #       functions, rules, indexes and frontend.
 
 substitutions:
-  _DEPLOYMENT_TYPE: ''       # Default value, MUST be overridden by trigger.
-  # Frontend configuration.
-  _FIREBASE_APP_ID: ''       # Unique Firebase application id. 
-  _FIREBASE_API_KEY: ''      # API key frontend will use to connect to Firebase.
-  _FIREBASE_AUTH_DOMAIN: ''  # Domain from which Firebase client may connect.
-  _PROJECT_ID: ''            # Unique Firebase/Cloud project id.
-  _STORAGE_BUCKET: ''        # Default Cloud Storage bucket name.
-  _MESSAGING_SENDER_ID: ''   # Firebase Cloud Messaging sender id.
-  _MEASUREMENT_ID: ''        # Google Analytics id.
+  _DEPLOYMENT_TYPE: '' # MUST be overridden by trigger.
+  _FIREBASE_CONFIG: '' # JSON used to create ./frontend/firebase_config.ts. 
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -61,18 +54,29 @@ steps:
     fi
     if [[ " all frontend " == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       MISSING_VARS=""
-      if [[ -z "${_FIREBASE_APP_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_APP_ID"; fi
-      if [[ -z "${_FIREBASE_API_KEY}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_API_KEY"; fi
-      if [[ -z "${_FIREBASE_AUTH_DOMAIN}" ]]; then MISSING_VARS="${MISSING_VARS} _FIREBASE_AUTH_DOMAIN"; fi
-      if [[ -z "${_PROJECT_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _PROJECT_ID"; fi
-      if [[ -z "${_STORAGE_BUCKET}" ]]; then MISSING_VARS="${MISSING_VARS} _STORAGE_BUCKET"; fi
-      if [[ -z "${_MESSAGING_SENDER_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _MESSAGING_SENDER_ID"; fi
-      if [[ -z "${_MEASUREMENT_ID}" ]]; then MISSING_VARS="${MISSING_VARS} _MEASUREMENT_ID"; fi
-
-      if [[ -n "${MISSING_VARS}" ]]; then
-        echo "Validation Failed: The following substitution values are missing for '${_DEPLOYMENT_TYPE}' deployment:${MISSING_VARS}"
+      if [[ -z "${_FIREBASE_CONFIG}" ]]; then
+        echo "Validation Failed: '_FIREBASE_CONFIG' missing for '${_DEPLOYMENT_TYPE}' deployment"
         exit 1
       fi
+      echo "${_FIREBASE_CONFIG}" | \
+        node -e '
+          const config = JSON.parse(require("fs").readFileSync(0, "utf-8"));
+          if (typeof config !== "object") throw new Error("Config must be an object");
+          const missingFields = [
+            "apiKey",
+            "appId",
+            "authDomain",
+            "measurementId",
+            "messagingSenderId",
+            "projectId",
+            "storageBucket",
+          ].filter((field) =>
+            !config[field] || typeof config[field] !== "string"
+          );
+          if (missingFields.length) {
+            throw new Error(`Missing required fields: ${missingFields}`);
+          }
+        '
       echo "Validation Passed: All Frontend configuration values are present."
     fi
   dir: '.'
@@ -276,18 +280,8 @@ steps:
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Generating firebase_config.ts from substitution variables..."
-      cat <<EOF > ./frontend/firebase_config.ts
-    import {FirebaseOptions} from 'firebase/app';
-    export const FIREBASE_CONFIG: FirebaseOptions = {
-      apiKey: '${_FIREBASE_API_KEY}',
-      authDomain: '${_FIREBASE_AUTH_DOMAIN}',
-      projectId: '${_PROJECT_ID}',
-      storageBucket: '${_STORAGE_BUCKET}',
-      messagingSenderId: '${_MESSAGING_SENDER_ID}',
-      appId: '${_FIREBASE_APP_ID}',
-      measurementId: '${_MEASUREMENT_ID}',
-    };
-    EOF
+      echo "import {FirebaseOptions} from 'firebase/app';" > ./frontend/firebase_config.ts
+      echo "export const FIREBASE_CONFIG: FirebaseOptions = ${_FIREBASE_CONFIG};" >> ./frontend/firebase_config.ts
       echo "Building frontend workspace for production..."
       npm run build:prod --workspace=frontend
     else

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,33 +1,57 @@
 # cloudbuild.yaml for Deliberate Lab Deployments
 #
 # This build config supports multiple deployment types controlled by the
-# substitution variable `_DEPLOYMENT_TYPE`.
-#
-# Usage:
-#   This variable MUST be specified in the build trigger.
-#
-# Allowed Values for `_DEPLOYMENT_TYPE`:
-#   - test:
-#       Runs linting, formatting checks, and unit tests for all workspaces.
-#       Does NOT deploy anything.
-#   - functions:
-#       Runs validation (lint/test) and builds the project.
-#       Deploys Cloud Functions.
-#   - rules:
-#       Deploys security rules for Firestore and Realtime Database.
-#   - indexes:
-#       Deploys Firestore indexes.
-#       Includes a safety mechanism to backup existing indexes before deploying.
-#   - frontend:
-#       Runs validation (lint/test) and builds the project.
-#       Deploys Cloud App Engine frontend.
-#   - all:
-#       Runs the full pipeline: validation, build, test, and deployment of
-#       functions, rules, indexes and frontend.
+# required substitution variable `_DEPLOYMENT_TYPE`.
 
 substitutions:
-  _DEPLOYMENT_TYPE: '' # MUST be overridden by trigger.
-  _FIREBASE_CONFIG: '' # JSON used to create ./frontend/firebase_config.ts. 
+  # MUST be specified in the build trigger. Allowed values:
+  #   - test:
+  #       Runs linting, formatting checks, and unit tests for all workspaces.
+  #       Does NOT deploy anything.
+  #   - functions:
+  #       Runs validation (lint/test) and builds the project.
+  #       Deploys Cloud Functions.
+  #   - rules:
+  #       Deploys security rules for Firestore and Realtime Database.
+  #   - indexes:
+  #       Deploys Firestore indexes. Includes a safety mechanism to backup
+  #       existing indexes before deploying.
+  #   - frontend:
+  #       Runs validation (lint/test) and builds the project.
+  #       Deploys Cloud App Engine frontend.
+  #   - all:
+  #       Runs the full pipeline: validation, build, test, and deployment of
+  #       functions, rules, indexes and frontend.
+  _DEPLOYMENT_TYPE: ''
+
+  # When `_DEPLOYMENT_TYPE` is 'all' or 'frontend', this value MUST also be set
+  # to a JSON string containing an object of the form:
+  #
+  # ```json
+  # {
+  #   "apiKey": "...",
+  #   "appId": "...",
+  #   "authDomain": "...",
+  #   "measurementId": "...",
+  #   "messagingSenderId": "...",
+  #   "projectId": "...",
+  #   "storageBucket": "..."
+  # }
+  # ```
+  #
+  # See https://firebase.google.com/docs/reference/js/app.firebaseoptions
+  _FIREBASE_CONFIG: ''
+
+  # When deploying the frontend, this substitution value determines whether
+  # traffic will automatically be migrated over to the newly deployed frontend.
+  # Allowed values:
+  #   - true:
+  #       The `gcloud app deploy` command will run WITHOUT `--no-promote`.
+  #       Traffic WILL auto-migrate to the newly deployed frontend.
+  #   - false (default):
+  #       The `gcloud app deploy` command will run WITH `--no-promote`. Traffic 
+  #       WILL NOT be directed to the newly deployed frontend automatically.
+  _AUTO_PROMOTE: 'false'
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -53,6 +77,11 @@ steps:
       exit 1
     fi
     if [[ " all frontend " == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      if [[ "${_AUTO_PROMOTE}" != "true" && "${_AUTO_PROMOTE}" != "false" ]]; then
+        echo "Validation Failed: '_AUTO_PROMOTE' must be strictly 'true' or 'false'. Got: '${_AUTO_PROMOTE}'"
+        exit 1
+      fi
+
       MISSING_VARS=""
       if [[ -z "${_FIREBASE_CONFIG}" ]]; then
         echo "Validation Failed: '_FIREBASE_CONFIG' missing for '${_DEPLOYMENT_TYPE}' deployment"
@@ -299,7 +328,8 @@ steps:
     else
       echo "Skipping Build Frontend for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['TestFrontend'] # Must be finished using dev build.
+  waitFor:
+    - 'TestFrontend'  # MUST be finished using dev build's firebase_config.ts.
   dir: '.'
 
 # Deploy Functions Step
@@ -386,4 +416,31 @@ steps:
       echo "Skipping Firebase indexes deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['TestFunctions']
+  dir: '.'
+
+# Deploy Frontend
+- name: 'node:22'
+  id: DeployFrontend
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      APP_DEPLOY_FLAGS="--no-promote"
+      if [[ "${_AUTO_PROMOTE}" == "true" ]]; then
+        echo "Auto-promotion enabled."
+        APP_DEPLOY_FLAGS=""
+      else
+        echo "Auto-promotion disabled."
+      fi
+      (cd ./frontend && gcloud app deploy ./app.yaml ${APP_DEPLOY_FLAGS})
+    else
+      echo "Skipping Frontend deploy for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor:
+    - 'BuildProdFrontend'
+    - 'DeployFirebaseFunctions'
+    - 'DeployFirebaseIndexes'
+    - 'DeployFirebaseRules'
   dir: '.'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -164,7 +164,7 @@ steps:
 - name: 'node:22'
   id: BuildUtils
   env:
-    - 'DEPLOYMENT_TYPES=" all functions test "'
+    - 'DEPLOYMENT_TYPES=" all frontend functions test "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -194,7 +194,41 @@ steps:
   waitFor: ['BuildUtils']
   dir: '.'
 
-# Run Tests
+# Build Frontend Workspace
+- name: 'node:22'
+  id: BuildFrontend
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Building frontend workspace..."
+      npm run build --workspace=frontend
+    else
+      echo "Skipping Build Frontend for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['BuildUtils']
+  dir: '.'
+
+# Run Utils Tests
+- name: 'node:22'
+  id: TestUtils
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend functions test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Running Utils tests..."
+      npm test --workspace=utils
+    else
+      echo "Skipping Utils tests for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['BuildUtils']
+  dir: '.'
+
+# Run Functions Tests
 - name: 'node:22'
   id: TestFunctions
   env:
@@ -205,13 +239,29 @@ steps:
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       export JAVA_HOME=$(pwd)/java-runtime
       export PATH=$JAVA_HOME/bin:$PATH
-      echo "Running Backend Tests..."
-      npm test --workspace=utils
+      echo "Running Firebase Functions Tests..."
       npm test --workspace=functions
     else
-      echo "Skipping Tests for '${_DEPLOYMENT_TYPE}' deployment."
+      echo "Skipping Functions tests for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['BuildFunctions', 'InstallJava']
+  dir: '.'
+
+# Run Frontend Tests
+- name: 'node:22'
+  id: TestFrontend
+  env:
+    - 'DEPLOYMENT_TYPES=" all frontend test "'
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+      echo "Running Frontend Tests..."
+      npm test --workspace=frontend
+    else
+      echo "Skipping Frontend tests for '${_DEPLOYMENT_TYPE}' deployment."
+    fi
+  waitFor: ['BuildUtils']
   dir: '.'
 
 # Deploy Functions Step

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -178,15 +178,14 @@ steps:
 - name: 'node:22'
   id: LintCheck
   env:
-    - 'DEPLOYMENT_TYPES=" all functions test "'
+    - 'DEPLOYMENT_TYPES=" all frontend functions test "'
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Lint/Format Check..."
-      # Scoped to backend directories to avoid blocking on frontend issues
-      npx prettier --check "functions/**/*.ts" "utils/**/*.ts"
-      npx eslint --quiet "functions/**/*.ts" "utils/**/*.ts"
+      npx prettier --check "**/*.ts"
+      npx eslint --quiet "**/*.ts"
     else
       echo "Skipping Lint/Format Check for '${_DEPLOYMENT_TYPE}' deployment."
     fi

--- a/frontend/index.example.html
+++ b/frontend/index.example.html
@@ -1,34 +1,42 @@
 <html>
-
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Deliberate Lab</title>
-  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet" />
-  <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" />
-  <% if (process.env.NODE_ENV==='production' ) { %>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deliberate Lab</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons&display=block"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+    />
+    <% if (process.env.NODE_ENV==='production' ) { %>
     <script>
       function addAnalyticsScript() {
         // Create a new script element
         var gaScript = document.createElement('script');
 
         // Set the script source (replace with your actual gtag.js URL)
-        // TODO: Replace 'your-google-analytics-id' with real ID
-        gaScript.src = `https://www.googletagmanager.com/gtag/js?id='your-google-analytics-id'`;
+        gaScript.src = `https://www.googletagmanager.com/gtag/js?id=<%= analyticsId %>`;
         gaScript.async = true;
 
         // Create a script element for the config code
         var configScript = document.createElement('script');
 
-        // TODO: Replace 'your-google-analytics-id' with real ID
         configScript.textContent = `
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', 'your-google-analytics-id');
+          gtag('config', '<%= analyticsId %>');
         `;
         // Append the scripts to the head of the document
         document.head.appendChild(gaScript);
@@ -38,59 +46,58 @@
       addAnalyticsScript();
     </script>
     <% } %>
-      <style>
-        body {
-          margin: 0;
-        }
+    <style>
+      body {
+        margin: 0;
+      }
 
-        .noscript {
-          align-items: center;
-          background: #eee;
-          box-sizing: border-box;
-          color: #222;
-          display: flex;
-          flex-direction: column;
-          font-family: 'Inter', Helvetica, sans-serif;
-          font-size: 16px;
-          height: 100%;
-          line-height: 22px;
-          margin: 0;
-          padding: 24px;
-        }
+      .noscript {
+        align-items: center;
+        background: #eee;
+        box-sizing: border-box;
+        color: #222;
+        display: flex;
+        flex-direction: column;
+        font-family: 'Inter', Helvetica, sans-serif;
+        font-size: 16px;
+        height: 100%;
+        line-height: 22px;
+        margin: 0;
+        padding: 24px;
+      }
 
-        .noscript section {
-          background: #fff;
-          border-radius: 8px;
-          color: #222;
-          display: flex;
-          flex-direction: column;
-          gap: 8px;
-          padding: 16px;
-        }
+      .noscript section {
+        background: #fff;
+        border-radius: 8px;
+        color: #222;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 16px;
+      }
 
-        .noscript h1 {
-          font-size: 22px;
-          font-weight: 500;
-          line-height: 28px;
-          margin: 0;
-        }
+      .noscript h1 {
+        font-size: 22px;
+        font-weight: 500;
+        line-height: 28px;
+        margin: 0;
+      }
 
-        .noscript p {
-          margin: 0;
-        }
-      </style>
-</head>
+      .noscript p {
+        margin: 0;
+      }
+    </style>
+  </head>
 
-<body>
-  <noscript class="noscript">
-    <section>
-      <h1>🕊️ JavaScript required</h1>
-      <p>
-        Welcome to Deliberate Lab! You'll need to enable JavaScript
-        to use this app.
-      </p>
-    </section>
-  </noscript>
-</body>
-
+  <body>
+    <noscript class="noscript">
+      <section>
+        <h1>🕊️ JavaScript required</h1>
+        <p>
+          Welcome to Deliberate Lab! You'll need to enable JavaScript to use
+          this app.
+        </p>
+      </section>
+    </noscript>
+  </body>
 </html>

--- a/frontend/index.example.html
+++ b/frontend/index.example.html
@@ -40,6 +40,9 @@
         `;
         // Append the scripts to the head of the document
         document.head.appendChild(gaScript);
+        document.head.appendChild(configScript);
+      }
+      // Comment out if not tracking analytics
       addAnalyticsScript();
     </script>
     <% } %>

--- a/frontend/index.example.html
+++ b/frontend/index.example.html
@@ -40,9 +40,6 @@
         `;
         // Append the scripts to the head of the document
         document.head.appendChild(gaScript);
-        document.head.appendChild(configScript);
-      }
-      // Comment out if not tracking analytics
       addAnalyticsScript();
     </script>
     <% } %>

--- a/frontend/webpack.config.mts
+++ b/frontend/webpack.config.mts
@@ -76,6 +76,9 @@ export default (
         favicon: './favicon.png',
         // Prepend an optional prefix path to the base URL of referenced assets in index.html
         base: process.env.URL_PREFIX ?? '/',
+        templateParameters: {
+          analyticsId: process.env.MEASUREMENT_ID || 'your-google-analytics-id',
+        },
       }),
       new webpack.DefinePlugin({
         'process.env.URL_PREFIX': process.env.URL_PREFIX ?? "'/'",


### PR DESCRIPTION
Adds Deliberate Lab frontend to Google Cloud Build config (`cloudbuild.yaml`), including:

* Substitution values needed by the frontend
* Validation of substitution values
* Performing frontend unit tests
* Build frontend
* Deploy to Google Cloud App Engine