### PR TITLE
Add codelab for experiment creation using the Deliberate Lab API

### DIFF
--- a/docs/developers/experiment-api-codelab.md
+++ b/docs/developers/experiment-api-codelab.md
@@ -247,16 +247,16 @@ Export all experiment data including participant responses:
 # Export full experiment data
 data = client.export_experiment(experiment_id)
 
-# Access exported structure
+# Access exported structure (uses Map format)
 experiment = data["experiment"]
-stages = data["stages"]
-cohorts = data["cohorts"]
-participants = data["participants"]
+stage_map = data["stageMap"]
+cohort_map = data["cohortMap"]
+participant_map = data["participantMap"]
 
 print(f"Experiment: {experiment['metadata']['name']}")
-print(f"Stages: {len(stages)}")
-print(f"Cohorts: {len(cohorts)}")
-print(f"Total participants: {len(participants)}")
+print(f"Stages: {len(stage_map)}")
+print(f"Cohorts: {len(cohort_map)}")
+print(f"Total participants: {len(participant_map)}")
 
 # Save to file
 import json

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -627,6 +627,7 @@ class ChatStageConfig(BaseModel):
     name: str
     descriptions: Any
     progress: Any
+    discussions: list[Any] = []  # Required for cohort creation
     timeLimitInMinutes: float | None = None
     requireFullTime: bool | None = None
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes introduced by this PR. -->

- [x] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed.


I gave my API key to gemini and let it run through the codelab and it successfully generated 
<img width="315" height="98" alt="image" src="https://github.com/user-attachments/assets/c62287dd-f363-44f1-9875-87e4c0677414" />

---

## Related issues

1005  -- added a default discussions [] field for the API.
---
