### PR TITLE
Add links to new codelab.

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -26,6 +26,8 @@
     url: /developers/deploy
   - title: API Reference
     url: /developers/api
+  - title: "Codelab: Create Experiment via API"
+    url: /developers/experiment-api-codelab
 - title: Feature Docs
   pages:
   - title: Variables

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -52,6 +52,8 @@ experiments = client.list_experiments()
 data = client.export_experiment("experiment-id")
 ```
 
+> **New to the API?** Check out the [Create a Demo Experiment Codelab](./experiment-api-codelab.md) for a hands-on tutorial.
+
 ## API Reference
 
 <div id="swagger-ui"></div>


### PR DESCRIPTION
## Description
Add links to new codelab in the API.md as well as the nav bar.

- [x] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Related issues

---
