### PR TITLE
Check for empty variable config when creating experiments

### DIFF
--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -17,6 +17,7 @@ import {
   StageKind,
   StageManager,
   VariableConfig,
+  requiresValues,
   STAGE_MANAGER,
   checkApiKeyExists,
   createAgentMediatorPersonaConfig,
@@ -131,10 +132,7 @@ export class ExperimentEditor extends Service {
     }
 
     for (const config of this.experiment.variableConfigs ?? []) {
-      if (
-        config.type === 'random_permutation' ||
-        config.type === 'balanced_assignment'
-      ) {
+      if (requiresValues(config.type)) {
         if (config.values.length === 0) {
           errors.push(
             `Variable "${config.definition.name}" must contain at least one value`,

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -129,6 +129,20 @@ export class ExperimentEditor extends Service {
           break;
       }
     }
+
+    for (const config of this.experiment.variableConfigs ?? []) {
+      if (
+        config.type === 'random_permutation' ||
+        config.type === 'balanced_assignment'
+      ) {
+        if (config.values.length === 0) {
+          errors.push(
+            `Variable "${config.definition.name}" must contain at least one value`,
+          );
+        }
+      }
+    }
+
     return errors;
   }
 

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -17,6 +17,7 @@ import {
   StageKind,
   StageManager,
   VariableConfig,
+  MultiValueVariableConfigType,
   requiresValues,
   STAGE_MANAGER,
   checkApiKeyExists,
@@ -133,9 +134,10 @@ export class ExperimentEditor extends Service {
 
     for (const config of this.experiment.variableConfigs ?? []) {
       if (requiresValues(config.type)) {
-        if (config.values.length === 0) {
+        const multiConfig = config as MultiValueVariableConfigType;
+        if (multiConfig.values.length === 0) {
           errors.push(
-            `Variable "${config.definition.name}" must contain at least one value`,
+            `Variable "${multiConfig.definition.name}" must contain at least one value`,
           );
         }
       }

--- a/functions/src/dl_api/experiments.dl_api.integration.test.ts
+++ b/functions/src/dl_api/experiments.dl_api.integration.test.ts
@@ -978,5 +978,40 @@ describe('API Experiment Creation Integration Tests', () => {
         'values array must contain at least one item',
       );
     });
+
+    it('should accept experiment creation with valid variable configuration', async () => {
+      const template = getFlipCardExperimentTemplate();
+      template.experiment.variableConfigs = [
+        {
+          id: 'var1',
+          type: 'random_permutation',
+          scope: 'experiment',
+          values: ['item1', 'item2'],
+          shuffleConfig: {
+            shuffle: true,
+            seed: 'experiment',
+            customSeed: '',
+          },
+          definition: {
+            name: 'Valid Random Permutation',
+            description: '',
+            schema: {type: 'string'},
+          },
+        },
+      ];
+
+      const response = await apiRequest('POST', '/v1/experiments', {
+        template: JSON.parse(JSON.stringify(template)),
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.experiment).toBeDefined();
+      expect(data.experiment.variableConfigs).toHaveLength(1);
+      expect(data.experiment.variableConfigs[0].values).toEqual([
+        'item1',
+        'item2',
+      ]);
+    });
   });
 });

--- a/functions/src/dl_api/experiments.dl_api.integration.test.ts
+++ b/functions/src/dl_api/experiments.dl_api.integration.test.ts
@@ -946,5 +946,37 @@ describe('API Experiment Creation Integration Tests', () => {
       const data = await response.json();
       expect(data.error).toContain('Duplicate cohort alias found');
     });
+
+    it('should reject experiment creation with invalid variable configuration (empty values array)', async () => {
+      const template = getFlipCardExperimentTemplate();
+      template.experiment.variableConfigs = [
+        {
+          id: 'var1',
+          type: 'random_permutation',
+          scope: 'experiment',
+          values: [],
+          shuffleConfig: {
+            shuffle: true,
+            seed: 'experiment',
+            customSeed: '',
+          },
+          definition: {
+            name: 'Empty Random Permutation',
+            description: '',
+            schema: {type: 'string'},
+          },
+        },
+      ];
+
+      const response = await apiRequest('POST', '/v1/experiments', {
+        template: JSON.parse(JSON.stringify(template)),
+      });
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain(
+        'values array must contain at least one item',
+      );
+    });
   });
 });

--- a/functions/src/dl_api/experiments.dl_api.ts
+++ b/functions/src/dl_api/experiments.dl_api.ts
@@ -321,7 +321,7 @@ export async function updateExperiment(
 
     if (!result.success) {
       throw createHttpError(
-        result.errorCode || 500,
+        result.httpErrorCode || 500,
         result.errorMessage || 'Failed to update experiment',
       );
     }
@@ -412,7 +412,7 @@ export async function updateExperiment(
 
   if (!result.success) {
     throw createHttpError(
-      result.errorCode || 500,
+      result.httpErrorCode || 500,
       result.errorMessage || 'Failed to update experiment',
     );
   }

--- a/functions/src/dl_api/experiments.dl_api.ts
+++ b/functions/src/dl_api/experiments.dl_api.ts
@@ -320,25 +320,10 @@ export async function updateExperiment(
     );
 
     if (!result.success) {
-      if (result.error === 'not-found') {
-        throw createHttpError(404, 'Experiment not found');
-      } else if (result.error === 'not-owner') {
-        throw createHttpError(
-          403,
-          'Only the creator can update the experiment',
-        );
-      } else if (result.error === 'cohort-definitions-locked') {
-        throw createHttpError(
-          400,
-          'Cannot modify cohort definitions after participants have joined',
-        );
-      } else if (result.error === 'invalid-stages') {
-        throw createHttpError(400, 'Invalid stage configuration');
-      } else if (result.error === 'invalid-variables') {
-        throw createHttpError(400, 'Invalid variable configuration');
-      } else if (result.error === 'duplicate-cohort-aliases') {
-        throw createHttpError(400, 'Duplicate cohort aliases found');
-      }
+      throw createHttpError(
+        result.errorCode || 500,
+        result.errorMessage || 'Failed to update experiment',
+      );
     }
 
     res.status(200).json({
@@ -426,22 +411,10 @@ export async function updateExperiment(
   );
 
   if (!result.success) {
-    if (result.error === 'not-found') {
-      throw createHttpError(404, 'Experiment not found');
-    } else if (result.error === 'not-owner') {
-      throw createHttpError(403, 'Only the creator can update the experiment');
-    } else if (result.error === 'cohort-definitions-locked') {
-      throw createHttpError(
-        400,
-        'Cannot modify cohort definitions after participants have joined',
-      );
-    } else if (result.error === 'invalid-stages') {
-      throw createHttpError(400, 'Invalid stage configuration');
-    } else if (result.error === 'invalid-variables') {
-      throw createHttpError(400, 'Invalid variable configuration');
-    } else if (result.error === 'duplicate-cohort-aliases') {
-      throw createHttpError(400, 'Duplicate cohort aliases found');
-    }
+    throw createHttpError(
+      result.errorCode || 500,
+      result.errorMessage || 'Failed to update experiment',
+    );
   }
 
   res.status(200).json({

--- a/functions/src/dl_api/experiments.dl_api.ts
+++ b/functions/src/dl_api/experiments.dl_api.ts
@@ -334,6 +334,8 @@ export async function updateExperiment(
         );
       } else if (result.error === 'invalid-stages') {
         throw createHttpError(400, 'Invalid stage configuration');
+      } else if (result.error === 'invalid-variables') {
+        throw createHttpError(400, 'Invalid variable configuration');
       } else if (result.error === 'duplicate-cohort-aliases') {
         throw createHttpError(400, 'Duplicate cohort aliases found');
       }
@@ -435,6 +437,8 @@ export async function updateExperiment(
       );
     } else if (result.error === 'invalid-stages') {
       throw createHttpError(400, 'Invalid stage configuration');
+    } else if (result.error === 'invalid-variables') {
+      throw createHttpError(400, 'Invalid variable configuration');
     } else if (result.error === 'duplicate-cohort-aliases') {
       throw createHttpError(400, 'Duplicate cohort aliases found');
     }

--- a/functions/src/experiment.endpoints.ts
+++ b/functions/src/experiment.endpoints.ts
@@ -101,7 +101,7 @@ export const updateExperiment = onCall(async (request) => {
     {collectionName: data.collectionName},
   );
 
-  return {success: result.success, error: result.error};
+  return {success: result.success};
 });
 
 // ************************************************************************* //

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -328,13 +328,6 @@ export interface UpdateExperimentOptions {
  */
 export interface UpdateExperimentResult {
   success: boolean;
-  error?:
-    | 'not-found'
-    | 'not-owner'
-    | 'cohort-definitions-locked'
-    | 'invalid-stages'
-    | 'invalid-variables'
-    | 'duplicate-cohort-aliases';
   httpErrorCode?: number;
   errorMessage?: string;
 }
@@ -365,7 +358,6 @@ export async function updateExperimentFromTemplate(
   if (!stageValidation.valid) {
     return {
       success: false,
-      error: 'invalid-stages',
       httpErrorCode: 400,
       errorMessage: `Invalid stage configuration: ${stageValidation.error}`,
     };
@@ -379,7 +371,6 @@ export async function updateExperimentFromTemplate(
     if (!variableValidation.valid) {
       return {
         success: false,
-        error: 'invalid-variables',
         httpErrorCode: 400,
         errorMessage: `Invalid variable configuration: ${variableValidation.error}`,
       };
@@ -393,7 +384,6 @@ export async function updateExperimentFromTemplate(
       if (seenAliases.has(def.alias)) {
         return {
           success: false,
-          error: 'duplicate-cohort-aliases',
           httpErrorCode: 400,
           errorMessage: `Duplicate cohort alias found: "${def.alias}"`,
         };
@@ -418,7 +408,6 @@ export async function updateExperimentFromTemplate(
   if (!oldExperiment.exists) {
     return {
       success: false,
-      error: 'not-found',
       httpErrorCode: 404,
       errorMessage: 'Experiment not found',
     };
@@ -431,7 +420,6 @@ export async function updateExperimentFromTemplate(
     if (!isAdmin) {
       return {
         success: false,
-        error: 'not-owner',
         httpErrorCode: 403,
         errorMessage: 'Only the creator or an admin can update the experiment',
       };

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -22,7 +22,7 @@ import {getExperimentDownload} from './data';
 import {generateVariablesForScope} from './variables.utils';
 import {AuthGuard} from './utils/auth-guard';
 import {createCohortFromDefinition} from './cohort.utils';
-import {validateStages} from './utils/validation';
+import {validateStages, validateVariables} from './utils/validation';
 
 /**
  * Create cohorts from cohort definitions and update the definitions with generated IDs.
@@ -85,6 +85,18 @@ export async function writeExperimentFromTemplate(
   const stageValidation = validateStages(template.stageConfigs);
   if (!stageValidation.valid) {
     throw new Error(`Invalid stage configuration: ${stageValidation.error}`);
+  }
+
+  // Validate variables
+  if (template.experiment.variableConfigs) {
+    const variableValidation = validateVariables(
+      template.experiment.variableConfigs,
+    );
+    if (!variableValidation.valid) {
+      throw new Error(
+        `Invalid variable configuration: ${variableValidation.error}`,
+      );
+    }
   }
 
   // Validate cohort definitions
@@ -321,6 +333,7 @@ export interface UpdateExperimentResult {
     | 'not-owner'
     | 'cohort-definitions-locked'
     | 'invalid-stages'
+    | 'invalid-variables'
     | 'duplicate-cohort-aliases';
 }
 
@@ -349,6 +362,16 @@ export async function updateExperimentFromTemplate(
   const stageValidation = validateStages(template.stageConfigs);
   if (!stageValidation.valid) {
     return {success: false, error: 'invalid-stages'};
+  }
+
+  // Validate variables
+  if (template.experiment.variableConfigs) {
+    const variableValidation = validateVariables(
+      template.experiment.variableConfigs,
+    );
+    if (!variableValidation.valid) {
+      return {success: false, error: 'invalid-variables'};
+    }
   }
 
   // Validate cohort definitions

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -335,6 +335,8 @@ export interface UpdateExperimentResult {
     | 'invalid-stages'
     | 'invalid-variables'
     | 'duplicate-cohort-aliases';
+  errorCode?: number;
+  errorMessage?: string;
 }
 
 /**
@@ -361,7 +363,12 @@ export async function updateExperimentFromTemplate(
   // Validate stage configs (schema + cross-field business rules)
   const stageValidation = validateStages(template.stageConfigs);
   if (!stageValidation.valid) {
-    return {success: false, error: 'invalid-stages'};
+    return {
+      success: false,
+      error: 'invalid-stages',
+      errorCode: 400,
+      errorMessage: `Invalid stage configuration: ${stageValidation.error}`,
+    };
   }
 
   // Validate variables
@@ -370,7 +377,12 @@ export async function updateExperimentFromTemplate(
       template.experiment.variableConfigs,
     );
     if (!variableValidation.valid) {
-      return {success: false, error: 'invalid-variables'};
+      return {
+        success: false,
+        error: 'invalid-variables',
+        errorCode: 400,
+        errorMessage: `Invalid variable configuration: ${variableValidation.error}`,
+      };
     }
   }
 
@@ -379,7 +391,12 @@ export async function updateExperimentFromTemplate(
     const seenAliases = new Set<string>();
     for (const def of template.experiment.cohortDefinitions) {
       if (seenAliases.has(def.alias)) {
-        return {success: false, error: 'duplicate-cohort-aliases'};
+        return {
+          success: false,
+          error: 'duplicate-cohort-aliases',
+          errorCode: 400,
+          errorMessage: `Duplicate cohort alias found: "${def.alias}"`,
+        };
       }
       seenAliases.add(def.alias);
     }
@@ -399,7 +416,12 @@ export async function updateExperimentFromTemplate(
   // Check if experiment exists
   const oldExperiment = await document.get();
   if (!oldExperiment.exists) {
-    return {success: false, error: 'not-found'};
+    return {
+      success: false,
+      error: 'not-found',
+      errorCode: 404,
+      errorMessage: 'Experiment not found',
+    };
   }
 
   // Verify that the experimenter is the creator or an admin
@@ -407,7 +429,12 @@ export async function updateExperimentFromTemplate(
     const isAdmin = await AuthGuard.isAdminEmail(firestore, experimenterId);
 
     if (!isAdmin) {
-      return {success: false, error: 'not-owner'};
+      return {
+        success: false,
+        error: 'not-owner',
+        errorCode: 403,
+        errorMessage: 'Only the creator or an admin can update the experiment',
+      };
     }
   }
 
@@ -452,7 +479,13 @@ export async function updateExperimentFromTemplate(
 
   if (lockedFieldsChanged && hasParticipants) {
     // Can't change locked fields after participants join
-    return {success: false, error: 'cohort-definitions-locked'};
+    return {
+      success: false,
+      error: 'cohort-definitions-locked',
+      errorCode: 400,
+      errorMessage:
+        'Cannot modify cohort definitions after participants have joined',
+    };
   }
 
   if (!lockedFieldsChanged) {

--- a/functions/src/experiment.utils.ts
+++ b/functions/src/experiment.utils.ts
@@ -335,7 +335,7 @@ export interface UpdateExperimentResult {
     | 'invalid-stages'
     | 'invalid-variables'
     | 'duplicate-cohort-aliases';
-  errorCode?: number;
+  httpErrorCode?: number;
   errorMessage?: string;
 }
 
@@ -366,7 +366,7 @@ export async function updateExperimentFromTemplate(
     return {
       success: false,
       error: 'invalid-stages',
-      errorCode: 400,
+      httpErrorCode: 400,
       errorMessage: `Invalid stage configuration: ${stageValidation.error}`,
     };
   }
@@ -380,7 +380,7 @@ export async function updateExperimentFromTemplate(
       return {
         success: false,
         error: 'invalid-variables',
-        errorCode: 400,
+        httpErrorCode: 400,
         errorMessage: `Invalid variable configuration: ${variableValidation.error}`,
       };
     }
@@ -394,7 +394,7 @@ export async function updateExperimentFromTemplate(
         return {
           success: false,
           error: 'duplicate-cohort-aliases',
-          errorCode: 400,
+          httpErrorCode: 400,
           errorMessage: `Duplicate cohort alias found: "${def.alias}"`,
         };
       }
@@ -419,7 +419,7 @@ export async function updateExperimentFromTemplate(
     return {
       success: false,
       error: 'not-found',
-      errorCode: 404,
+      httpErrorCode: 404,
       errorMessage: 'Experiment not found',
     };
   }
@@ -432,7 +432,7 @@ export async function updateExperimentFromTemplate(
       return {
         success: false,
         error: 'not-owner',
-        errorCode: 403,
+        httpErrorCode: 403,
         errorMessage: 'Only the creator or an admin can update the experiment',
       };
     }
@@ -482,7 +482,7 @@ export async function updateExperimentFromTemplate(
     return {
       success: false,
       error: 'cohort-definitions-locked',
-      errorCode: 400,
+      httpErrorCode: 400,
       errorMessage:
         'Cannot modify cohort definitions after participants have joined',
     };

--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -9,6 +9,8 @@ import {
   StageConfigData,
   StageTextConfigSchema,
   StageProgressConfigSchema,
+  requiresValues,
+  VariableConfigType,
 } from '@deliberation-lab/utils';
 import {type TSchema} from '@sinclair/typebox';
 import {
@@ -284,7 +286,7 @@ export function validateVariables(configs: unknown[]): ValidationResult {
       ((config?.definition as Record<string, unknown>)?.name as string) ||
       'unnamed';
 
-    if (type === 'random_permutation' || type === 'balanced_assignment') {
+    if (requiresValues(type as VariableConfigType)) {
       const values = config?.values;
       if (!Array.isArray(values) || values.length === 0) {
         errorMessages.push(

--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -259,3 +259,43 @@ export function validateCohortParticipantConfig(
 
   return {valid: true};
 }
+
+// ************************************************************************* //
+// VARIABLE VALIDATION                                                       //
+// ************************************************************************* //
+
+/**
+ * Validate variable configurations to ensure multi-value variables have non-empty values
+ */
+export function validateVariables(configs: unknown[]): ValidationResult {
+  if (!Array.isArray(configs)) {
+    return {
+      valid: false,
+      error: 'Invalid variable configurations: must be an array',
+    };
+  }
+
+  const errorMessages: string[] = [];
+
+  for (let i = 0; i < configs.length; i++) {
+    const config = configs[i] as Record<string, unknown>;
+    const type = config?.type as string;
+    const name =
+      ((config?.definition as Record<string, unknown>)?.name as string) ||
+      'unnamed';
+
+    if (type === 'random_permutation' || type === 'balanced_assignment') {
+      const values = config?.values;
+      if (!Array.isArray(values) || values.length === 0) {
+        errorMessages.push(
+          `Variable "${name}" (${type}): values array must contain at least one item`,
+        );
+      }
+    }
+  }
+
+  if (errorMessages.length > 0) {
+    return {valid: false, error: errorMessages.join('\n')};
+  }
+  return {valid: true};
+}

--- a/utils/src/variables.ts
+++ b/utils/src/variables.ts
@@ -105,6 +105,14 @@ export function getVariableConfigTypeDescription(
   }
 }
 
+/** Returns whether a variable config type requires a non-empty values pool */
+export function requiresValues(type: VariableConfigType): boolean {
+  return (
+    type === VariableConfigType.RANDOM_PERMUTATION ||
+    type === VariableConfigType.BALANCED_ASSIGNMENT
+  );
+}
+
 /**
  * Strategy for balancing assignments across participants.
  */


### PR DESCRIPTION
## Description

Add validation that checks for empty variables when creating an experiment. This applies to both the API and the web interface. Previously, an experiment could be saved with a bad variable config, but it would fail when trying to create a cohort.

- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [x] *Screenshots or videos* included (if applicable)
- [ ] Clear reproduction steps provided to invoke the feature (if applicable)
- [x] All tests pass (if applicable)

<img width="3084" height="1632" alt="ArnphiaRS3w8of9" src="https://github.com/user-attachments/assets/6f6838e7-daaf-403d-be26-cdbf2484b769" />

---

## Related issues
This PR fixes: #1074 

---
