### PR TITLE
Show participant number for anonymous_animal, add informal name formatting

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1450,10 +1450,6 @@
               "type": "string"
             }
           ]
-        },
-        "showParticipantNumber": {
-          "default": true,
-          "type": "boolean"
         }
       }
     },

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1452,6 +1452,7 @@
           ]
         },
         "showParticipantNumber": {
+          "default": true,
           "type": "boolean"
         }
       }

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1450,6 +1450,9 @@
               "type": "string"
             }
           ]
+        },
+        "showParticipantNumber": {
+          "type": "boolean"
         }
       }
     },

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1450,6 +1450,10 @@
               "type": "string"
             }
           ]
+        },
+        "informalNameStyle": {
+          "default": false,
+          "type": "boolean"
         }
       }
     },

--- a/frontend/src/components/stages/profile_stage_editor.scss
+++ b/frontend/src/components/stages/profile_stage_editor.scss
@@ -7,25 +7,27 @@
   height: 100%;
 }
 
+.profile-option {
+  @include common.flex-row-align-center;
+  cursor: pointer;
+  gap: common.$spacing-small;
+}
+
+.divider {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.title {
+  @include typescale.title-medium;
+  color: var(--md-sys-color-secondary);
+}
+
 .checkbox-wrapper {
   @include common.flex-row-align-center;
-  gap: common.$spacing-medium;
+  cursor: pointer;
+  gap: common.$spacing-small;
 }
 
 md-checkbox {
   flex-shrink: 0;
-}
-
-.profile-options {
-  @include common.flex-column;
-  gap: common.$spacing-medium;
-}
-
-.profile-option {
-  @include common.flex-row-align-center;
-  gap: common.$spacing-small;
-
-  label {
-    cursor: pointer;
-  }
 }

--- a/frontend/src/components/stages/profile_stage_editor.ts
+++ b/frontend/src/components/stages/profile_stage_editor.ts
@@ -1,5 +1,4 @@
 import '../../pair-components/textarea';
-import '@material/web/checkbox/checkbox.js';
 import '@material/web/radio/radio';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -96,29 +95,6 @@ export class ProfileStageEditorComponent extends MobxLitElement {
           ></md-radio>
           <label>🐱 Generate anonymous animal-themed profiles</label>
         </div>
-        ${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL
-          ? html`
-              <label class="checkbox-wrapper">
-                <md-checkbox
-                  touch-target="wrapper"
-                  ?checked=${this.stage.showParticipantNumber}
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @click=${() => {
-                    if (!this.stage) return;
-                    this.experimentEditor.updateStage({
-                      ...this.stage,
-                      showParticipantNumber: !this.stage.showParticipantNumber,
-                    });
-                  }}
-                >
-                </md-checkbox>
-                <span
-                  >Include numeric ID in name (e.g., Bear 1002 instead of
-                  Bear)</span
-                >
-              </label>
-            `
-          : nothing}
         <div class="profile-option">
           <md-radio
             name="profile-type"

--- a/frontend/src/components/stages/profile_stage_editor.ts
+++ b/frontend/src/components/stages/profile_stage_editor.ts
@@ -1,4 +1,5 @@
 import '../../pair-components/textarea';
+import '@material/web/checkbox/checkbox.js';
 import '@material/web/radio/radio';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -95,6 +96,29 @@ export class ProfileStageEditorComponent extends MobxLitElement {
           ></md-radio>
           <label>🐱 Generate anonymous animal-themed profiles</label>
         </div>
+        ${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL
+          ? html`
+              <label class="checkbox-wrapper">
+                <md-checkbox
+                  touch-target="wrapper"
+                  ?checked=${this.stage.informalNameStyle}
+                  ?disabled=${!this.experimentEditor.canEditStages}
+                  @click=${() => {
+                    if (!this.stage) return;
+                    this.experimentEditor.updateStage({
+                      ...this.stage,
+                      informalNameStyle: !this.stage.informalNameStyle,
+                    });
+                  }}
+                >
+                </md-checkbox>
+                <span
+                  >Use informal name style (e.g., bear123 instead of Bear
+                  1002)</span
+                >
+              </label>
+            `
+          : nothing}
         <div class="profile-option">
           <md-radio
             name="profile-type"

--- a/frontend/src/components/stages/profile_stage_editor.ts
+++ b/frontend/src/components/stages/profile_stage_editor.ts
@@ -62,79 +62,78 @@ export class ProfileStageEditorComponent extends MobxLitElement {
       });
     };
 
+    const isAnonymous =
+      this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL ||
+      this.stage.profileType === ProfileType.ANONYMOUS_PARTICIPANT;
+
     return html`
-      <div class="profile-options">
-        <div class="profile-option">
-          <md-radio
-            name="profile-type"
-            value="default"
-            ?checked=${this.stage.profileType === ProfileType.DEFAULT}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @change=${() => handleProfileTypeChange(ProfileType.DEFAULT)}
-          ></md-radio>
-          <label>Let participants set their own profiles</label>
-        </div>
-        <div class="profile-option">
-          <md-radio
-            name="profile-type"
-            value="default-gendered"
-            ?checked=${this.stage.profileType === ProfileType.DEFAULT_GENDERED}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @change=${() =>
-              handleProfileTypeChange(ProfileType.DEFAULT_GENDERED)}
-          ></md-radio>
-          <label>Let participants choose from the default gendered set</label>
-        </div>
-        <div class="profile-option">
-          <md-radio
-            name="profile-type"
-            value="animal"
-            ?checked=${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @change=${() =>
-              handleProfileTypeChange(ProfileType.ANONYMOUS_ANIMAL)}
-          ></md-radio>
-          <label>🐱 Generate anonymous animal-themed profiles</label>
-        </div>
-        ${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL
-          ? html`
-              <label class="checkbox-wrapper">
-                <md-checkbox
-                  touch-target="wrapper"
-                  ?checked=${this.stage.informalNameStyle}
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @click=${() => {
-                    if (!this.stage) return;
-                    this.experimentEditor.updateStage({
-                      ...this.stage,
-                      informalNameStyle: !this.stage.informalNameStyle,
-                    });
-                  }}
-                >
-                </md-checkbox>
-                <span
-                  >Use informal name style (e.g., bear123 instead of Bear
-                  1002)</span
-                >
-              </label>
-            `
-          : nothing}
-        <div class="profile-option">
-          <md-radio
-            name="profile-type"
-            value="participant"
-            ?checked=${this.stage.profileType ===
-            ProfileType.ANONYMOUS_PARTICIPANT}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @change=${() =>
-              handleProfileTypeChange(ProfileType.ANONYMOUS_PARTICIPANT)}
-          ></md-radio>
-          <label
-            >👤 Generate anonymous participant profiles (Participant 1, 2,
-            ...)</label
-          >
-        </div>
-      </div>
+      <div class="title">Participant-created profiles</div>
+      <label class="profile-option">
+        <md-radio
+          name="profile-type"
+          value="default"
+          ?checked=${this.stage.profileType === ProfileType.DEFAULT}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @change=${() => handleProfileTypeChange(ProfileType.DEFAULT)}
+        ></md-radio>
+        Let participants set their own profiles
+      </label>
+      <label class="profile-option">
+        <md-radio
+          name="profile-type"
+          value="default-gendered"
+          ?checked=${this.stage.profileType === ProfileType.DEFAULT_GENDERED}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @change=${() => handleProfileTypeChange(ProfileType.DEFAULT_GENDERED)}
+        ></md-radio>
+        Let participants choose from the default gendered set
+      </label>
+      <div class="divider"></div>
+      <div class="title">Anonymous profiles</div>
+      <label class="profile-option">
+        <md-radio
+          name="profile-type"
+          value="animal"
+          ?checked=${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @change=${() => handleProfileTypeChange(ProfileType.ANONYMOUS_ANIMAL)}
+        ></md-radio>
+        🐱 Generate anonymous animal-themed profiles
+      </label>
+      <label class="profile-option">
+        <md-radio
+          name="profile-type"
+          value="participant"
+          ?checked=${this.stage.profileType ===
+          ProfileType.ANONYMOUS_PARTICIPANT}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @change=${() =>
+            handleProfileTypeChange(ProfileType.ANONYMOUS_PARTICIPANT)}
+        ></md-radio>
+        👤 Generate anonymous participant profiles (Participant 1, 2, ...)
+      </label>
+      ${isAnonymous
+        ? html`
+            <label class="checkbox-wrapper">
+              <md-checkbox
+                touch-target="wrapper"
+                ?checked=${this.stage.informalNameStyle}
+                ?disabled=${!this.experimentEditor.canEditStages}
+                @click=${() => {
+                  if (!this.stage) return;
+                  this.experimentEditor.updateStage({
+                    ...this.stage,
+                    informalNameStyle: !this.stage.informalNameStyle,
+                  });
+                }}
+              >
+              </md-checkbox>
+              <span
+                >Use informal name style (e.g., bear123 or participant123)</span
+              >
+            </label>
+          `
+        : nothing}
     `;
   }
 }

--- a/frontend/src/components/stages/profile_stage_editor.ts
+++ b/frontend/src/components/stages/profile_stage_editor.ts
@@ -1,4 +1,5 @@
 import '../../pair-components/textarea';
+import '@material/web/checkbox/checkbox.js';
 import '@material/web/radio/radio';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -8,11 +9,7 @@ import {customElement, property} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
 
-import {
-  ProfileType,
-  ProfileStageConfig,
-  StageKind,
-} from '@deliberation-lab/utils';
+import {ProfileType, ProfileStageConfig} from '@deliberation-lab/utils';
 
 import {styles} from './profile_stage_editor.scss';
 
@@ -99,6 +96,29 @@ export class ProfileStageEditorComponent extends MobxLitElement {
           ></md-radio>
           <label>🐱 Generate anonymous animal-themed profiles</label>
         </div>
+        ${this.stage.profileType === ProfileType.ANONYMOUS_ANIMAL
+          ? html`
+              <label class="checkbox-wrapper">
+                <md-checkbox
+                  touch-target="wrapper"
+                  ?checked=${this.stage.showParticipantNumber}
+                  ?disabled=${!this.experimentEditor.canEditStages}
+                  @click=${() => {
+                    if (!this.stage) return;
+                    this.experimentEditor.updateStage({
+                      ...this.stage,
+                      showParticipantNumber: !this.stage.showParticipantNumber,
+                    });
+                  }}
+                >
+                </md-checkbox>
+                <span
+                  >Include numeric ID in name (e.g., Bear 1002 instead of
+                  Bear)</span
+                >
+              </label>
+            `
+          : nothing}
         <div class="profile-option">
           <md-radio
             name="profile-type"

--- a/frontend/src/shared/templates/quickstart_private_chat.ts
+++ b/frontend/src/shared/templates/quickstart_private_chat.ts
@@ -46,7 +46,7 @@ const CHAT_STAGE_ID = 'chat';
 function getStageConfigs(): StageConfig[] {
   const stages: StageConfig[] = [];
   stages.push(
-    createProfileStage(),
+    createProfileStage({profileType: ProfileType.ANONYMOUS_ANIMAL}),
     createPrivateChatStage({
       id: CHAT_STAGE_ID,
       name: 'Private chat with agent',

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -140,16 +140,8 @@ export const createParticipant = onCall(async (request) => {
       ) as ProfileStageConfig | undefined;
       const profileType =
         profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
-      const showParticipantNumber =
-        profileStage?.showParticipantNumber ?? false;
 
-      setProfile(
-        numParticipants,
-        participantConfig,
-        true,
-        profileType,
-        showParticipantNumber,
-      );
+      setProfile(numParticipants, participantConfig, true, profileType);
     } else {
       setProfile(numParticipants, participantConfig, false);
     }

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -140,8 +140,15 @@ export const createParticipant = onCall(async (request) => {
       ) as ProfileStageConfig | undefined;
       const profileType =
         profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
+      const informalNameStyle = profileStage?.informalNameStyle ?? false;
 
-      setProfile(numParticipants, participantConfig, true, profileType);
+      setProfile(
+        numParticipants,
+        participantConfig,
+        true,
+        profileType,
+        informalNameStyle,
+      );
     } else {
       setProfile(numParticipants, participantConfig, false);
     }

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -140,8 +140,16 @@ export const createParticipant = onCall(async (request) => {
       ) as ProfileStageConfig | undefined;
       const profileType =
         profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
+      const showParticipantNumber =
+        profileStage?.showParticipantNumber ?? false;
 
-      setProfile(numParticipants, participantConfig, true, profileType);
+      setProfile(
+        numParticipants,
+        participantConfig,
+        true,
+        profileType,
+        showParticipantNumber,
+      );
     } else {
       setProfile(numParticipants, participantConfig, false);
     }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -391,6 +391,7 @@ class ProfileStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     profileType: ProfileType
+    showParticipantNumber: bool | None = None
 
 
 class Strategy(StrEnum):

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -391,7 +391,6 @@ class ProfileStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     profileType: ProfileType
-    showParticipantNumber: bool | None = True
 
 
 class Strategy(StrEnum):

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -391,6 +391,7 @@ class ProfileStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     profileType: ProfileType
+    informalNameStyle: bool | None = False
 
 
 class Strategy(StrEnum):

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -391,7 +391,7 @@ class ProfileStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     profileType: ProfileType
-    showParticipantNumber: bool | None = None
+    showParticipantNumber: bool | None = True
 
 
 class Strategy(StrEnum):

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -192,15 +192,19 @@ export function setProfile(
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
 ) {
+  // Generate random number for unique participant ID
+  const randomNumber = Math.floor(Math.random() * 10000);
+
   const generateProfileFromSet = (
     profileSet: {name: string; avatar: string}[],
+    repeat?: number,
   ): AnonymousProfileMetadata => {
     // TODO: Randomly select from set
     const {name, avatar} = profileSet[participantNumber % profileSet.length];
     return {
-      name,
+      name: `${name} ${randomNumber}`,
       avatar,
-      repeat: Math.floor(participantNumber / profileSet.length),
+      repeat: repeat ?? Math.floor(participantNumber / profileSet.length),
     };
   };
 
@@ -212,27 +216,14 @@ export function setProfile(
     };
   };
 
-  // Generate random number for unique participant ID (used in publicID and anonymous participant profile)
-  const randomNumber = Math.floor(Math.random() * 10000);
-
-  const generateAnonymousParticipantProfile = (): AnonymousProfileMetadata => {
-    return {
-      name: `Participant ${randomNumber}`,
-      avatar: '👤',
-      repeat: 0,
-    };
-  };
-
   // Set anonymous profiles
   const profileAnimal1 = generateProfileFromSet(PROFILE_SET_ANIMALS_1);
   const profileAnimal2 = generateProfileFromSet(PROFILE_SET_ANIMALS_2);
   const profileNature = generateProfileFromSet(PROFILE_SET_NATURE);
-  const profileAnonymousParticipant = generateAnonymousParticipantProfile();
-
-  // Append random number to profile names (e.g., "Bear 1002")
-  profileAnimal1.name = `${profileAnimal1.name} ${randomNumber}`;
-  profileAnimal2.name = `${profileAnimal2.name} ${randomNumber}`;
-  profileNature.name = `${profileNature.name} ${randomNumber}`;
+  const profileAnonymousParticipant = generateProfileFromSet(
+    [{name: 'Participant', avatar: '👤'}],
+    0,
+  );
 
   config.anonymousProfiles[PROFILE_SET_ANIMALS_1_ID] = profileAnimal1;
   config.anonymousProfiles[PROFILE_SET_ANIMALS_2_ID] = profileAnimal2;
@@ -248,26 +239,25 @@ export function setProfile(
   config.anonymousProfiles[PROFILE_SET_RANDOM_3_ID] =
     generateRandomHashProfile();
 
-  // Define public ID (using anonymous animal 1 set)
-  const mainProfile = profileAnimal1;
+  // Define public ID (using base animal name without number)
+  const baseName =
+    PROFILE_SET_ANIMALS_1[participantNumber % PROFILE_SET_ANIMALS_1.length]
+      .name;
   const color = COLORS[Math.floor(Math.random() * COLORS.length)];
 
-  config.publicId =
-    `${mainProfile.name}-${color}-${randomNumber}`.toLowerCase();
+  config.publicId = `${baseName}-${color}-${randomNumber}`.toLowerCase();
 
   if (setAnonymousProfile) {
-    if (profileType === ProfileType.ANONYMOUS_PARTICIPANT) {
-      // Use participant number profile
-      const participantProfile =
-        config.anonymousProfiles[PROFILE_SET_ANONYMOUS_PARTICIPANT_ID];
-      config.name = participantProfile.name;
-      config.avatar = participantProfile.avatar;
-    } else if (profileType === ProfileType.ANONYMOUS_ANIMAL) {
-      // Use animal profile (default)
-      config.name = mainProfile.name;
-      config.avatar = mainProfile.avatar;
+    const profileSetMap: Partial<Record<ProfileType, string>> = {
+      [ProfileType.ANONYMOUS_ANIMAL]: PROFILE_SET_ANIMALS_1_ID,
+      [ProfileType.ANONYMOUS_PARTICIPANT]: PROFILE_SET_ANONYMOUS_PARTICIPANT_ID,
+    };
+    const profileSetId = profileSetMap[profileType];
+    if (profileSetId) {
+      const profile = config.anonymousProfiles[profileSetId];
+      config.name = profile.name;
+      config.avatar = profile.avatar;
     }
-    // Note: ProfileType.DEFAULT should not reach here as setAnonymousProfile would be false
     config.pronouns = '';
   }
 }

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -191,17 +191,27 @@ export function setProfile(
   config: ParticipantProfileExtended,
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
+  informalNameStyle = false,
 ) {
   const randomNumber = Math.floor(Math.random() * 10000);
 
+  // Format name with random number.
+  // Informal style: "bear123" (lowercase, no space)
+  // Default style: "Bear 1002"
+  const formatName = (name: string) => {
+    if (informalNameStyle) {
+      return `${name.toLowerCase()}${randomNumber}`;
+    }
+    return `${name} ${randomNumber}`;
+  };
+
   // Create anonymous profile from a named profile set.
-  // Appends random number to name (e.g., "Bear 1002", "Participant 1002").
   const profileFromSet = (
     profileSet: {name: string; avatar: string}[],
   ): AnonymousProfileMetadata => {
     const {name, avatar} = profileSet[participantNumber % profileSet.length];
     return {
-      name: `${name} ${randomNumber}`,
+      name: formatName(name),
       avatar,
       repeat: Math.floor(participantNumber / profileSet.length),
     };

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -192,61 +192,45 @@ export function setProfile(
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
 ) {
-  // Generate random number for unique participant ID
   const randomNumber = Math.floor(Math.random() * 10000);
 
-  const generateProfileFromSet = (
+  // Create anonymous profile from a named profile set.
+  // Appends random number to name (e.g., "Bear 1002", "Participant 1002").
+  const profileFromSet = (
     profileSet: {name: string; avatar: string}[],
-    repeat?: number,
   ): AnonymousProfileMetadata => {
-    // TODO: Randomly select from set
     const {name, avatar} = profileSet[participantNumber % profileSet.length];
     return {
       name: `${name} ${randomNumber}`,
       avatar,
-      repeat: repeat ?? Math.floor(participantNumber / profileSet.length),
+      repeat: Math.floor(participantNumber / profileSet.length),
     };
   };
 
-  const generateRandomHashProfile = (): AnonymousProfileMetadata => {
-    return {
-      name: generateId(),
-      avatar: '',
+  // Set anonymous profiles for each profile set
+  config.anonymousProfiles = {
+    [PROFILE_SET_ANIMALS_1_ID]: profileFromSet(PROFILE_SET_ANIMALS_1),
+    [PROFILE_SET_ANIMALS_2_ID]: profileFromSet(PROFILE_SET_ANIMALS_2),
+    [PROFILE_SET_NATURE_ID]: profileFromSet(PROFILE_SET_NATURE),
+    [PROFILE_SET_ANONYMOUS_PARTICIPANT_ID]: {
+      name: `Participant ${randomNumber}`,
+      avatar: '👤',
       repeat: 0,
-    };
+    },
+    // Random hashes for ordering/randomization
+    [PROFILE_SET_RANDOM_1_ID]: {name: generateId(), avatar: '', repeat: 0},
+    [PROFILE_SET_RANDOM_2_ID]: {name: generateId(), avatar: '', repeat: 0},
+    [PROFILE_SET_RANDOM_3_ID]: {name: generateId(), avatar: '', repeat: 0},
   };
 
-  // Set anonymous profiles
-  const profileAnimal1 = generateProfileFromSet(PROFILE_SET_ANIMALS_1);
-  const profileAnimal2 = generateProfileFromSet(PROFILE_SET_ANIMALS_2);
-  const profileNature = generateProfileFromSet(PROFILE_SET_NATURE);
-  const profileAnonymousParticipant = generateProfileFromSet(
-    [{name: 'Participant', avatar: '👤'}],
-    0,
-  );
-
-  config.anonymousProfiles[PROFILE_SET_ANIMALS_1_ID] = profileAnimal1;
-  config.anonymousProfiles[PROFILE_SET_ANIMALS_2_ID] = profileAnimal2;
-  config.anonymousProfiles[PROFILE_SET_NATURE_ID] = profileNature;
-  config.anonymousProfiles[PROFILE_SET_ANONYMOUS_PARTICIPANT_ID] =
-    profileAnonymousParticipant;
-
-  // Set random hashes (can be used for random ordering, etc.)
-  config.anonymousProfiles[PROFILE_SET_RANDOM_1_ID] =
-    generateRandomHashProfile();
-  config.anonymousProfiles[PROFILE_SET_RANDOM_2_ID] =
-    generateRandomHashProfile();
-  config.anonymousProfiles[PROFILE_SET_RANDOM_3_ID] =
-    generateRandomHashProfile();
-
-  // Define public ID (using base animal name without number)
+  // Define public ID using base animal name (without number suffix)
   const baseName =
     PROFILE_SET_ANIMALS_1[participantNumber % PROFILE_SET_ANIMALS_1.length]
       .name;
   const color = COLORS[Math.floor(Math.random() * COLORS.length)];
-
   config.publicId = `${baseName}-${color}-${randomNumber}`.toLowerCase();
 
+  // Set display profile for anonymous participants
   if (setAnonymousProfile) {
     const profileSetMap: Partial<Record<ProfileType, string>> = {
       [ProfileType.ANONYMOUS_ANIMAL]: PROFILE_SET_ANIMALS_1_ID,

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -191,6 +191,7 @@ export function setProfile(
   config: ParticipantProfileExtended,
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
+  showParticipantNumber = false,
 ) {
   const generateProfileFromSet = (
     profileSet: {name: string; avatar: string}[],
@@ -229,6 +230,13 @@ export function setProfile(
   const profileNature = generateProfileFromSet(PROFILE_SET_NATURE);
   const profileAnonymousParticipant = generateAnonymousParticipantProfile();
 
+  // Append random number to profile names (e.g., "Bear 1002" instead of "Bear")
+  if (showParticipantNumber) {
+    profileAnimal1.name = `${profileAnimal1.name} ${randomNumber}`;
+    profileAnimal2.name = `${profileAnimal2.name} ${randomNumber}`;
+    profileNature.name = `${profileNature.name} ${randomNumber}`;
+  }
+
   config.anonymousProfiles[PROFILE_SET_ANIMALS_1_ID] = profileAnimal1;
   config.anonymousProfiles[PROFILE_SET_ANIMALS_2_ID] = profileAnimal2;
   config.anonymousProfiles[PROFILE_SET_NATURE_ID] = profileNature;
@@ -259,7 +267,12 @@ export function setProfile(
       config.avatar = participantProfile.avatar;
     } else if (profileType === ProfileType.ANONYMOUS_ANIMAL) {
       // Use animal profile (default)
-      config.name = `${mainProfile.name}${mainProfile.repeat === 0 ? '' : ` ${mainProfile.repeat + 1}`}`;
+      if (showParticipantNumber) {
+        // Name already has numeric suffix (e.g., "Bear 1002")
+        config.name = mainProfile.name;
+      } else {
+        config.name = `${mainProfile.name}${mainProfile.repeat === 0 ? '' : ` ${mainProfile.repeat + 1}`}`;
+      }
       config.avatar = mainProfile.avatar;
     }
     // Note: ProfileType.DEFAULT should not reach here as setAnonymousProfile would be false

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -223,7 +223,7 @@ export function setProfile(
     [PROFILE_SET_ANIMALS_2_ID]: profileFromSet(PROFILE_SET_ANIMALS_2),
     [PROFILE_SET_NATURE_ID]: profileFromSet(PROFILE_SET_NATURE),
     [PROFILE_SET_ANONYMOUS_PARTICIPANT_ID]: {
-      name: `Participant ${randomNumber}`,
+      name: formatName('Participant'),
       avatar: '👤',
       repeat: 0,
     },

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -191,7 +191,6 @@ export function setProfile(
   config: ParticipantProfileExtended,
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
-  showParticipantNumber = false,
 ) {
   const generateProfileFromSet = (
     profileSet: {name: string; avatar: string}[],
@@ -230,12 +229,10 @@ export function setProfile(
   const profileNature = generateProfileFromSet(PROFILE_SET_NATURE);
   const profileAnonymousParticipant = generateAnonymousParticipantProfile();
 
-  // Append random number to profile names (e.g., "Bear 1002" instead of "Bear")
-  if (showParticipantNumber) {
-    profileAnimal1.name = `${profileAnimal1.name} ${randomNumber}`;
-    profileAnimal2.name = `${profileAnimal2.name} ${randomNumber}`;
-    profileNature.name = `${profileNature.name} ${randomNumber}`;
-  }
+  // Append random number to profile names (e.g., "Bear 1002")
+  profileAnimal1.name = `${profileAnimal1.name} ${randomNumber}`;
+  profileAnimal2.name = `${profileAnimal2.name} ${randomNumber}`;
+  profileNature.name = `${profileNature.name} ${randomNumber}`;
 
   config.anonymousProfiles[PROFILE_SET_ANIMALS_1_ID] = profileAnimal1;
   config.anonymousProfiles[PROFILE_SET_ANIMALS_2_ID] = profileAnimal2;
@@ -267,12 +264,7 @@ export function setProfile(
       config.avatar = participantProfile.avatar;
     } else if (profileType === ProfileType.ANONYMOUS_ANIMAL) {
       // Use animal profile (default)
-      if (showParticipantNumber) {
-        // Name already has numeric suffix (e.g., "Bear 1002")
-        config.name = mainProfile.name;
-      } else {
-        config.name = `${mainProfile.name}${mainProfile.repeat === 0 ? '' : ` ${mainProfile.repeat + 1}`}`;
-      }
+      config.name = mainProfile.name;
       config.avatar = mainProfile.avatar;
     }
     // Note: ProfileType.DEFAULT should not reach here as setAnonymousProfile would be false

--- a/utils/src/stages/profile_stage.ts
+++ b/utils/src/stages/profile_stage.ts
@@ -22,6 +22,7 @@ export enum ProfileType {
 export interface ProfileStageConfig extends BaseStageConfig {
   kind: StageKind.PROFILE;
   profileType: ProfileType;
+  informalNameStyle?: boolean; // e.g., "bear123" instead of "Bear 1002"
 }
 
 // ************************************************************************* //
@@ -39,5 +40,6 @@ export function createProfileStage(
     descriptions: config.descriptions ?? createStageTextConfig(),
     progress: config.progress ?? createStageProgressConfig(),
     profileType: config.profileType ?? ProfileType.DEFAULT,
+    informalNameStyle: config.informalNameStyle ?? false,
   };
 }

--- a/utils/src/stages/profile_stage.ts
+++ b/utils/src/stages/profile_stage.ts
@@ -22,7 +22,6 @@ export enum ProfileType {
 export interface ProfileStageConfig extends BaseStageConfig {
   kind: StageKind.PROFILE;
   profileType: ProfileType;
-  showParticipantNumber?: boolean; // e.g., "Bear 1002" instead of "Bear"
 }
 
 // ************************************************************************* //
@@ -40,6 +39,5 @@ export function createProfileStage(
     descriptions: config.descriptions ?? createStageTextConfig(),
     progress: config.progress ?? createStageProgressConfig(),
     profileType: config.profileType ?? ProfileType.DEFAULT,
-    showParticipantNumber: config.showParticipantNumber ?? true,
   };
 }

--- a/utils/src/stages/profile_stage.ts
+++ b/utils/src/stages/profile_stage.ts
@@ -22,6 +22,7 @@ export enum ProfileType {
 export interface ProfileStageConfig extends BaseStageConfig {
   kind: StageKind.PROFILE;
   profileType: ProfileType;
+  showParticipantNumber?: boolean; // e.g., "Bear 1002" instead of "Bear"
 }
 
 // ************************************************************************* //
@@ -39,5 +40,6 @@ export function createProfileStage(
     descriptions: config.descriptions ?? createStageTextConfig(),
     progress: config.progress ?? createStageProgressConfig(),
     profileType: config.profileType ?? ProfileType.DEFAULT,
+    showParticipantNumber: config.showParticipantNumber ?? true,
   };
 }

--- a/utils/src/stages/profile_stage.validation.ts
+++ b/utils/src/stages/profile_stage.validation.ts
@@ -23,6 +23,7 @@ export const ProfileStageConfigData = Type.Composite(
           Type.Literal(ProfileType.ANONYMOUS_ANIMAL),
           Type.Literal(ProfileType.ANONYMOUS_PARTICIPANT),
         ]),
+        showParticipantNumber: Type.Optional(Type.Boolean()),
       },
       strict,
     ),

--- a/utils/src/stages/profile_stage.validation.ts
+++ b/utils/src/stages/profile_stage.validation.ts
@@ -23,6 +23,7 @@ export const ProfileStageConfigData = Type.Composite(
           Type.Literal(ProfileType.ANONYMOUS_ANIMAL),
           Type.Literal(ProfileType.ANONYMOUS_PARTICIPANT),
         ]),
+        informalNameStyle: Type.Optional(Type.Boolean({default: false})),
       },
       strict,
     ),

--- a/utils/src/stages/profile_stage.validation.ts
+++ b/utils/src/stages/profile_stage.validation.ts
@@ -23,7 +23,6 @@ export const ProfileStageConfigData = Type.Composite(
           Type.Literal(ProfileType.ANONYMOUS_ANIMAL),
           Type.Literal(ProfileType.ANONYMOUS_PARTICIPANT),
         ]),
-        showParticipantNumber: Type.Optional(Type.Boolean({default: true})),
       },
       strict,
     ),

--- a/utils/src/stages/profile_stage.validation.ts
+++ b/utils/src/stages/profile_stage.validation.ts
@@ -23,7 +23,7 @@ export const ProfileStageConfigData = Type.Composite(
           Type.Literal(ProfileType.ANONYMOUS_ANIMAL),
           Type.Literal(ProfileType.ANONYMOUS_PARTICIPANT),
         ]),
-        showParticipantNumber: Type.Optional(Type.Boolean()),
+        showParticipantNumber: Type.Optional(Type.Boolean({default: true})),
       },
       strict,
     ),


### PR DESCRIPTION
Closes #1048

Always include random numeric ID in anonymous animal profile names, making them look more like usernames (e.g., "Bear 1002") instead of the current format which only appends a sequential number on collision (e.g., "Bear", "Bear 2"). This aligns behavior with ANONYMOUS_PARTICIPANT appraoch (e.g. "Participant 1002") and uses the same random number already generated for the public ID and anonymous participant profiles. This is now default behavior for new experiments going forward.

Also: 
* Changes the quickstart to use anonymous animal profiles instead of open-form profiles.
* Adds a new `informalNameStyle` option which displays names as `bear123`.
* Nicer profile stage editor UI.

<img width="686" height="458" alt="Screenshot 2026-03-11 at 3 53 30 PM" src="https://github.com/user-attachments/assets/361c8cd3-7bde-42a9-ae71-530aa95e895f" />


