### PR TITLE
requireFullTime -> timeMinimumInMinutes

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -674,7 +674,6 @@
         "descriptions",
         "progress",
         "timeLimitInMinutes",
-        "requireFullTime",
         "discussions"
       ],
       "properties": {
@@ -706,10 +705,10 @@
             }
           ]
         },
-        "requireFullTime": {
+        "timeMinimumInMinutes": {
           "anyOf": [
             {
-              "type": "boolean"
+              "type": "number"
             },
             {
               "type": "null"
@@ -1376,8 +1375,15 @@
             }
           ]
         },
-        "requireFullTime": {
-          "type": "boolean"
+        "timeMinimumInMinutes": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "isTurnBasedChat": {
           "type": "boolean"

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -13,26 +13,12 @@
       ],
       "properties": {
         "minParticipantsPerCohort": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "minimum": 0,
-              "type": "integer"
-            }
-          ]
+          "minimum": 0,
+          "type": ["null", "integer"]
         },
         "maxParticipantsPerCohort": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "minimum": 1,
-              "type": "integer"
-            }
-          ]
+          "minimum": 1,
+          "type": ["null", "integer"]
         },
         "includeAllParticipantsInCohortCount": {
           "type": "boolean"
@@ -674,6 +660,7 @@
         "descriptions",
         "progress",
         "timeLimitInMinutes",
+        "timeMinimumInMinutes",
         "discussions"
       ],
       "properties": {
@@ -696,24 +683,12 @@
           "$ref": "#/$defs/StageProgressConfig"
         },
         "timeLimitInMinutes": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "minimum": 1,
+          "type": ["integer", "null"]
         },
         "timeMinimumInMinutes": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "minimum": 1,
+          "type": ["integer", "null"]
         },
         "discussions": {
           "type": "array",
@@ -1307,27 +1282,13 @@
           "type": "number"
         },
         "rankingStageId": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": ["null", "string"]
         },
         "questionMap": {
           "type": "object",
           "patternProperties": {
             "^(.*)$": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "type": ["number", "null"]
             }
           },
           "title": "QuestionMap"
@@ -1344,7 +1305,8 @@
         "name",
         "descriptions",
         "progress",
-        "timeLimitInMinutes"
+        "timeLimitInMinutes",
+        "timeMinimumInMinutes"
       ],
       "properties": {
         "id": {
@@ -1366,24 +1328,12 @@
           "$ref": "#/$defs/StageProgressConfig"
         },
         "timeLimitInMinutes": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "minimum": 1,
+          "type": ["integer", "null"]
         },
         "timeMinimumInMinutes": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "minimum": 1,
+          "type": ["integer", "null"]
         },
         "isTurnBasedChat": {
           "type": "boolean"
@@ -1392,14 +1342,7 @@
           "type": "number"
         },
         "maxNumberOfTurns": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": ["number", "null"]
         },
         "preventCancellation": {
           "type": "boolean"
@@ -1825,14 +1768,7 @@
                 "type": "integer"
               },
               "maxParticipants": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": ["integer", "null"]
               }
             },
             "title": "Role"
@@ -2107,17 +2043,7 @@
           ]
         },
         "value": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
+          "type": ["string", "number", "boolean"]
         }
       }
     },
@@ -2279,14 +2205,7 @@
           }
         },
         "correctAnswerId": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": ["null", "string"]
         },
         "displayType": {
           "title": "MultipleChoiceDisplayType",
@@ -2804,34 +2723,13 @@
       "required": ["pronouns", "avatar", "name"],
       "properties": {
         "pronouns": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": ["null", "string"]
         },
         "avatar": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": ["null", "string"]
         },
         "name": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": ["null", "string"]
         }
       }
     },
@@ -3141,14 +3039,7 @@
           ]
         },
         "reasoningBudget": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": ["integer", "null"]
         },
         "includeReasoning": {
           "type": "boolean"
@@ -3790,14 +3681,7 @@
       ],
       "properties": {
         "wordsPerMinute": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": ["number", "null"]
         },
         "minMessagesBeforeResponding": {
           "type": "integer"
@@ -3806,14 +3690,7 @@
           "type": "boolean"
         },
         "maxResponses": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": ["integer", "null"]
         },
         "initialMessage": {
           "type": "string"

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -21,6 +21,7 @@ import {
   MediatorStatus,
   ParticipantProfile,
   convertUnifiedTimestampToTime,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {
   getChatStartTimestamp,
@@ -94,8 +95,20 @@ export class ChatPanel extends MobxLitElement {
       >
         ⏱️ Timer: ${this.stage.timeLimitInMinutes} minutes ${renderStatus()}
         ${this.stage.timeMinimumInMinutes &&
-        !publicStageData.discussionEndTimestamp
-          ? `You must stay on this chat for at least ${this.stage.timeMinimumInMinutes} minutes.`
+        !publicStageData.discussionEndTimestamp &&
+        publicStageData.discussionStartTimestamp &&
+        getTimeElapsed(publicStageData.discussionStartTimestamp, 'm') <
+          this.stage.timeMinimumInMinutes
+          ? (() => {
+              const remaining = Math.ceil(
+                this.stage.timeMinimumInMinutes -
+                  getTimeElapsed(
+                    publicStageData.discussionStartTimestamp!,
+                    'm',
+                  ),
+              );
+              return `You must stay in this chat for at least ${remaining} more minute${remaining !== 1 ? 's' : ''}.`;
+            })()
           : ''}
       </div>
       ${this.topLayout ? nothing : html`<div class="divider"></div>`}

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -93,8 +93,9 @@ export class ChatPanel extends MobxLitElement {
         class=${`countdown ${publicStageData.discussionEndTimestamp ? 'ended' : ''}`}
       >
         ⏱️ Timer: ${this.stage.timeLimitInMinutes} minutes ${renderStatus()}
-        ${this.stage.requireFullTime && !publicStageData.discussionEndTimestamp
-          ? 'You must stay on this chat for the full time.'
+        ${this.stage.timeMinimumInMinutes &&
+        !publicStageData.discussionEndTimestamp
+          ? `You must stay on this chat for at least ${this.stage.timeMinimumInMinutes} minutes.`
           : ''}
       </div>
       ${this.topLayout ? nothing : html`<div class="divider"></div>`}

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -18,15 +18,11 @@ import {
   ChatStageConfig,
   ChatStagePublicData,
   MediatorProfile,
-  MediatorStatus,
   ParticipantProfile,
   convertUnifiedTimestampToTime,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
-import {
-  getChatStartTimestamp,
-  getChatTimeRemainingInSeconds,
-} from '../../shared/stage.utils';
+import {getChatStartTimestamp} from '../../shared/stage.utils';
 import {getHashBasedColor} from '../../shared/utils';
 import {styles} from './chat_info_panel.scss';
 
@@ -58,12 +54,12 @@ export class ChatPanel extends MobxLitElement {
     return html`
       <div class="side-layout">
         <stage-description .stage=${this.stage} noPadding> </stage-description>
-        ${this.renderTimer(true)} ${this.renderParticipantList()}
+        ${this.renderTimer()} ${this.renderParticipantList()}
       </div>
     `;
   }
 
-  private renderTimer(showDivider = false) {
+  private renderTimer() {
     if (!this.stage) return nothing;
 
     const publicStageData = this.cohortService.stagePublicDataMap[

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -71,7 +71,6 @@ export class ChatEditor extends MobxLitElement {
 
   private renderTimeLimit() {
     const timeLimit = this.stage?.timeLimitInMinutes ?? null;
-    const requireFullTime = this.stage?.requireFullTime ?? false;
 
     const updateCheck = () => {
       if (!this.stage) return;
@@ -79,6 +78,7 @@ export class ChatEditor extends MobxLitElement {
         this.experimentEditor.updateStage({
           ...this.stage,
           timeLimitInMinutes: null,
+          timeMinimumInMinutes: null,
         });
       } else {
         this.experimentEditor.updateStage({
@@ -88,7 +88,7 @@ export class ChatEditor extends MobxLitElement {
       }
     };
 
-    const updateNum = (e: InputEvent) => {
+    const updateMaxTime = (e: InputEvent) => {
       if (!this.stage) return;
       const timeLimit = Number((e.target as HTMLTextAreaElement).value);
       this.experimentEditor.updateStage({
@@ -97,11 +97,14 @@ export class ChatEditor extends MobxLitElement {
       });
     };
 
-    const updateRequireFullTime = (e: Event) => {
+    const updateMinTime = (e: InputEvent) => {
       if (!this.stage) return;
+      const val = Number((e.target as HTMLInputElement).value);
+      const max = this.stage.timeLimitInMinutes;
+      const clamped = max !== null ? Math.min(val, max) : val;
       this.experimentEditor.updateStage({
         ...this.stage,
-        requireFullTime: (e.target as HTMLInputElement).checked,
+        timeMinimumInMinutes: clamped > 0 ? clamped : null,
       });
     };
 
@@ -120,10 +123,7 @@ export class ChatEditor extends MobxLitElement {
         ${timeLimit !== null
           ? html`
               <div class="number-input tab">
-                <label for="timeLimit">
-                  Elapsed time from first message to conversation close (in
-                  minutes)
-                </label>
+                <label for="timeLimit"> Maximum time (in minutes) </label>
                 <input
                   type="number"
                   id="timeLimit"
@@ -131,18 +131,24 @@ export class ChatEditor extends MobxLitElement {
                   min="0"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateNum}
+                  @input=${updateMaxTime}
                 />
               </div>
-              <div class="checkbox-wrapper tab">
-                <md-checkbox
-                  touch-target="wrapper"
-                  ?checked=${requireFullTime}
+              <div class="number-input tab tab-bottom">
+                <label for="timeMinimum">
+                  Minimum time participants must stay (in minutes)
+                </label>
+                <input
+                  type="number"
+                  id="timeMinimum"
+                  name="timeMinimum"
+                  min="0"
+                  .max=${timeLimit ?? ''}
+                  .value=${this.stage?.timeMinimumInMinutes ?? ''}
+                  placeholder="No minimum"
                   ?disabled=${!this.experimentEditor.canEditStages}
-                  @change=${updateRequireFullTime}
-                >
-                </md-checkbox>
-                <div>Require participants to stay until time elapses</div>
+                  @input=${updateMinTime}
+                />
               </div>
             `
           : nothing}

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -90,7 +90,9 @@ export class ChatEditor extends MobxLitElement {
 
     const updateMaxTime = (e: InputEvent) => {
       if (!this.stage) return;
-      const timeLimit = Number((e.target as HTMLTextAreaElement).value);
+      const timeLimit = Math.floor(
+        Number((e.target as HTMLTextAreaElement).value),
+      );
       this.experimentEditor.updateStage({
         ...this.stage,
         timeLimitInMinutes: timeLimit,
@@ -99,7 +101,7 @@ export class ChatEditor extends MobxLitElement {
 
     const updateMinTime = (e: InputEvent) => {
       if (!this.stage) return;
-      const val = Number((e.target as HTMLInputElement).value);
+      const val = Math.floor(Number((e.target as HTMLInputElement).value));
       const max = this.stage.timeLimitInMinutes;
       const clamped = max !== null ? Math.min(val, max) : val;
       this.experimentEditor.updateStage({
@@ -123,12 +125,15 @@ export class ChatEditor extends MobxLitElement {
         ${timeLimit !== null
           ? html`
               <div class="number-input tab">
-                <label for="timeLimit"> Maximum time (in minutes) </label>
+                <label for="timeLimit">
+                  Maximum time in minutes (starting at first message)
+                </label>
                 <input
                   type="number"
                   id="timeLimit"
                   name="timeLimit"
                   min="0"
+                  step="1"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
                   @input=${updateMaxTime}
@@ -143,6 +148,7 @@ export class ChatEditor extends MobxLitElement {
                   id="timeMinimum"
                   name="timeMinimum"
                   min="0"
+                  step="1"
                   .max=${timeLimit ?? ''}
                   .value=${this.stage?.timeMinimumInMinutes ?? ''}
                   placeholder="No minimum"

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -70,43 +70,35 @@ export class ChatEditor extends MobxLitElement {
   }
 
   private renderTimeLimit() {
-    const timeLimit = this.stage?.timeLimitInMinutes ?? null;
+    const timeLimit = this.stage?.timeLimitInMinutes;
 
     const updateCheck = () => {
-      if (!this.stage) return;
-      if (this.stage.timeLimitInMinutes) {
-        this.experimentEditor.updateStage({
-          ...this.stage,
-          timeLimitInMinutes: null,
-          timeMinimumInMinutes: null,
-        });
-      } else {
-        this.experimentEditor.updateStage({
-          ...this.stage,
-          timeLimitInMinutes: 20, // Default to 20 if checked
-        });
-      }
+      const isSet = this.stage?.timeLimitInMinutes != null;
+      this.experimentEditor.updateStage({
+        ...this.stage!,
+        timeLimitInMinutes: isSet ? null : 20,
+        timeMinimumInMinutes: null,
+      });
     };
 
     const updateMaxTime = (e: InputEvent) => {
-      if (!this.stage) return;
-      const timeLimit = Math.floor(
-        Number((e.target as HTMLTextAreaElement).value),
-      );
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
       this.experimentEditor.updateStage({
-        ...this.stage,
-        timeLimitInMinutes: timeLimit,
+        ...this.stage!,
+        timeLimitInMinutes,
       });
     };
 
     const updateMinTime = (e: InputEvent) => {
-      if (!this.stage) return;
-      const val = Math.floor(Number((e.target as HTMLInputElement).value));
-      const max = this.stage.timeLimitInMinutes;
-      const clamped = max !== null ? Math.min(val, max) : val;
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const minTime = val > 0 ? Math.floor(val) : null;
+      const max = this.stage?.timeLimitInMinutes;
+      const timeMinimumInMinutes =
+        minTime != null && max != null ? Math.min(minTime, max) : minTime;
       this.experimentEditor.updateStage({
-        ...this.stage,
-        timeMinimumInMinutes: clamped > 0 ? clamped : null,
+        ...this.stage!,
+        timeMinimumInMinutes,
       });
     };
 
@@ -115,24 +107,26 @@ export class ChatEditor extends MobxLitElement {
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
-            ?checked=${timeLimit !== null}
+            ?checked=${timeLimit != null}
             ?disabled=${!this.experimentEditor.canEditStages}
             @click=${updateCheck}
           >
           </md-checkbox>
           <div>Disable conversation after a fixed amount of time</div>
         </div>
-        ${timeLimit !== null
+        ${timeLimit != null
           ? html`
               <div class="number-input tab">
                 <label for="timeLimit">
-                  Maximum time in minutes (starting at first message)
+                  Maximum time in minutes (starting at first message).
+                  Participant will remain in chat until minimum messages
+                  requirement is met, even if maximum time has passed.
                 </label>
                 <input
                   type="number"
                   id="timeLimit"
                   name="timeLimit"
-                  min="0"
+                  min="1"
                   step="1"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
@@ -141,13 +135,14 @@ export class ChatEditor extends MobxLitElement {
               </div>
               <div class="number-input tab tab-bottom">
                 <label for="timeMinimum">
-                  Minimum time participants must stay (in minutes)
+                  Minimum time participants must stay (in minutes). Takes
+                  precedence over maximum number of messages.
                 </label>
                 <input
                   type="number"
                   id="timeMinimum"
                   name="timeMinimum"
-                  min="0"
+                  min="1"
                   step="1"
                   .max=${timeLimit ?? ''}
                   .value=${this.stage?.timeMinimumInMinutes ?? ''}

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -26,6 +26,7 @@ import {
   ChatStageConfig,
   DiscussionItem,
   StageKind,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 
 import {styles} from './group_chat_participant_view.scss';
@@ -164,7 +165,7 @@ export class GroupChatView extends MobxLitElement {
     }
 
     const onClick = async () => {
-      if (!this.stage) return;
+      if (!this.stage || !this.isMinimumTimeMet) return;
 
       this.readyToEndDiscussionLoading = true;
       try {
@@ -183,13 +184,16 @@ export class GroupChatView extends MobxLitElement {
       this.participantService.isReadyToEndChatDiscussion(
         this.stage.id,
         currentDiscussionId,
-      );
+      ) ||
+      !this.isMinimumTimeMet;
 
     return html`
       <pr-tooltip
-        text=${isDisabled
-          ? 'You can move on once others are also ready to move on.'
-          : ''}
+        text=${!this.isMinimumTimeMet
+          ? `You must wait until ${this.stage.timeMinimumInMinutes} minutes have passed.`
+          : isDisabled
+            ? 'You can move on once others are also ready to move on.'
+            : ''}
         position="TOP_END"
       >
         <pr-button
@@ -252,20 +256,7 @@ export class GroupChatView extends MobxLitElement {
     );
 
     // Determine if Next Stage button should be disabled
-    let disableNext = false;
-    const requireFullTime = this.stage.requireFullTime;
-    const publicStageData = this.cohortService.stagePublicDataMap[
-      this.stage.id
-    ] as ChatStagePublicData;
-    if (
-      publicStageData &&
-      requireFullTime &&
-      this.stage.timeLimitInMinutes !== null
-    ) {
-      if (!publicStageData.discussionEndTimestamp) {
-        disableNext = true;
-      }
-    }
+    const disableNext = !this.isMinimumTimeMet;
 
     const renderProgress = () => {
       if (!this.stage?.progress.showParticipantProgress) {
@@ -305,6 +296,23 @@ export class GroupChatView extends MobxLitElement {
         ${this.renderEndDiscussionButton(currentDiscussionId)}
       </stage-footer>
     `;
+  }
+
+  get isMinimumTimeMet() {
+    if (!this.stage || !this.stage.timeMinimumInMinutes) return true;
+
+    const publicStageData = this.cohortService.stagePublicDataMap[
+      this.stage.id
+    ] as ChatStagePublicData;
+
+    if (!publicStageData?.discussionStartTimestamp) {
+      return false;
+    }
+
+    return (
+      getTimeElapsed(publicStageData.discussionStartTimestamp, 'm') >=
+      this.stage.timeMinimumInMinutes
+    );
   }
 }
 

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -190,7 +190,7 @@ export class GroupChatView extends MobxLitElement {
     return html`
       <pr-tooltip
         text=${!this.isMinimumTimeMet
-          ? `You must stay on this chat for at least ${this.stage.timeMinimumInMinutes} minutes.`
+          ? `You must stay in this chat for at least ${this.minutesRemainingUntilMinimum} more minute${this.minutesRemainingUntilMinimum !== 1 ? 's' : ''}.`
           : isDisabled
             ? 'You can move on once others are also ready to move on.'
             : ''}
@@ -313,6 +313,24 @@ export class GroupChatView extends MobxLitElement {
       getTimeElapsed(publicStageData.discussionStartTimestamp, 'm') >=
       this.stage.timeMinimumInMinutes
     );
+  }
+
+  get minutesRemainingUntilMinimum(): number {
+    if (!this.stage?.timeMinimumInMinutes) return 0;
+
+    const publicStageData = this.cohortService.stagePublicDataMap[
+      this.stage.id
+    ] as ChatStagePublicData;
+
+    if (!publicStageData?.discussionStartTimestamp) {
+      return this.stage.timeMinimumInMinutes;
+    }
+
+    const elapsed = getTimeElapsed(
+      publicStageData.discussionStartTimestamp,
+      'm',
+    );
+    return Math.ceil(this.stage.timeMinimumInMinutes - elapsed);
   }
 }
 

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -220,10 +220,6 @@ export class GroupChatView extends MobxLitElement {
   private renderIndicators() {
     if (!this.stage) return nothing;
 
-    const publicStageData = this.cohortService.stagePublicDataMap[
-      this.stage.id
-    ] as ChatStagePublicData;
-
     // Check if all other participants have completed the stage
     const completed = this.cohortService.getStageCompletedParticipants(
       this.stage.id,

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -190,7 +190,7 @@ export class GroupChatView extends MobxLitElement {
     return html`
       <pr-tooltip
         text=${!this.isMinimumTimeMet
-          ? `You must wait until ${this.stage.timeMinimumInMinutes} minutes have passed.`
+          ? `You must stay on this chat for at least ${this.stage.timeMinimumInMinutes} minutes.`
           : isDisabled
             ? 'You can move on once others are also ready to move on.'
             : ''}

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -41,43 +41,35 @@ export class ChatEditor extends MobxLitElement {
   }
 
   private renderTimeLimit() {
-    const timeLimit = this.stage?.timeLimitInMinutes ?? null;
+    const timeLimit = this.stage?.timeLimitInMinutes;
 
     const updateCheck = () => {
-      if (!this.stage) return;
-      if (this.stage.timeLimitInMinutes) {
-        this.experimentEditor.updateStage({
-          ...this.stage,
-          timeLimitInMinutes: null,
-          timeMinimumInMinutes: null,
-        });
-      } else {
-        this.experimentEditor.updateStage({
-          ...this.stage,
-          timeLimitInMinutes: 20, // Default to 20 if checked
-        });
-      }
+      const isSet = this.stage?.timeLimitInMinutes != null;
+      this.experimentEditor.updateStage({
+        ...this.stage!,
+        timeLimitInMinutes: isSet ? null : 20,
+        timeMinimumInMinutes: null,
+      });
     };
 
     const updateMaxTime = (e: InputEvent) => {
-      if (!this.stage) return;
-      const timeLimit = Math.floor(
-        Number((e.target as HTMLTextAreaElement).value),
-      );
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
       this.experimentEditor.updateStage({
-        ...this.stage,
-        timeLimitInMinutes: timeLimit,
+        ...this.stage!,
+        timeLimitInMinutes,
       });
     };
 
     const updateMinTime = (e: InputEvent) => {
-      if (!this.stage) return;
-      const val = Math.floor(Number((e.target as HTMLInputElement).value));
-      const max = this.stage.timeLimitInMinutes;
-      const clamped = max !== null ? Math.min(val, max) : val;
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const minTime = val > 0 ? Math.floor(val) : null;
+      const max = this.stage?.timeLimitInMinutes;
+      const timeMinimumInMinutes =
+        minTime != null && max != null ? Math.min(minTime, max) : minTime;
       this.experimentEditor.updateStage({
-        ...this.stage,
-        timeMinimumInMinutes: clamped > 0 ? clamped : null,
+        ...this.stage!,
+        timeMinimumInMinutes,
       });
     };
 
@@ -86,14 +78,14 @@ export class ChatEditor extends MobxLitElement {
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
-            ?checked=${timeLimit !== null}
+            ?checked=${timeLimit != null}
             ?disabled=${!this.experimentEditor.canEditStages}
             @click=${updateCheck}
           >
           </md-checkbox>
           <div>Disable conversation after a fixed amount of time</div>
         </div>
-        ${timeLimit !== null
+        ${timeLimit != null
           ? html`
               <div class="number-input tab">
                 <label for="timeLimit">
@@ -105,7 +97,7 @@ export class ChatEditor extends MobxLitElement {
                   type="number"
                   id="timeLimit"
                   name="timeLimit"
-                  min="0"
+                  min="1"
                   step="1"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
@@ -121,7 +113,7 @@ export class ChatEditor extends MobxLitElement {
                   type="number"
                   id="timeMinimum"
                   name="timeMinimum"
-                  min="0"
+                  min="1"
                   step="1"
                   .max=${timeLimit ?? ''}
                   .value=${this.stage?.timeMinimumInMinutes ?? ''}

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -61,7 +61,9 @@ export class ChatEditor extends MobxLitElement {
 
     const updateMaxTime = (e: InputEvent) => {
       if (!this.stage) return;
-      const timeLimit = Number((e.target as HTMLTextAreaElement).value);
+      const timeLimit = Math.floor(
+        Number((e.target as HTMLTextAreaElement).value),
+      );
       this.experimentEditor.updateStage({
         ...this.stage,
         timeLimitInMinutes: timeLimit,
@@ -70,7 +72,7 @@ export class ChatEditor extends MobxLitElement {
 
     const updateMinTime = (e: InputEvent) => {
       if (!this.stage) return;
-      const val = Number((e.target as HTMLInputElement).value);
+      const val = Math.floor(Number((e.target as HTMLInputElement).value));
       const max = this.stage.timeLimitInMinutes;
       const clamped = max !== null ? Math.min(val, max) : val;
       this.experimentEditor.updateStage({
@@ -94,12 +96,15 @@ export class ChatEditor extends MobxLitElement {
         ${timeLimit !== null
           ? html`
               <div class="number-input tab">
-                <label for="timeLimit"> Maximum time (in minutes) </label>
+                <label for="timeLimit">
+                  Maximum time in minutes (starting at first message)
+                </label>
                 <input
                   type="number"
                   id="timeLimit"
                   name="timeLimit"
                   min="0"
+                  step="1"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
                   @input=${updateMaxTime}
@@ -114,6 +119,7 @@ export class ChatEditor extends MobxLitElement {
                   id="timeMinimum"
                   name="timeMinimum"
                   min="0"
+                  step="1"
                   .max=${timeLimit ?? ''}
                   .value=${this.stage?.timeMinimumInMinutes ?? ''}
                   placeholder="No minimum"

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -42,7 +42,6 @@ export class ChatEditor extends MobxLitElement {
 
   private renderTimeLimit() {
     const timeLimit = this.stage?.timeLimitInMinutes ?? null;
-    const requireFullTime = this.stage?.requireFullTime ?? false;
 
     const updateCheck = () => {
       if (!this.stage) return;
@@ -50,6 +49,7 @@ export class ChatEditor extends MobxLitElement {
         this.experimentEditor.updateStage({
           ...this.stage,
           timeLimitInMinutes: null,
+          timeMinimumInMinutes: null,
         });
       } else {
         this.experimentEditor.updateStage({
@@ -59,7 +59,7 @@ export class ChatEditor extends MobxLitElement {
       }
     };
 
-    const updateNum = (e: InputEvent) => {
+    const updateMaxTime = (e: InputEvent) => {
       if (!this.stage) return;
       const timeLimit = Number((e.target as HTMLTextAreaElement).value);
       this.experimentEditor.updateStage({
@@ -68,11 +68,14 @@ export class ChatEditor extends MobxLitElement {
       });
     };
 
-    const updateRequireFullTime = (e: Event) => {
+    const updateMinTime = (e: InputEvent) => {
       if (!this.stage) return;
+      const val = Number((e.target as HTMLInputElement).value);
+      const max = this.stage.timeLimitInMinutes;
+      const clamped = max !== null ? Math.min(val, max) : val;
       this.experimentEditor.updateStage({
         ...this.stage,
-        requireFullTime: (e.target as HTMLInputElement).checked,
+        timeMinimumInMinutes: clamped > 0 ? clamped : null,
       });
     };
 
@@ -91,10 +94,7 @@ export class ChatEditor extends MobxLitElement {
         ${timeLimit !== null
           ? html`
               <div class="number-input tab">
-                <label for="timeLimit">
-                  Elapsed time from first message to conversation close (in
-                  minutes)
-                </label>
+                <label for="timeLimit"> Maximum time (in minutes) </label>
                 <input
                   type="number"
                   id="timeLimit"
@@ -102,18 +102,24 @@ export class ChatEditor extends MobxLitElement {
                   min="0"
                   .value=${timeLimit}
                   ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateNum}
+                  @input=${updateMaxTime}
                 />
               </div>
-              <div class="checkbox-wrapper tab">
-                <md-checkbox
-                  touch-target="wrapper"
-                  ?checked=${requireFullTime}
+              <div class="number-input tab tab-bottom">
+                <label for="timeMinimum">
+                  Minimum time participants must stay (in minutes)
+                </label>
+                <input
+                  type="number"
+                  id="timeMinimum"
+                  name="timeMinimum"
+                  min="0"
+                  .max=${timeLimit ?? ''}
+                  .value=${this.stage?.timeMinimumInMinutes ?? ''}
+                  placeholder="No minimum"
                   ?disabled=${!this.experimentEditor.canEditStages}
-                  @change=${updateRequireFullTime}
-                >
-                </md-checkbox>
-                <div>Require participants to stay until time elapses</div>
+                  @input=${updateMinTime}
+                />
               </div>
             `
           : nothing}

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -97,7 +97,9 @@ export class ChatEditor extends MobxLitElement {
           ? html`
               <div class="number-input tab">
                 <label for="timeLimit">
-                  Maximum time in minutes (starting at first message)
+                  Maximum time in minutes (starting at first message).
+                  Participant will remain in chat until minimum messages
+                  requirement is met, even if maximum time has passed.
                 </label>
                 <input
                   type="number"
@@ -112,7 +114,8 @@ export class ChatEditor extends MobxLitElement {
               </div>
               <div class="number-input tab tab-bottom">
                 <label for="timeMinimum">
-                  Minimum time participants must stay (in minutes)
+                  Minimum time participants must stay (in minutes). Takes
+                  precedence over maximum number of messages.
                 </label>
                 <input
                   type="number"
@@ -195,12 +198,17 @@ export class ChatEditor extends MobxLitElement {
   private renderMinNumberOfTurns() {
     const minNumberOfTurns = this.stage?.minNumberOfTurns ?? 0;
 
+    const maxNumberOfTurns = this.stage?.maxNumberOfTurns ?? null;
+
     const updateNum = (e: InputEvent) => {
       if (!this.stage) return;
-      const value = Number((e.target as HTMLInputElement).value);
+      let value = Math.max(0, Number((e.target as HTMLInputElement).value));
+      if (maxNumberOfTurns !== null) {
+        value = Math.min(value, maxNumberOfTurns);
+      }
       this.experimentEditor.updateStage({
         ...this.stage,
-        minNumberOfTurns: Math.max(0, value),
+        minNumberOfTurns: value,
       });
     };
 
@@ -208,13 +216,15 @@ export class ChatEditor extends MobxLitElement {
       <div class="config-item">
         <div class="number-input">
           <label for="minTurns">
-            Minimum number of participant messages required (0 = no minimum)
+            Minimum number of participant messages required (0 = no minimum).
+            Takes precedence over maximum time limit.
           </label>
           <input
             type="number"
             id="minTurns"
             name="minTurns"
             min="0"
+            .max=${maxNumberOfTurns ?? ''}
             .value=${minNumberOfTurns}
             ?disabled=${!this.experimentEditor.canEditStages}
             @input=${updateNum}
@@ -227,14 +237,23 @@ export class ChatEditor extends MobxLitElement {
   private renderMaxNumberOfTurns() {
     const maxNumberOfTurns = this.stage?.maxNumberOfTurns;
 
+    const minNumberOfTurns = this.stage?.minNumberOfTurns ?? 0;
+
     const updateNum = (e: InputEvent) => {
       if (!this.stage) return;
       const value = (e.target as HTMLInputElement).value;
-      // If empty string, set to null; otherwise parse as number (minimum 1)
-      this.experimentEditor.updateStage({
-        ...this.stage,
-        maxNumberOfTurns: value === '' ? null : Math.max(1, Number(value)),
-      });
+      if (value === '') {
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          maxNumberOfTurns: null,
+        });
+      } else {
+        const num = Math.max(minNumberOfTurns, Math.max(1, Number(value)));
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          maxNumberOfTurns: num,
+        });
+      }
     };
 
     return html`

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -124,19 +124,11 @@ export class PrivateChatView extends MobxLitElement {
       : participantMessageCount >= this.stage.minNumberOfTurns;
 
     // Check if minimum time is met
-    let minTimeMet = true;
-    if (
-      this.stage.timeMinimumInMinutes !== null &&
-      this.stage.timeMinimumInMinutes > 0
-    ) {
-      if (!discussionStartTimestamp) {
-        minTimeMet = false;
-      } else {
-        if (elapsedMinutes < this.stage.timeMinimumInMinutes) {
-          minTimeMet = false;
-        }
-      }
-    }
+    const minTimeMet =
+      this.stage.timeMinimumInMinutes == null ||
+      this.stage.timeMinimumInMinutes <= 0 ||
+      (discussionStartTimestamp !== null &&
+        elapsedMinutes >= this.stage.timeMinimumInMinutes);
 
     const isNextDisabled = !minTurnsMet || !minTimeMet;
 

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -14,6 +14,7 @@ import {
   ChatMessage,
   PrivateChatStageConfig,
   UserType,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {getHashBasedColor} from '../../shared/utils';
 import {ResponseTimeoutTracker} from '../../shared/response_timeout';
@@ -86,8 +87,19 @@ export class PrivateChatView extends MobxLitElement {
       participantMessageCount >= this.stage.maxNumberOfTurns &&
       !isWaitingForResponse;
 
-    // Check if conversation has ended (max turns reached and not waiting for response)
-    const isConversationOver = maxTurnsReached;
+    const discussionStartTimestamp =
+      chatMessages.length > 0 ? chatMessages[0].timestamp : null;
+    const elapsedMinutes = discussionStartTimestamp
+      ? getTimeElapsed(discussionStartTimestamp, 'm')
+      : 0;
+
+    const maxTimeReached =
+      this.stage.timeLimitInMinutes !== null &&
+      this.stage.timeLimitInMinutes > 0 &&
+      elapsedMinutes >= this.stage.timeLimitInMinutes;
+
+    // Check if conversation has ended
+    const isConversationOver = maxTurnsReached || maxTimeReached;
 
     // Disable input if turn-taking is set and latest message
     // is from participant OR if conversation is over
@@ -111,6 +123,23 @@ export class PrivateChatView extends MobxLitElement {
         !isWaitingForResponse
       : participantMessageCount >= this.stage.minNumberOfTurns;
 
+    // Check if minimum time is met
+    let minTimeMet = true;
+    if (
+      this.stage.timeMinimumInMinutes !== null &&
+      this.stage.timeMinimumInMinutes > 0
+    ) {
+      if (!discussionStartTimestamp) {
+        minTimeMet = false;
+      } else {
+        if (elapsedMinutes < this.stage.timeMinimumInMinutes) {
+          minTimeMet = false;
+        }
+      }
+    }
+
+    const isNextDisabled = !minTurnsMet || !minTimeMet;
+
     return html`
       <chat-interface .stage=${this.stage} .disableInput=${isDisabledInput()}>
         ${chatMessages.map((message) => this.renderChatMessage(message))}
@@ -119,12 +148,15 @@ export class PrivateChatView extends MobxLitElement {
           : nothing}
         ${isConversationOver ? this.renderConversationEndedMessage() : nothing}
       </chat-interface>
-      <stage-footer .disabled=${!minTurnsMet}>
+      <stage-footer .disabled=${isNextDisabled}>
         ${this.stage.progress.showParticipantProgress
           ? html`<progress-stage-completed></progress-stage-completed>`
           : nothing}
         ${!minTurnsMet && !isConversationOver
           ? this.renderMinTurnsMessage(participantMessageCount)
+          : nothing}
+        ${!minTimeMet && minTurnsMet && !isConversationOver
+          ? this.renderMinTimeMessage()
           : nothing}
       </stage-footer>
     `;
@@ -195,6 +227,15 @@ export class PrivateChatView extends MobxLitElement {
       <div class="description">
         Please send at least ${remaining} more
         message${remaining === 1 ? '' : 's'} before proceeding.
+      </div>
+    `;
+  }
+
+  private renderMinTimeMessage() {
+    return html`
+      <div class="description">
+        You must wait until ${this.stage?.timeMinimumInMinutes} minutes have
+        passed.
       </div>
     `;
   }

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -226,8 +226,8 @@ export class PrivateChatView extends MobxLitElement {
   private renderMinTimeMessage() {
     return html`
       <div class="description">
-        You must wait until ${this.stage?.timeMinimumInMinutes} minutes have
-        passed.
+        You must stay on this chat for at least
+        ${this.stage?.timeMinimumInMinutes} minutes.
       </div>
     `;
   }

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -98,8 +98,18 @@ export class PrivateChatView extends MobxLitElement {
       this.stage.timeLimitInMinutes > 0 &&
       elapsedMinutes >= this.stage.timeLimitInMinutes;
 
+    // Check if minimum number of turns met for progression
+    // For turn-based chats, only count completed turns (where agent has responded)
+    const minTurnsMet = this.stage.isTurnBasedChat
+      ? participantMessageCount >= this.stage.minNumberOfTurns &&
+        !isWaitingForResponse
+      : participantMessageCount >= this.stage.minNumberOfTurns;
+
     // Check if conversation has ended
-    const isConversationOver = maxTurnsReached || maxTimeReached;
+    // Min turns takes precedence: conversation stays open until min turns is met,
+    // even if max time has elapsed.
+    const isConversationOver =
+      maxTurnsReached || (maxTimeReached && minTurnsMet);
 
     // Disable input if turn-taking is set and latest message
     // is from participant OR if conversation is over
@@ -116,13 +126,6 @@ export class PrivateChatView extends MobxLitElement {
       return isWaitingForResponse;
     };
 
-    // Check if minimum number of turns met for progression
-    // For turn-based chats, only count completed turns (where agent has responded)
-    const minTurnsMet = this.stage.isTurnBasedChat
-      ? participantMessageCount >= this.stage.minNumberOfTurns &&
-        !isWaitingForResponse
-      : participantMessageCount >= this.stage.minNumberOfTurns;
-
     // Check if minimum time is met
     const minTimeMet =
       this.stage.timeMinimumInMinutes == null ||
@@ -138,16 +141,21 @@ export class PrivateChatView extends MobxLitElement {
         ${isWaitingForResponse && !isConversationOver
           ? this.renderAgentIndicator(chatMessages)
           : nothing}
-        ${isConversationOver ? this.renderConversationEndedMessage() : nothing}
+        ${isConversationOver && minTimeMet
+          ? this.renderConversationEndedMessage()
+          : nothing}
+        ${isConversationOver && !minTimeMet
+          ? this.renderWaitingForMinTimeMessage(elapsedMinutes)
+          : nothing}
       </chat-interface>
       <stage-footer .disabled=${isNextDisabled}>
         ${this.stage.progress.showParticipantProgress
           ? html`<progress-stage-completed></progress-stage-completed>`
           : nothing}
         ${!minTurnsMet && !isConversationOver
-          ? this.renderMinTurnsMessage(participantMessageCount)
+          ? this.renderMinTurnsMessage(participantMessageCount, maxTimeReached)
           : nothing}
-        ${!minTimeMet && minTurnsMet && !isConversationOver
+        ${!minTimeMet && minTurnsMet
           ? this.renderMinTimeMessage(elapsedMinutes)
           : nothing}
       </stage-footer>
@@ -212,13 +220,26 @@ export class PrivateChatView extends MobxLitElement {
     `;
   }
 
-  private renderMinTurnsMessage(currentCount: number) {
+  private renderWaitingForMinTimeMessage(elapsedMinutes: number) {
+    const remaining = Math.ceil(
+      (this.stage?.timeMinimumInMinutes ?? 0) - elapsedMinutes,
+    );
+    return html`
+      <div class="description">
+        The conversation has ended. Please wait ${remaining} more
+        minute${remaining !== 1 ? 's' : ''} before proceeding.
+      </div>
+    `;
+  }
+
+  private renderMinTurnsMessage(currentCount: number, maxTimeReached: boolean) {
     const remaining = this.stage!.minNumberOfTurns - currentCount;
     if (remaining <= 0) return nothing;
     return html`
       <div class="description">
-        Please send at least ${remaining} more
-        message${remaining === 1 ? '' : 's'} before proceeding.
+        ${maxTimeReached ? 'Time is up, but please' : 'Please'} send at least
+        ${remaining} more message${remaining === 1 ? '' : 's'} before
+        proceeding.
       </div>
     `;
   }

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -148,7 +148,7 @@ export class PrivateChatView extends MobxLitElement {
           ? this.renderMinTurnsMessage(participantMessageCount)
           : nothing}
         ${!minTimeMet && minTurnsMet && !isConversationOver
-          ? this.renderMinTimeMessage()
+          ? this.renderMinTimeMessage(elapsedMinutes)
           : nothing}
       </stage-footer>
     `;
@@ -223,11 +223,14 @@ export class PrivateChatView extends MobxLitElement {
     `;
   }
 
-  private renderMinTimeMessage() {
+  private renderMinTimeMessage(elapsedMinutes: number) {
+    const remaining = Math.ceil(
+      (this.stage?.timeMinimumInMinutes ?? 0) - elapsedMinutes,
+    );
     return html`
       <div class="description">
-        You must stay on this chat for at least
-        ${this.stage?.timeMinimumInMinutes} minutes.
+        You must stay in this chat for at least ${remaining} more
+        minute${remaining !== 1 ? 's' : ''}.
       </div>
     `;
   }

--- a/frontend/src/shared/templates/agent_participant_integration_template.ts
+++ b/frontend/src/shared/templates/agent_participant_integration_template.ts
@@ -254,7 +254,7 @@ const INT_GROUP_CHAT_STAGE = createChatStage({
     minParticipants: 2,
   }),
   timeLimitInMinutes: 2,
-  requireFullTime: true,
+  timeMinimumInMinutes: 2,
 });
 
 // ****************************************************************************

--- a/frontend/src/shared/templates/charity_allocations.ts
+++ b/frontend/src/shared/templates/charity_allocations.ts
@@ -1,8 +1,6 @@
 import {
-  createTextPromptItem,
   createChatStage,
   createDefaultMediatorGroupChatPrompt,
-  createDefaultStageContextPromptItem,
   AgentMediatorTemplate,
   MediatorPromptConfig,
   createAgentMediatorPersonaConfig,
@@ -11,9 +9,6 @@ import {
   StructuredOutputSchema,
   createStructuredOutputConfig,
   createAgentChatSettings,
-  PromptItemType,
-  ProfileInfoPromptItem,
-  ProfileContextPromptItem,
   DEFAULT_AGENT_MODEL_SETTINGS,
   DEFAULT_EXPLANATION_FIELD,
   DEFAULT_READY_TO_END_FIELD,
@@ -461,9 +456,6 @@ export function getCharityDebateTemplate(
         discussionStageId,
         `${EMOJIS[roundNum - 1]} Round ${roundNum}: Discussion`,
         setting,
-        {
-          persona: {id: mediatorAgentId, name: mediatorFriendlyName},
-        } as AgentMediatorTemplate,
       );
     } else {
       discussionStage = createAllocationDiscussionStage(
@@ -554,7 +546,6 @@ function createDiscussionStageWithMediator(
   stageId: string,
   stageName: string,
   setting: string,
-  mediatorTemplate: AgentMediatorTemplate,
 ): StageConfig {
   const mediatorText = `\n\n🤖 An AI-based facilitator will be present in this discussion.`;
   const discussionText = `Discuss the ideal allocation of ${setting}.${mediatorText}`;

--- a/frontend/src/shared/templates/charity_allocations.ts
+++ b/frontend/src/shared/templates/charity_allocations.ts
@@ -565,7 +565,7 @@ function createDiscussionStageWithMediator(
     descriptions: createStageTextConfig({primaryText: discussionText}),
     progress: createStageProgressConfig({waitForAllParticipants: true}),
     timeLimitInMinutes: 5,
-    requireFullTime: true, // Setting this to True causes the timeLimit to be a min AND maximum.
+    timeMinimumInMinutes: 5,
   });
 }
 
@@ -935,7 +935,7 @@ function createAllocationDiscussionStage(
     descriptions: createStageTextConfig({primaryText: discussionText}),
     progress: createStageProgressConfig({waitForAllParticipants: true}),
     timeLimitInMinutes: 5,
-    requireFullTime: true,
+    timeMinimumInMinutes: 5,
   });
 }
 

--- a/frontend/src/shared/templates/charity_allocations_ootb.ts
+++ b/frontend/src/shared/templates/charity_allocations_ootb.ts
@@ -566,7 +566,7 @@ function createDiscussionStageWithMediator(
     descriptions: createStageTextConfig({primaryText: discussionText}),
     progress: createStageProgressConfig({waitForAllParticipants: true}),
     timeLimitInMinutes: 5,
-    requireFullTime: true, // Setting this to True causes the timeLimit to be a min AND maximum.
+    timeMinimumInMinutes: 5,
   });
 }
 
@@ -936,7 +936,7 @@ function createAllocationDiscussionStage(
     descriptions: createStageTextConfig({primaryText: discussionText}),
     progress: createStageProgressConfig({waitForAllParticipants: true}),
     timeLimitInMinutes: 5,
-    requireFullTime: true,
+    timeMinimumInMinutes: 5,
   });
 }
 

--- a/frontend/src/shared/templates/charity_allocations_ootb.ts
+++ b/frontend/src/shared/templates/charity_allocations_ootb.ts
@@ -1,9 +1,7 @@
 import {
   ApiKeyType,
   AgentModelSettings,
-  createTextPromptItem,
   createChatStage,
-  createDefaultStageContextPromptItem,
   AgentMediatorTemplate,
   MediatorPromptConfig,
   createAgentMediatorPersonaConfig,
@@ -12,10 +10,6 @@ import {
   StructuredOutputSchema,
   createStructuredOutputConfig,
   createAgentChatSettings,
-  PromptItemType,
-  ProfileInfoPromptItem,
-  ProfileContextPromptItem,
-  DEFAULT_AGENT_MODEL_SETTINGS,
   DEFAULT_EXPLANATION_FIELD,
   DEFAULT_READY_TO_END_FIELD,
   DEFAULT_RESPONSE_FIELD,
@@ -69,32 +63,6 @@ export enum MediatorModelType {
 const GEMINI_MEDIATOR_ID = 'gemini-mediator-agent';
 const CLAUDE_MEDIATOR_ID = 'claude-mediator-agent';
 const OPENAI_MEDIATOR_ID = 'openai-mediator-agent';
-
-const FAILURE_MODE_ENUMS = [
-  'NoFailureModeDetected',
-  'LowEffortOrLowEngagement',
-  'OffTopicDrift',
-  'UnevenParticipation',
-  'NoJustificationOrPrematureConsensus',
-  'BinaryStuck',
-  'SelfContainedReasoningOnly',
-];
-
-const SOLUTION_STRATEGY_ENUMS = [
-  'NoSolutionNeeded', // No failure mode / still early
-  // LowEffortOrLowEngagement
-  'InviteBriefReasoningOrValues',
-  // OffTopicDrift
-  'GentlyRefocusOnAllocationTask',
-  // UnevenParticipation
-  'InviteQuietVoiceOpenSpace',
-  // NoJustificationOrPrematureConsensus
-  'CheckConsensusElicitOneReason',
-  // BinaryStuck
-  'ExploreMiddleGroundOrSharedGoals',
-  // SelfContainedReasoningOnly
-  'PromptEngagementWithOthers',
-];
 
 export const OOTB_CHARITY_DEBATE_METADATA = createMetadataConfig({
   name: 'Out-of-the-box Mediated Charity Debate (3 Rounds)',

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "test": "npm run test:unit && npm run test:firestore",
-    "test:firestore": "firebase -c ../firebase-test.json emulators:exec --only firestore,functions --project=demo-deliberate-lab \"npx jest --runInBand $npm_package_config_firestore_tests\"",
+    "test:firestore": "GOOGLE_CLOUD_PROJECT=demo-deliberate-lab firebase -c ../firebase-test.json emulators:exec --only firestore,functions --project=demo-deliberate-lab \"npx jest --runInBand $npm_package_config_firestore_tests\"",
     "test:unit": "npx jest --testPathIgnorePatterns=$npm_package_config_firestore_tests",
     "typecheck": "tsc --noEmit",
     "migrate:require-full-time": "npx tsx src/migrations/migrate-require-full-time.ts",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,9 @@
     "test": "npm run test:unit && npm run test:firestore",
     "test:firestore": "firebase -c ../firebase-test.json emulators:exec --only firestore,functions --project=demo-deliberate-lab \"npx jest --runInBand $npm_package_config_firestore_tests\"",
     "test:unit": "npx jest --testPathIgnorePatterns=$npm_package_config_firestore_tests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "migrate:require-full-time": "npx tsx src/migrations/migrate-require-full-time.ts",
+    "migrate:require-full-time:apply": "npx tsx src/migrations/migrate-require-full-time.ts --apply"
   },
   "engines": {
     "node": "22"

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -1,7 +1,12 @@
 import {
   ChatMessage,
+  ChatStageConfig,
+  ChatStagePublicData,
+  ChatStageParticipantAnswer,
   createChatMessage,
+  createChatStageParticipantAnswer,
   createSystemChatMessage,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 import {app} from '../app';
@@ -14,13 +19,6 @@ import {
   getFirestoreExperiment,
   getFirestoreParticipantRef,
 } from '../utils/firestore';
-import {
-  ChatStageConfig,
-  ChatStagePublicData,
-  ChatStageParticipantAnswer,
-  createChatStageParticipantAnswer,
-  getTimeElapsed,
-} from '@deliberation-lab/utils';
 import {updateParticipantNextStage} from '../participant.utils';
 
 /** Used for private chats if model response fails. */
@@ -72,33 +70,33 @@ export async function updateParticipantReadyToEndChat(
   );
   if (!publicStageData) return;
 
-  let startTimestamp = (publicStageData as ChatStagePublicData)
-    .discussionStartTimestamp;
-
-  if (stage.kind === 'privateChat' && !startTimestamp) {
-    const chatRef = app
-      .firestore()
-      .collection('experiments')
-      .doc(experimentId)
-      .collection('participants')
-      .doc(participantId)
-      .collection('stageData')
-      .doc(stage.id)
-      .collection('privateChats')
-      .orderBy('timestamp', 'asc')
-      .limit(1);
-
-    const chatSnap = await chatRef.get();
-    if (!chatSnap.empty) {
-      startTimestamp = chatSnap.docs[0].data().timestamp as Timestamp;
-    }
-  }
-
   const minTime = (stage as ChatStageConfig).timeMinimumInMinutes;
-  if (minTime !== undefined && minTime !== null && minTime > 0) {
+  if (minTime != null && minTime > 0) {
+    let startTimestamp = (publicStageData as ChatStagePublicData)
+      .discussionStartTimestamp;
+
+    // For private chats, fall back to the first message timestamp
+    if (stage.kind === 'privateChat' && !startTimestamp) {
+      const results = await app
+        .firestore()
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('stageData')
+        .doc(stage.id)
+        .collection('privateChats')
+        .orderBy('timestamp', 'asc')
+        .limit(1)
+        .get();
+
+      if (!results.empty) {
+        startTimestamp = results.docs[0].data().timestamp as Timestamp;
+      }
+    }
+
     if (!startTimestamp) return;
-    const elapsedMinutes = getTimeElapsed(startTimestamp, 'm');
-    if (elapsedMinutes < minTime) return;
+    if (getTimeElapsed(startTimestamp, 'm') < minTime) return;
   }
 
   const participantAnswerDoc = getFirestoreParticipantAnswerRef(

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -19,6 +19,7 @@ import {
   ChatStagePublicData,
   ChatStageParticipantAnswer,
   createChatStageParticipantAnswer,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {updateParticipantNextStage} from '../participant.utils';
 
@@ -71,6 +72,35 @@ export async function updateParticipantReadyToEndChat(
   );
   if (!publicStageData) return;
 
+  let startTimestamp = (publicStageData as ChatStagePublicData)
+    .discussionStartTimestamp;
+
+  if (stage.kind === 'privateChat' && !startTimestamp) {
+    const chatRef = app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('participants')
+      .doc(participantId)
+      .collection('stageData')
+      .doc(stage.id)
+      .collection('privateChats')
+      .orderBy('timestamp', 'asc')
+      .limit(1);
+
+    const chatSnap = await chatRef.get();
+    if (!chatSnap.empty) {
+      startTimestamp = chatSnap.docs[0].data().timestamp as Timestamp;
+    }
+  }
+
+  const minTime = (stage as ChatStageConfig).timeMinimumInMinutes;
+  if (minTime !== undefined && minTime !== null && minTime > 0) {
+    if (!startTimestamp) return;
+    const elapsedMinutes = getTimeElapsed(startTimestamp, 'm');
+    if (elapsedMinutes < minTime) return;
+  }
+
   const participantAnswerDoc = getFirestoreParticipantAnswerRef(
     experimentId,
     participantId,
@@ -111,6 +141,7 @@ export async function updateParticipantReadyToEndChat(
   } else {
     // Otherwise, move to next stage
     const experiment = await getFirestoreExperiment(experimentId);
+    if (!experiment) return;
     await updateParticipantNextStage(
       experimentId,
       participant,

--- a/functions/src/dl_api/experiments.dl_api.integration.test.ts
+++ b/functions/src/dl_api/experiments.dl_api.integration.test.ts
@@ -15,6 +15,7 @@ import {
   ProlificConfig,
   Visibility,
   createExperimentConfig,
+  createPrivateChatStage,
 } from '@deliberation-lab/utils';
 import {
   TestContext,
@@ -893,6 +894,27 @@ describe('API Experiment Creation Integration Tests', () => {
         const forkStage = normalizeStageForComparison(forkedExp.stages[i]);
         expect(forkStage).toEqual(origStage);
       }
+    });
+  });
+
+  // ==========================================================================
+  // Stage Validation Tests
+  // ==========================================================================
+
+  describe('Stage validation', () => {
+    it('should reject experiment creation with invalid stage config (minTurns > maxTurns)', async () => {
+      const invalidStage = createPrivateChatStage({
+        name: 'Invalid chat',
+        minNumberOfTurns: 10,
+        maxNumberOfTurns: 3,
+      });
+
+      const response = await apiRequest('POST', '/v1/experiments', {
+        name: 'Invalid experiment',
+        stages: JSON.parse(JSON.stringify([invalidStage])),
+      });
+
+      expect(response.ok).toBe(false);
     });
   });
 });

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -22,6 +22,7 @@ import {getExperimentDownload} from './data';
 import {generateVariablesForScope} from './variables.utils';
 import {AuthGuard} from './utils/auth-guard';
 import {createCohortFromDefinition} from './cohort.utils';
+import {validateStages} from './utils/validation';
 
 /**
  * Create cohorts from cohort definitions and update the definitions with generated IDs.
@@ -79,6 +80,12 @@ export async function writeExperimentFromTemplate(
   options: WriteExperimentOptions = {},
 ): Promise<string> {
   const {collectionName = 'experiments'} = options;
+
+  // Validate stage configs (schema + cross-field business rules)
+  const stageValidation = validateStages(template.stageConfigs);
+  if (!stageValidation.valid) {
+    throw new Error(`Invalid stage configuration: ${stageValidation.error}`);
+  }
 
   // Set up experiment config with stageIds
   const experimentConfig = createExperimentConfig(
@@ -298,7 +305,11 @@ export interface UpdateExperimentOptions {
  */
 export interface UpdateExperimentResult {
   success: boolean;
-  error?: 'not-found' | 'not-owner' | 'cohort-definitions-locked';
+  error?:
+    | 'not-found'
+    | 'not-owner'
+    | 'cohort-definitions-locked'
+    | 'invalid-stages';
 }
 
 /**
@@ -321,6 +332,12 @@ export async function updateExperimentFromTemplate(
   options: UpdateExperimentOptions = {},
 ): Promise<UpdateExperimentResult> {
   const {collectionName = 'experiments'} = options;
+
+  // Validate stage configs (schema + cross-field business rules)
+  const stageValidation = validateStages(template.stageConfigs);
+  if (!stageValidation.valid) {
+    return {success: false, error: 'invalid-stages'};
+  }
 
   // Set up experiment config with stageIds
   const experimentConfig = createExperimentConfig(

--- a/functions/src/migrations/migrate-require-full-time.ts
+++ b/functions/src/migrations/migrate-require-full-time.ts
@@ -74,12 +74,19 @@ async function migrateStages(dryRun: boolean): Promise<ExperimentMigration[]> {
       .collection('stages')
       .get();
 
+    const stageDocs = stagesSnapshot.docs.filter(
+      (doc) => doc.data().requireFullTime,
+    );
+    if (stageDocs.length === 0) continue;
+
+    console.log(
+      `\n[${dateCreated}] [${experimentId}] ${experimentName} — ${stageDocs.length} stage(s):`,
+    );
+
     const stages: StageMigration[] = [];
-
-    for (const stageDoc of stagesSnapshot.docs) {
+    for (const stageDoc of stageDocs) {
       const stage = stageDoc.data();
-
-      if (!stage.requireFullTime) continue;
+      const timeMinimumInMinutes = stage.timeLimitInMinutes ?? null;
 
       const result: StageMigration = {
         stageId: stageDoc.id,
@@ -89,8 +96,6 @@ async function migrateStages(dryRun: boolean): Promise<ExperimentMigration[]> {
       };
 
       try {
-        const timeMinimumInMinutes = stage.timeLimitInMinutes ?? null;
-
         console.log(
           `  Stage "${stage.name}" (${stage.kind}): ` +
             `requireFullTime: true → timeMinimumInMinutes: ${timeMinimumInMinutes}`,
@@ -113,12 +118,7 @@ async function migrateStages(dryRun: boolean): Promise<ExperimentMigration[]> {
       stages.push(result);
     }
 
-    if (stages.length > 0) {
-      console.log(
-        `\n[${dateCreated}] ${experimentName} [${experimentId}] — ${stages.length} stage(s):`,
-      );
-      experiments.push({experimentId, experimentName, dateCreated, stages});
-    }
+    experiments.push({experimentId, experimentName, dateCreated, stages});
   }
 
   return experiments;
@@ -175,7 +175,7 @@ async function main() {
       const errors = exp.stages.filter((s) => s.error);
       const status = errors.length > 0 ? `${errors.length} error(s)` : 'OK';
       console.log(
-        `  [${exp.dateCreated}] ${exp.experimentName} [${exp.experimentId}]: ${exp.stages.length} stage(s) — ${status}`,
+        `  [${exp.dateCreated}] [${exp.experimentId}] ${exp.experimentName}: ${exp.stages.length} stage(s) — ${status}`,
       );
     }
   }

--- a/functions/src/migrations/migrate-require-full-time.ts
+++ b/functions/src/migrations/migrate-require-full-time.ts
@@ -1,0 +1,199 @@
+/**
+ * One-time migration script to convert requireFullTime to timeMinimumInMinutes.
+ *
+ * For any stage with requireFullTime: true, this sets
+ * timeMinimumInMinutes = timeLimitInMinutes (making the minimum equal to the
+ * maximum, which is the equivalent behavior).
+ *
+ * Usage:
+ *   cd functions
+ *   npm run migrate:require-full-time            # Preview changes (dry run)
+ *   npm run migrate:require-full-time:apply      # Apply changes
+ *
+ * Options:
+ *   --apply    Apply changes (default is dry run)
+ */
+
+import * as admin from 'firebase-admin';
+import * as readline from 'readline';
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    projectId: process.env.GCLOUD_PROJECT || 'deliberate-lab',
+  });
+}
+
+const db = admin.firestore();
+
+interface StageMigration {
+  stageId: string;
+  stageName: string;
+  stageKind: string;
+  timeLimitInMinutes: number | null;
+  error?: string;
+}
+
+interface ExperimentMigration {
+  experimentId: string;
+  experimentName: string;
+  dateCreated: string;
+  stages: StageMigration[];
+}
+
+async function migrateStages(dryRun: boolean): Promise<ExperimentMigration[]> {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`requireFullTime → timeMinimumInMinutes Migration`);
+  console.log(
+    `Mode: ${dryRun ? 'DRY RUN (no changes will be written)' : 'LIVE'}`,
+  );
+  console.log(`${'='.repeat(60)}\n`);
+
+  const experiments: ExperimentMigration[] = [];
+
+  const experimentsSnapshot = await db.collection('experiments').get();
+  console.log(`Found ${experimentsSnapshot.size} experiments to check.\n`);
+
+  const sortedDocs = [...experimentsSnapshot.docs].sort((a, b) => {
+    const aTime = a.data()?.metadata?.dateCreated?.seconds ?? 0;
+    const bTime = b.data()?.metadata?.dateCreated?.seconds ?? 0;
+    return aTime - bTime;
+  });
+
+  for (const experimentDoc of sortedDocs) {
+    const experimentId = experimentDoc.id;
+    const experimentData = experimentDoc.data();
+    const experimentName = experimentData?.metadata?.name || 'Unnamed';
+    const dateCreated = experimentData?.metadata?.dateCreated?.seconds
+      ? new Date(experimentData.metadata.dateCreated.seconds * 1000)
+          .toISOString()
+          .split('T')[0]
+      : 'unknown';
+    const stagesSnapshot = await db
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('stages')
+      .get();
+
+    const stages: StageMigration[] = [];
+
+    for (const stageDoc of stagesSnapshot.docs) {
+      const stage = stageDoc.data();
+
+      if (!stage.requireFullTime) continue;
+
+      const result: StageMigration = {
+        stageId: stageDoc.id,
+        stageName: stage.name || 'Unnamed',
+        stageKind: stage.kind || 'unknown',
+        timeLimitInMinutes: stage.timeLimitInMinutes ?? null,
+      };
+
+      try {
+        const timeMinimumInMinutes = stage.timeLimitInMinutes ?? null;
+
+        console.log(
+          `  Stage "${stage.name}" (${stage.kind}): ` +
+            `requireFullTime: true → timeMinimumInMinutes: ${timeMinimumInMinutes}`,
+        );
+
+        if (!dryRun) {
+          await stageDoc.ref.update({
+            timeMinimumInMinutes,
+            requireFullTime: admin.firestore.FieldValue.delete(),
+          });
+          console.log(`    Updated.`);
+        } else {
+          console.log(`    [DRY RUN] Would update.`);
+        }
+      } catch (error) {
+        result.error = error instanceof Error ? error.message : String(error);
+        console.error(`    Error: ${result.error}`);
+      }
+
+      stages.push(result);
+    }
+
+    if (stages.length > 0) {
+      console.log(
+        `\n[${dateCreated}] ${experimentName} [${experimentId}] — ${stages.length} stage(s):`,
+      );
+      experiments.push({experimentId, experimentName, dateCreated, stages});
+    }
+  }
+
+  return experiments;
+}
+
+function confirm(prompt: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(prompt, (answer: string) => {
+      rl.close();
+      resolve(['y', 'yes'].includes(answer.trim().toLowerCase()));
+    });
+  });
+}
+
+async function main() {
+  const dryRun = !process.argv.includes('--apply');
+  const projectId = process.env.GCLOUD_PROJECT || 'deliberate-lab';
+
+  console.log(`\nProject: ${projectId}`);
+  console.log(
+    `Mode: ${dryRun ? 'DRY RUN' : 'LIVE (will write to Firestore)'}\n`,
+  );
+
+  const confirmed = await confirm(
+    `Proceed with ${dryRun ? 'dry run' : 'LIVE migration'}? (y/N): `,
+  );
+  if (!confirmed) {
+    console.log('Aborted.');
+    process.exit(0);
+  }
+
+  const experiments = await migrateStages(dryRun);
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Summary`);
+  console.log(`${'='.repeat(60)}`);
+
+  const totalStages = experiments.reduce((sum, e) => sum + e.stages.length, 0);
+  const totalErrors = experiments.reduce(
+    (sum, e) => sum + e.stages.filter((s) => s.error).length,
+    0,
+  );
+
+  console.log(`Experiments affected: ${experiments.length}`);
+  console.log(`Stages migrated: ${totalStages}`);
+
+  if (experiments.length > 0) {
+    console.log('');
+    for (const exp of experiments) {
+      const errors = exp.stages.filter((s) => s.error);
+      const status = errors.length > 0 ? `${errors.length} error(s)` : 'OK';
+      console.log(
+        `  [${exp.dateCreated}] ${exp.experimentName} [${exp.experimentId}]: ${exp.stages.length} stage(s) — ${status}`,
+      );
+    }
+  }
+
+  if (totalErrors > 0) {
+    console.log(`\nErrors: ${totalErrors}`);
+    for (const exp of experiments) {
+      for (const s of exp.stages.filter((s) => s.error)) {
+        console.log(`  "${exp.experimentName}" → "${s.stageName}": ${s.error}`);
+      }
+    }
+  }
+
+  if (dryRun && totalStages > 0) {
+    console.log(`\nRun with --apply to apply changes.`);
+  }
+
+  process.exit(totalErrors > 0 ? 1 : 0);
+}
+
+main();

--- a/functions/src/stages/chat.endpoints.ts
+++ b/functions/src/stages/chat.endpoints.ts
@@ -125,7 +125,7 @@ export const updateChatStageParticipantAnswer = onCall(async (request) => {
   const stage = await getFirestoreStage(data.experimentId, stageId);
   if (stage) {
     const minTime = (stage as ChatStageConfig).timeMinimumInMinutes;
-    if (minTime !== undefined && minTime !== null && minTime > 0) {
+    if (minTime != null && minTime > 0) {
       const publicStageData = await getFirestoreStagePublicData(
         data.experimentId,
         data.cohortId,

--- a/functions/src/stages/chat.endpoints.ts
+++ b/functions/src/stages/chat.endpoints.ts
@@ -1,13 +1,19 @@
 import {Value} from '@sinclair/typebox/value';
 import {
+  ChatStageConfig,
+  ChatStagePublicData,
   StageKind,
   UpdateChatStageParticipantAnswerData,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 import {onCall, HttpsError} from 'firebase-functions/v2/https';
 
 import {app} from '../app';
-import {getFirestoreStage} from '../utils/firestore';
+import {
+  getFirestoreStage,
+  getFirestoreStagePublicData,
+} from '../utils/firestore';
 import {
   checkConfigDataUnionOnPath,
   isUnionError,
@@ -112,6 +118,28 @@ export const updateChatStageParticipantAnswer = onCall(async (request) => {
   const validInput = Value.Check(UpdateChatStageParticipantAnswerData, data);
   if (!validInput) {
     handleUpdateChatStageParticipantAnswerValidationErrors(data);
+  }
+
+  // Check minimum time enforcement
+  const stageId = data.chatStageParticipantAnswer.id;
+  const stage = await getFirestoreStage(data.experimentId, stageId);
+  if (stage) {
+    const minTime = (stage as ChatStageConfig).timeMinimumInMinutes;
+    if (minTime !== undefined && minTime !== null && minTime > 0) {
+      const publicStageData = await getFirestoreStagePublicData(
+        data.experimentId,
+        data.cohortId,
+        stageId,
+      );
+      const startTimestamp = (publicStageData as ChatStagePublicData)
+        ?.discussionStartTimestamp;
+      if (!startTimestamp || getTimeElapsed(startTimestamp, 'm') < minTime) {
+        throw new HttpsError(
+          'failed-precondition',
+          'Minimum time requirement has not been met.',
+        );
+      }
+    }
   }
 
   // Define document reference

--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -185,7 +185,7 @@ export function validateStages(stages: unknown[]): ValidationResult {
                 `  - ${nestedError.path}: ${nestedError.message}`,
               );
             }
-          } catch (err) {
+          } catch {
             // If drilling into union fails, fall back to generic error
             errorMessages.push(`  - ${error.path}: ${error.message}`);
           }

--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -1,6 +1,7 @@
 /** Pretty printing and analysis utils for typebox validation */
 
 import {
+  BaseStageConfig,
   CONFIG_DATA,
   CohortParticipantConfig,
   CohortParticipantConfigSchema,
@@ -111,12 +112,17 @@ export const checkUnionErrorOnPath = (
     : Value.Errors(validator, value);
 };
 
+/** Schema-only map extracted from CONFIG_DATA for union error resolution. */
+const CONFIG_DATA_SCHEMAS: Record<Index, TSchema> = Object.fromEntries(
+  Object.entries(CONFIG_DATA).map(([key, entry]) => [key, entry.schema]),
+);
+
 // Variants
 export const checkConfigDataUnionOnPath = (
   data: unknown,
   path: string,
   references?: TSchema[],
-) => checkUnionErrorOnPath(data, path, CONFIG_DATA, references);
+) => checkUnionErrorOnPath(data, path, CONFIG_DATA_SCHEMAS, references);
 
 // ************************************************************************* //
 // STAGE VALIDATION                                                          //
@@ -185,6 +191,19 @@ export function validateStages(stages: unknown[]): ValidationResult {
           }
         } else {
           errorMessages.push(`  - ${error.path}: ${error.message}`);
+        }
+      }
+    } else {
+      // Schema passed — run cross-field business rule validation
+      const stageObj = stage as BaseStageConfig;
+      const entry = CONFIG_DATA[stageObj.kind as string];
+      if (entry?.validate) {
+        const result = entry.validate(stageObj);
+        if (!result.valid) {
+          const stageName = stageObj?.name || 'unnamed';
+          errorMessages.push(
+            `Stage ${i} (name: "${stageName}", kind: "${stageObj.kind}"): ${result.error}`,
+          );
         }
       }
     }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -366,7 +366,7 @@ class PrivateChatStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     timeLimitInMinutes: float | None = None
-    requireFullTime: bool | None = None
+    timeMinimumInMinutes: float | None = None
     isTurnBasedChat: bool | None = None
     minNumberOfTurns: float | None = None
     maxNumberOfTurns: float | None = None
@@ -987,7 +987,7 @@ class ChatStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     timeLimitInMinutes: float | None = None
-    requireFullTime: bool | None = None
+    timeMinimumInMinutes: float | None = None
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
 
 

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -61,26 +61,12 @@ class CohortDefinition(BaseModel):
     maxParticipantsPerCohort: Annotated[int | None, Field(ge=1)] = None
 
 
-class MinParticipantsPerCohort(RootModel[int]):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    root: Annotated[int, Field(ge=0)]
-
-
-class MaxParticipantsPerCohort(RootModel[int]):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    root: Annotated[int, Field(ge=1)]
-
-
 class CohortParticipantConfig(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    minParticipantsPerCohort: MinParticipantsPerCohort | None = None
-    maxParticipantsPerCohort: MaxParticipantsPerCohort | None = None
+    minParticipantsPerCohort: Annotated[int | None, Field(ge=0)] = None
+    maxParticipantsPerCohort: Annotated[int | None, Field(ge=1)] = None
     includeAllParticipantsInCohortCount: bool
     botProtection: bool
 
@@ -365,8 +351,8 @@ class PrivateChatStageConfig(BaseModel):
     name: Annotated[str, Field(min_length=1)]
     descriptions: StageTextConfig
     progress: StageProgressConfig
-    timeLimitInMinutes: float | None = None
-    timeMinimumInMinutes: float | None = None
+    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
+    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     isTurnBasedChat: bool | None = None
     minNumberOfTurns: float | None = None
     maxNumberOfTurns: float | None = None
@@ -986,8 +972,8 @@ class ChatStageConfig(BaseModel):
     name: Annotated[str, Field(min_length=1)]
     descriptions: StageTextConfig
     progress: StageProgressConfig
-    timeLimitInMinutes: float | None = None
-    timeMinimumInMinutes: float | None = None
+    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
+    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
 
 

--- a/utils/src/export-schemas.ts
+++ b/utils/src/export-schemas.ts
@@ -266,7 +266,80 @@ function simplifyAllOf(obj: unknown): unknown {
   return result;
 }
 
-const simplifiedSchema = simplifyAllOf(fixedSchema) as Record<string, unknown>;
+/**
+ * Simplify unions that consist only of simple primitive types (plus null).
+ *
+ * Pattern: anyOf: [{type: 'integer', ...}, {type: 'null'}]
+ * Simplified: {type: ['integer', 'null'], ...}
+ *
+ * This allows datamodel-codegen to inline these as Optional[primitive] instead
+ * of creating RootModels or subclasses. It safely avoids collapsing enums or literals.
+ */
+function simplifyUnions(obj: unknown): unknown {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => simplifyUnions(item));
+  }
+
+  const record = obj as Record<string, unknown>;
+
+  // Check if this is an anyOf that can be simplified
+  if (Array.isArray(record.anyOf) && record.anyOf.length > 0) {
+    const members = record.anyOf as Record<string, unknown>[];
+
+    // Check if all members are simple primitives (no objects, no arrays, no enums/consts)
+    const canCollapse = members.every(
+      (m) =>
+        m.type &&
+        typeof m.type === 'string' &&
+        m.type !== 'object' &&
+        m.type !== 'array' &&
+        !m.const &&
+        !m.enum &&
+        !m.$ref &&
+        !m.anyOf &&
+        !m.oneOf &&
+        !m.allOf,
+    );
+
+    if (canCollapse) {
+      // Separate members into those with constraints and those without (pure types)
+      const constrained = members.filter((m) => Object.keys(m).length > 1);
+
+      // Only collapse if there's at most one member with constraints (e.g. integer + null)
+      // to avoid merging conflicting rules (like two different patterns).
+      if (constrained.length <= 1) {
+        const types = [...new Set(members.map((m) => m.type as string))];
+        const base = constrained.length === 1 ? constrained[0] : members[0];
+        const result: Record<string, unknown> = {
+          ...base,
+          type: types.length === 1 ? types[0] : types,
+        };
+
+        // Preserve title if it exists on the union itself
+        if (record.title) result.title = record.title;
+
+        return simplifyUnions(result);
+      }
+    }
+  }
+
+  // Recursively process all properties
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    result[key] = simplifyUnions(value);
+  }
+  return result;
+}
+
+const simplifiedAllOf = simplifyAllOf(fixedSchema) as Record<string, unknown>;
+const simplifiedSchema = simplifyUnions(simplifiedAllOf) as Record<
+  string,
+  unknown
+>;
 simplifiedSchema.$id = 'DeliberateLabSchemas';
 
 /**

--- a/utils/src/export-schemas.ts
+++ b/utils/src/export-schemas.ts
@@ -54,8 +54,8 @@ function collectSchemasWithId(
 }
 
 // Verify all stage configs have $id for proper naming in $defs
-for (const [key, schema] of Object.entries(CONFIG_DATA)) {
-  if (!(schema as Record<string, unknown>).$id) {
+for (const [key, entry] of Object.entries(CONFIG_DATA)) {
+  if (!(entry.schema as Record<string, unknown>).$id) {
     throw new Error(
       `Stage config "${key}" is missing $id. Add $id to its TypeBox definition.`,
     );

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -73,6 +73,7 @@ export * from './stages/stage.handler';
 export * from './stages/stage.manager';
 export * from './stages/stage.prompts';
 export * from './stages/stage.validation';
+export * from './stages/stage.schemas';
 
 export * from './stages/chat_stage';
 export * from './stages/chat_stage.manager';

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -29,7 +29,7 @@ export interface ChatStageConfig extends BaseStageConfig {
   kind: StageKind.CHAT;
   discussions: ChatDiscussion[]; // ordered list of discussions
   timeLimitInMinutes: number | null; // How long remaining in the chat.
-  requireFullTime: boolean; // Require participants to stay in chat until time limit is up
+  timeMinimumInMinutes: number | null; // Minimum amount of time participants must spend in chat.
 }
 
 /** Chat discussion. */
@@ -118,7 +118,7 @@ export function createChatStage(
       createStageProgressConfig({waitForAllParticipants: true}),
     discussions: config.discussions ?? [],
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
-    requireFullTime: config.requireFullTime ?? false,
+    timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
   };
 }
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -28,8 +28,9 @@ import {
 export interface ChatStageConfig extends BaseStageConfig {
   kind: StageKind.CHAT;
   discussions: ChatDiscussion[]; // ordered list of discussions
-  timeLimitInMinutes: number | null; // Maximum duration in minutes, or null if no limit.
-  timeMinimumInMinutes: number | null; // Minimum time participants must stay, or null if no minimum.
+  // TODO: Migrate to seconds for internal storage to avoid fractional-minute ambiguity.
+  timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
+  timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
 }
 
 /** Chat discussion. */

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -28,8 +28,8 @@ import {
 export interface ChatStageConfig extends BaseStageConfig {
   kind: StageKind.CHAT;
   discussions: ChatDiscussion[]; // ordered list of discussions
-  timeLimitInMinutes: number | null; // How long remaining in the chat.
-  timeMinimumInMinutes: number | null; // Minimum amount of time participants must spend in chat.
+  timeLimitInMinutes: number | null; // Maximum duration in minutes, or null if no limit.
+  timeMinimumInMinutes: number | null; // Minimum time participants must stay, or null if no minimum.
 }
 
 /** Chat discussion. */

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -62,10 +62,14 @@ export const ChatStageConfigData = Type.Composite(
     Type.Object(
       {
         kind: Type.Literal(StageKind.CHAT),
-        timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
-        timeMinimumInMinutes: Type.Optional(
-          Type.Union([Type.Number(), Type.Null()]),
-        ),
+        timeLimitInMinutes: Type.Union([
+          Type.Integer({minimum: 1}),
+          Type.Null(),
+        ]),
+        timeMinimumInMinutes: Type.Union([
+          Type.Integer({minimum: 1}),
+          Type.Null(),
+        ]),
         discussions: Type.Array(ChatDiscussionData),
       },
       strict,

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -1,9 +1,13 @@
 import {Type, type Static} from '@sinclair/typebox';
 import {UnifiedTimestampSchema} from '../shared.validation';
-import {StageKind} from './stage';
+import {BaseStageConfig, StageKind} from './stage';
 import {ChatDiscussionType} from './chat_stage';
-import {BaseStageConfigSchema} from './stage.schemas';
+import {
+  BaseStageConfigSchema,
+  type StageValidationResult,
+} from './stage.schemas';
 import {UserType} from '../participant';
+import {ChatStageConfig} from './chat_stage';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = {additionalProperties: false} as const;
@@ -69,6 +73,23 @@ export const ChatStageConfigData = Type.Composite(
   ],
   {$id: 'ChatStageConfig', ...strict},
 );
+
+/** Validate cross-field business rules for chat time configs. */
+export function validateChatStageConfig(
+  stage: BaseStageConfig,
+): StageValidationResult {
+  const {timeMinimumInMinutes: min, timeLimitInMinutes: max} =
+    stage as ChatStageConfig;
+
+  if (min != null && max != null && min > max) {
+    return {
+      valid: false,
+      error: `timeMinimumInMinutes (${min}) cannot exceed timeLimitInMinutes (${max})`,
+    };
+  }
+
+  return {valid: true};
+}
 
 // ************************************************************************* //
 // updateChatMessage endpoint                                                //

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -59,7 +59,9 @@ export const ChatStageConfigData = Type.Composite(
       {
         kind: Type.Literal(StageKind.CHAT),
         timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
-        requireFullTime: Type.Union([Type.Boolean(), Type.Null()]),
+        timeMinimumInMinutes: Type.Optional(
+          Type.Union([Type.Number(), Type.Null()]),
+        ),
         discussions: Type.Array(ChatDiscussionData),
       },
       strict,

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -26,8 +26,8 @@ export interface PrivateChatStageConfig extends BaseStageConfig {
   // If defined, ends chat after specified time limit
   // (starting from when the first message is sent)
   timeLimitInMinutes: number | null;
-  // Require participants to stay in chat until time limit is up
-  requireFullTime: boolean;
+  // Minimum amount of time a participant must spend in chat
+  timeMinimumInMinutes: number | null;
   // If true, requires participant to go back and forth with mediator(s)
   // (rather than being able to send multiple messages at once)
   isTurnBasedChat: boolean;
@@ -58,7 +58,7 @@ export function createPrivateChatStage(
       config.progress ??
       createStageProgressConfig({waitForAllParticipants: true}),
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
-    requireFullTime: config.requireFullTime ?? false,
+    timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
     isTurnBasedChat: config.isTurnBasedChat ?? true,
     minNumberOfTurns: config.minNumberOfTurns ?? 0,
     maxNumberOfTurns: config.maxNumberOfTurns ?? null,

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -23,10 +23,11 @@ import {
  */
 export interface PrivateChatStageConfig extends BaseStageConfig {
   kind: StageKind.PRIVATE_CHAT;
-  // If defined, ends chat after specified time limit
+  // TODO: Migrate to seconds for internal storage to avoid fractional-minute ambiguity.
+  // If defined, ends chat after specified time limit (integer minutes)
   // (starting from when the first message is sent)
   timeLimitInMinutes: number | null;
-  // Minimum amount of time a participant must spend in chat
+  // Minimum amount of time a participant must spend in chat (integer minutes)
   timeMinimumInMinutes: number | null;
   // If true, requires participant to go back and forth with mediator(s)
   // (rather than being able to send multiple messages at once)

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -19,10 +19,14 @@ export const PrivateChatStageConfigData = Type.Composite(
         kind: Type.Literal(StageKind.PRIVATE_CHAT),
         // If defined, ends chat after specified time limit
         // (starting from when the first message is sent)
-        timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
-        timeMinimumInMinutes: Type.Optional(
-          Type.Union([Type.Number(), Type.Null()]),
-        ),
+        timeLimitInMinutes: Type.Union([
+          Type.Integer({minimum: 1}),
+          Type.Null(),
+        ]),
+        timeMinimumInMinutes: Type.Union([
+          Type.Integer({minimum: 1}),
+          Type.Null(),
+        ]),
         // If true, requires participant to go back and forth with mediator(s)
         // (rather than being able to send multiple messages at once)
         isTurnBasedChat: Type.Optional(Type.Boolean()),

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -15,8 +15,9 @@ export const PrivateChatStageConfigData = Type.Composite(
         // If defined, ends chat after specified time limit
         // (starting from when the first message is sent)
         timeLimitInMinutes: Type.Union([Type.Number(), Type.Null()]),
-        // Require participants to stay in chat until time limit is up
-        requireFullTime: Type.Optional(Type.Boolean()),
+        timeMinimumInMinutes: Type.Optional(
+          Type.Union([Type.Number(), Type.Null()]),
+        ),
         // If true, requires participant to go back and forth with mediator(s)
         // (rather than being able to send multiple messages at once)
         isTurnBasedChat: Type.Optional(Type.Boolean()),

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -1,7 +1,12 @@
 import {Type, type Static} from '@sinclair/typebox';
 import {UnifiedTimestampSchema} from '../shared.validation';
-import {StageKind} from './stage';
-import {BaseStageConfigSchema} from './stage.schemas';
+import {BaseStageConfig, StageKind} from './stage';
+import {
+  BaseStageConfigSchema,
+  type StageValidationResult,
+} from './stage.schemas';
+import {validateChatStageConfig} from './chat_stage.validation';
+import {PrivateChatStageConfig} from './private_chat_stage';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = {additionalProperties: false} as const;
@@ -37,3 +42,24 @@ export const PrivateChatStageConfigData = Type.Composite(
   ],
   {$id: 'PrivateChatStageConfig', ...strict},
 );
+
+/** Validate cross-field business rules for private chat stage configs. */
+export function validatePrivateChatStageConfig(
+  stage: BaseStageConfig,
+): StageValidationResult {
+  // Check time constraints (shared with group chat)
+  const timeResult = validateChatStageConfig(stage);
+  if (!timeResult.valid) return timeResult;
+
+  const {minNumberOfTurns: minTurns, maxNumberOfTurns: maxTurns} =
+    stage as PrivateChatStageConfig;
+
+  if (minTurns != null && maxTurns != null && minTurns > maxTurns) {
+    return {
+      valid: false,
+      error: `minNumberOfTurns (${minTurns}) cannot exceed maxNumberOfTurns (${maxTurns})`,
+    };
+  }
+
+  return {valid: true};
+}

--- a/utils/src/stages/stage.schemas.ts
+++ b/utils/src/stages/stage.schemas.ts
@@ -6,6 +6,11 @@ import {StageKind} from './stage';
  * These are defined in a separate file to ensure they're bundled before Type.Ref() calls.
  */
 
+/** Result type for cross-field stage config validators. */
+export type StageValidationResult =
+  | {valid: true}
+  | {valid: false; error: string};
+
 /** StageTextConfig input validation. */
 export const StageTextConfigSchema = Type.Object(
   {

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -1,17 +1,24 @@
-import {Type} from '@sinclair/typebox';
-import {StageKind} from './stage';
+import {Type, type TSchema} from '@sinclair/typebox';
+import {BaseStageConfig, StageKind} from './stage';
+import {type StageValidationResult} from './stage.schemas';
 import {
   AssetAllocationStageConfigData,
   MultiAssetAllocationStageConfigData,
 } from './asset_allocation_stage.validation';
-import {ChatStageConfigData} from './chat_stage.validation';
+import {
+  ChatStageConfigData,
+  validateChatStageConfig,
+} from './chat_stage.validation';
 import {ChipStageConfigData} from './chip_stage.validation';
 import {ComprehensionStageConfigData} from './comprehension_stage.validation';
 import {FlipCardStageConfigData} from './flipcard_stage.validation';
 import {RankingStageConfigData} from './ranking_stage.validation';
 import {InfoStageConfigData} from './info_stage.validation';
 import {PayoutStageConfigData} from './payout_stage.validation';
-import {PrivateChatStageConfigData} from './private_chat_stage.validation';
+import {
+  PrivateChatStageConfigData,
+  validatePrivateChatStageConfig,
+} from './private_chat_stage.validation';
 import {ProfileStageConfigData} from './profile_stage.validation';
 import {RevealStageConfigData} from './reveal_stage.validation';
 import {RoleStageConfigData} from './role_stage.validation';
@@ -35,28 +42,39 @@ export const StageKindData = Type.Enum(StageKind, {$id: 'StageKind'});
 // writeExperiment, updateStageConfig endpoints                              //
 // ************************************************************************* //
 
-/** Map of stage kinds to their validators */
-export const CONFIG_DATA = {
-  assetAllocation: AssetAllocationStageConfigData,
-  multiAssetAllocation: MultiAssetAllocationStageConfigData,
-  chat: ChatStageConfigData,
-  chip: ChipStageConfigData,
-  comprehension: ComprehensionStageConfigData,
-  flipcard: FlipCardStageConfigData,
-  info: InfoStageConfigData,
-  payout: PayoutStageConfigData,
-  privateChat: PrivateChatStageConfigData,
-  profile: ProfileStageConfigData,
-  ranking: RankingStageConfigData,
-  reveal: RevealStageConfigData,
-  role: RoleStageConfigData,
-  salesperson: SalespersonStageConfigData,
-  stockinfo: StockInfoStageConfigData,
-  surveyPerParticipant: SurveyPerParticipantStageConfigData,
-  survey: SurveyStageConfigData,
-  tos: TOSStageConfigData,
-  transfer: TransferStageConfigData,
+/** Stage config entry with schema and optional cross-field validator. */
+export interface StageConfigEntry {
+  schema: TSchema;
+  validate?: (stage: BaseStageConfig) => StageValidationResult;
+}
+
+/** Map of stage kinds to their schema and optional validator */
+export const CONFIG_DATA: Record<string, StageConfigEntry> = {
+  assetAllocation: {schema: AssetAllocationStageConfigData},
+  multiAssetAllocation: {schema: MultiAssetAllocationStageConfigData},
+  chat: {schema: ChatStageConfigData, validate: validateChatStageConfig},
+  chip: {schema: ChipStageConfigData},
+  comprehension: {schema: ComprehensionStageConfigData},
+  flipcard: {schema: FlipCardStageConfigData},
+  info: {schema: InfoStageConfigData},
+  payout: {schema: PayoutStageConfigData},
+  privateChat: {
+    schema: PrivateChatStageConfigData,
+    validate: validatePrivateChatStageConfig,
+  },
+  profile: {schema: ProfileStageConfigData},
+  ranking: {schema: RankingStageConfigData},
+  reveal: {schema: RevealStageConfigData},
+  role: {schema: RoleStageConfigData},
+  salesperson: {schema: SalespersonStageConfigData},
+  stockinfo: {schema: StockInfoStageConfigData},
+  surveyPerParticipant: {schema: SurveyPerParticipantStageConfigData},
+  survey: {schema: SurveyStageConfigData},
+  tos: {schema: TOSStageConfigData},
+  transfer: {schema: TransferStageConfigData},
 };
 
 /** StageConfig input validation (union of all stage types) */
-export const StageConfigData = Type.Union(Object.values(CONFIG_DATA));
+export const StageConfigData = Type.Union(
+  Object.values(CONFIG_DATA).map((entry) => entry.schema),
+);


### PR DESCRIPTION
- Rename `requireFullTime` (boolean) to `timeMinimumInMinutes` (number | null), allowing experimenters to set a specific minimum time independent of the max time limit.
- Add enforcement of `timeLimitInMinutes` in private chat (previously only enforced in group chat).
- Add server-side validation of minimum time requirement in `chat.utils.ts` and `chat.endpoints.ts`.
- Add migration script to convert existing `requireFullTime: true` stages to equivalent `timeMinimumInMinutes` values.
- Force integer values for time inputs in editors.
- Add server-side validation between parameters 

(in lieu of #1058).
