### PR TITLE
build: Detect Java 21 and set JAVA_HOME and PATH in run_locally.sh

### DIFF
--- a/run_locally.sh
+++ b/run_locally.sh
@@ -102,6 +102,19 @@ if [ "$NODE_VERSION" -lt 22 ]; then
 fi
 echo "Node.js version: $(node -v)"
 
+# Ensure Java 21 is available (required by Firebase emulators)
+if [ -z "$JAVA_HOME" ]; then
+    if [ -d "/usr/lib/jvm/java-21-openjdk-amd64" ]; then
+        export JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+        echo "Auto-detected JAVA_HOME: $JAVA_HOME"
+    fi
+else
+    echo "Using provided JAVA_HOME: $JAVA_HOME"
+fi
+if [ -n "$JAVA_HOME" ]; then
+    export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
 if [ ! -d "node_modules" ]; then
     echo ""
     echo "node_modules not found."


### PR DESCRIPTION
When running locally, Deliberate Lab runs against Firebase emulators. These require a particularly narrow set of Java versions, preferring version 21.

This change honors the environment's specified `JAVA_HOME` if present. Otherwise, it looks for Java 21, and if found, sets the `JAVA_HOME` and `PATH` environment variables locally before bringing up the emulators.