### PR TITLE
Fix issue where reads & writes were interleaved for stage data migration

### DIFF
--- a/functions/src/participant.utils.test.ts
+++ b/functions/src/participant.utils.test.ts
@@ -1,0 +1,17 @@
+import {STAGE_KIND_REQUIRES_TRANSFER_MIGRATION} from '@deliberation-lab/utils';
+import {TRANSFER_MIGRATION_HANDLERS} from './participant.utils';
+
+describe('TRANSFER_MIGRATION_HANDLERS', () => {
+  it('should have a handler for every stage kind that requires transfer migration', () => {
+    const kindsRequiringMigration = Object.entries(
+      STAGE_KIND_REQUIRES_TRANSFER_MIGRATION,
+    )
+      .filter(([, required]) => required)
+      .map(([kind]) => kind)
+      .sort();
+
+    const kindsWithHandlers = Object.keys(TRANSFER_MIGRATION_HANDLERS).sort();
+
+    expect(kindsWithHandlers).toEqual(kindsRequiringMigration);
+  });
+});

--- a/utils/src/stages/stage.test.ts
+++ b/utils/src/stages/stage.test.ts
@@ -1,0 +1,9 @@
+import {STAGE_KIND_REQUIRES_TRANSFER_MIGRATION, StageKind} from './stage';
+
+describe('STAGE_KIND_REQUIRES_TRANSFER_MIGRATION', () => {
+  it('should have an entry for every StageKind', () => {
+    const allKinds = Object.values(StageKind);
+    const mappedKinds = Object.keys(STAGE_KIND_REQUIRES_TRANSFER_MIGRATION);
+    expect(mappedKinds.sort()).toEqual(allKinds.sort());
+  });
+});

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -194,6 +194,47 @@ export type StagePublicData =
   | MultiAssetAllocationStagePublicData
   | SurveyStagePublicData;
 
+/**
+ * Exhaustive map from every StageKind to whether its participant-keyed public
+ * data should be migrated when a participant transfers cohorts.
+ *
+ * When adding a new StageKind, you MUST add an entry here — TypeScript will
+ * error otherwise. Set to `true` if the stage has participant-keyed public data
+ * that is portable across cohorts (e.g., survey answers, rankings). Set to
+ * `false` if the stage has no public data, or its participant-keyed data is
+ * contextual to the cohort (e.g., chat discussion timestamps, game state).
+ * If `true`, a migration handler must also exist in
+ * functions/src/participant.utils.ts (enforced at compile time).
+ */
+export const STAGE_KIND_REQUIRES_TRANSFER_MIGRATION: Record<
+  StageKind,
+  boolean
+> = {
+  [StageKind.SURVEY]: true,
+  [StageKind.CHIP]: true,
+  [StageKind.RANKING]: true,
+  [StageKind.ASSET_ALLOCATION]: true,
+  [StageKind.MULTI_ASSET_ALLOCATION]: true,
+  [StageKind.FLIPCARD]: true,
+  [StageKind.ROLE]: true,
+  // Has participant-keyed public data, but contextual to the cohort's
+  // discussions — not portable across cohorts.
+  [StageKind.CHAT]: false,
+  // Has participant-keyed public data (move responses), but contextual
+  // to the cohort's game session — not portable across cohorts.
+  [StageKind.SALESPERSON]: false,
+  [StageKind.COMPREHENSION]: false,
+  [StageKind.INFO]: false,
+  [StageKind.PAYOUT]: false,
+  [StageKind.PRIVATE_CHAT]: false,
+  [StageKind.PROFILE]: false,
+  [StageKind.REVEAL]: false,
+  [StageKind.STOCKINFO]: false,
+  [StageKind.SURVEY_PER_PARTICIPANT]: false,
+  [StageKind.TOS]: false,
+  [StageKind.TRANSFER]: false,
+};
+
 /** Stage context data (used for assembling prompts). */
 export interface StageContextData {
   stage: StageConfig;


### PR DESCRIPTION
## Fix cohort trasnfer stage data migration issue
`migrateParticipantStageData` was interleaving `transaction.get()` and `transaction.set()` in a loop, causing "Firestore transactions require all reads to be executed before all writes" errors when transferring participants between cohorts with multiple stage types. This is fixed by first batching all reads first via `Promise.all`, then applying all writes.

## Add Stage transfer migration registry
-  Added `STAGE_KIND_REQUIRES_TRANSFER_MIGRATION` exhaustive registry (`Record<StageKind, boolean>`) so adding a new `StageKind` without deciding on migration behavior is a compile error (this was not the source of the problem, but is nice to have as a check). 
- Added tests verifying the registry covers all `StageKind` values and that every `true` entry has a corresponding migration handler