### PR TITLE
Google Cloud Build: Trap errors and log them before exiting

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,6 +77,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ -z "${_DEPLOYMENT_TYPE}" ]]; then
       echo "Validation Failed: '_DEPLOYMENT_TYPE' Substitution Value MUST be specified"
       exit 1
@@ -135,6 +136,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Installing Oracle JDK 21..."
       apt-get update -y && apt-get install -y wget
@@ -160,6 +162,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       # Removes 'predeploy' conditions since those are handled in separate steps.
       echo "Prepare firebase-prod.json file..."
@@ -182,6 +185,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     echo "Node version:"
     node -v
     echo "NPM version:"
@@ -199,6 +203,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Utils Lint/Format utils..."
       npx prettier --check "utils/**/*.ts"
@@ -217,6 +222,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Functions Lint/Format utils..."
       npx prettier --check "functions/**/*.ts"
@@ -235,6 +241,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Frontend Lint/Format utils..."
       npx prettier --check "frontend/**/*.ts"
@@ -253,6 +260,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Building utils workspace..."
       npm run build --workspace=utils
@@ -270,6 +278,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Building functions workspace..."
       npm run build --workspace=functions
@@ -287,6 +296,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Copying example Firebase config..."
       cp ./frontend/firebase_config.example.ts ./frontend/firebase_config.ts
@@ -308,6 +318,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Utils tests..."
       npm test --workspace=utils
@@ -325,6 +336,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       export JAVA_HOME=$(pwd)/java-runtime
       export PATH=$JAVA_HOME/bin:$PATH
@@ -344,6 +356,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Running Frontend tests against dev build..."
       npm test --workspace=frontend
@@ -361,6 +374,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       echo "Generating firebase_config.ts from substitution variables..."
       echo "import {FirebaseOptions} from 'firebase/app';" > ./frontend/firebase_config.ts
@@ -392,6 +406,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Functions..."
@@ -424,6 +439,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Firestore Rules..."
@@ -456,6 +472,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Database Rules..."
@@ -488,6 +505,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Storage Rules..."
@@ -520,11 +538,31 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
+
+    # Retry helper for transient network failures (read-only commands only).
+    retry() {
+      local retries="${RETRIES:-3}" delay=5 attempt=1
+      while true; do
+        "$@" && return 0
+        local exit_code=$?
+        if (( attempt >= retries )); then
+          echo "❌ Command failed after $retries attempts: $*"
+          return $exit_code
+        fi
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+        attempt=$(( attempt + 1 ))
+      done
+    }
+
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
-      
+
       echo "Fetching current production indexes (Backup)..."
-      npx firebase firestore:indexes --project ${PROJECT_ID} > existing_firestore_indexes.json
-      
+      INDEX_OUTPUT=$(retry npx firebase firestore:indexes --project ${PROJECT_ID})
+      echo "$INDEX_OUTPUT" > existing_firestore_indexes.json
+
       echo "--- EXISTING FIRESTORE INDEXES BACKUP: START ---"
       cat existing_firestore_indexes.json
       echo "--- EXISTING FIRESTORE INDEXES BACKUP: END ---"
@@ -539,8 +577,9 @@ steps:
           --force
 
         echo "Fetching deployed production indexes..."
-        npx firebase firestore:indexes --project ${PROJECT_ID} > deployed_firestore_indexes.json
-        
+        DEPLOYED_OUTPUT=$(retry npx firebase firestore:indexes --project ${PROJECT_ID})
+        echo "$DEPLOYED_OUTPUT" > deployed_firestore_indexes.json
+
         if cmp -s "existing_firestore_indexes.json" "deployed_firestore_indexes.json"; then
           echo "Deployed Firestore Indexes match existing (no change)."
         else
@@ -574,6 +613,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
       if [[ "${_DEPLOY}" == "true" ]]; then
         APP_DEPLOY_FLAGS="--no-promote"


### PR DESCRIPTION
This ensures that when a build command fails, the command that failed is logged and the error recorded. It also retries non-destructive commands rather than failing hard the first time.