### PR TITLE
fix: Use TestAgentPromptConfig type

### DIFF
--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -1038,7 +1038,7 @@ export class ExperimentManager extends Service {
   /** Test given agent config. */
   async testAgentConfig(
     agentConfig: AgentPersonaConfig,
-    promptConfig: BaseAgentPromptConfig,
+    promptConfig: TestAgentPromptConfig,
   ): Promise<ModelResponse> {
     const creatorId = this.sp.authService.experimenterData?.email;
     if (!creatorId) {


### PR DESCRIPTION
Update `testAgentConfig()` method to use `TestAgentPromptConfig` type.