### PR TITLE
Allow balanced assignment in ConditionAutoTransfer if multiple cohorts match

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1526,6 +1526,9 @@
           "items": {
             "$ref": "#/$defs/TransferGroup"
           }
+        },
+        "enableGroupBalancing": {
+          "type": "boolean"
         }
       }
     },

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -1235,6 +1235,7 @@ class ConditionAutoTransferConfig(BaseModel):
     type: Literal["condition"] = "condition"
     autoCohortParticipantConfig: CohortParticipantConfig
     transferGroups: Annotated[list[TransferGroup], Field(min_length=1)]
+    enableGroupBalancing: bool | None = None
 
 
 class TransferGroup(BaseModel):

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -99,6 +99,10 @@ export interface ConditionAutoTransferConfig extends BaseAutoTransferConfig {
   type: AutoTransferType.CONDITION;
   // Transfer groups evaluated in order - participant joins first matching group
   transferGroups: TransferGroup[];
+  // When true, if multiple groups are ready for a participant, pick the group
+  // whose target cohort has the fewest participants (balanced assignment).
+  // When false (default), first matching ready group wins.
+  enableGroupBalancing?: boolean;
 }
 
 // ************************************************************************* //
@@ -182,5 +186,6 @@ export function createConditionAutoTransferConfig(
     autoCohortParticipantConfig:
       config.autoCohortParticipantConfig ?? createCohortParticipantConfig(),
     transferGroups: config.transferGroups,
+    enableGroupBalancing: config.enableGroupBalancing ?? false,
   };
 }

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -66,6 +66,7 @@ export const ConditionAutoTransferConfigSchema = Type.Object(
     type: Type.Literal(AutoTransferType.CONDITION),
     autoCohortParticipantConfig: CohortParticipantConfigSchema,
     transferGroups: Type.Array(TransferGroupSchema, {minItems: 1}),
+    enableGroupBalancing: Type.Optional(Type.Boolean()),
   },
   {...strict, $id: 'ConditionAutoTransferConfig'},
 );


### PR DESCRIPTION
Added `enableGroupBalancing` option to `ConditionAutoTransferConfig` in the transfer stage. When enabled, participants matching multiple transfer groups with the same condition are balanced across target cohorts instead of always being assigned to the first matching group.

## Motivation
In experiments with multiple cohort variants sharing the same eligibility condition (e.g., two cohorts with the same variable values, except in different order), the default first-match-wins behavior sends all participants to the first group. `enableGroupBalancing` distributes participants evenly by selecting the group whose target cohort has the fewest participants. This is sort of a hack, but useful nonetheless, as the default behavior may be undesirable in some cases.

## Changes

### `utils/src/stages/transfer_stage.ts`
- Added `enableGroupBalancing?: boolean` to `ConditionAutoTransferConfig` interface (defaults to `false`)
- Updated `createConditionAutoTransferConfig` factory to pass through the field

### `functions/src/participant.utils.ts`
- Modified `handleConditionAutoTransfer` group selection logic:
  - When `enableGroupBalancing` is `false` (default): unchanged first-match-wins behavior
  - When `enableGroupBalancing` is `true`: collects all ready groups, fetches target cohort sizes, and picks the group with the fewest participants (first match as tiebreaker)

### `functions/src/cohort_definitions.integration.test.ts`
- Added two integration tests:
  1. Balanced mode: 4 participants across 2 groups with identical conditions yields 2+2 distribution
  2. Default mode: same setup without flag yields 4+0 (all to first group)
