### PR TITLE
Move memory defaults to app.ts instead of index.ts.

### DIFF
--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -1,5 +1,12 @@
 import {StageManager} from '@deliberation-lab/utils';
 import * as admin from 'firebase-admin';
+import {setGlobalOptions} from 'firebase-functions/v2';
+
+// Set global options before any function definitions.
+// This MUST be in this file (not index.ts) because the bundler resolves
+// dependency modules before executing index.ts top-level code.
+// Since all endpoint files import app.ts, this runs before any onCall() calls.
+setGlobalOptions({memory: '512MiB'});
 
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,9 +3,6 @@
  * All cloud functions are defined in their own files and imported here.
  */
 
-import {setGlobalOptions} from 'firebase-functions/v2';
-setGlobalOptions({memory: '512MiB'});
-
 // Endpoints called from frontend
 export * from './admin.endpoints';
 export * from './alert.endpoints';


### PR DESCRIPTION
setGlobalOptions in index.ts  (from #973) ran after all onCall() functions were already defined because esbuild evaluates dependency modules before entry point code. This moves setGlobalOptions to app.ts, which is imported by all endpoint files, ensuring it executes before any function definitions. 