### PR TITLE
build: Rename default projectId from your-project-id to demo-project-id

### DIFF
--- a/.firebaserc.example
+++ b/.firebaserc.example
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "your-project-id"
+    "default": "demo-project-id"
   }
 }

--- a/frontend/firebase_config.example.ts
+++ b/frontend/firebase_config.example.ts
@@ -3,7 +3,7 @@ import {FirebaseOptions} from 'firebase/app';
 export const FIREBASE_CONFIG: FirebaseOptions = {
   apiKey: 'your-api-key',
   authDomain: 'your-auth-domain',
-  projectId: 'your-project-id',
+  projectId: 'demo-project-id',
   storageBucket: 'your-storage-bucket',
   messagingSenderId: 'your-messaging-sender-id',
   appId: 'your-app-id',


### PR DESCRIPTION
Avoid unwanted prod queries and warnings when running in local dev mode by using `demo-` prefixed default project ID.