### PR TITLE
Name ports and detect forwarding failures in dev mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+  "remote.portsAttributes": {
+    "4000": {
+      "label": "Firebase Emulator Suite",
+      "onAutoForward": "notify"
+    },
+    "4201": {
+      "label": "Deliberate Lab Frontend",
+      "onAutoForward": "notify"
+    },
+    "5001": {
+      "label": "Functions Emulator",
+      "onAutoForward": "notify"
+    },
+    "8080": {
+      "label": "Firestore Emulator",
+      "onAutoForward": "notify"
+    },
+    "9000": {
+      "label": "RTDB Emulator",
+      "onAutoForward": "notify"
+    },
+    "9099": {
+      "label": "Auth Emulator",
+      "onAutoForward": "notify"
+    },
+    "9199": {
+      "label": "Storage Emulator",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -48,6 +48,9 @@ export class App extends MobxLitElement {
 
     switch (this.routerService.activePage) {
       case Pages.HOME:
+        if (this.authService.firestoreConnectionError) {
+          return this.renderConnectionError();
+        }
         if (!this.authService.isExperimenter) {
           return this.render403();
         }
@@ -71,6 +74,9 @@ export class App extends MobxLitElement {
           </div>
         `;
       case Pages.EXPERIMENT:
+        if (this.authService.firestoreConnectionError) {
+          return this.renderConnectionError();
+        }
         if (!this.authService.isExperimenter) {
           return this.render403();
         }
@@ -79,6 +85,9 @@ export class App extends MobxLitElement {
 
         return html` <experiment-dashboard></experiment-dashboard> `;
       case Pages.EXPERIMENT_CREATE:
+        if (this.authService.firestoreConnectionError) {
+          return this.renderConnectionError();
+        }
         if (!this.authService.isExperimenter) {
           return this.render403();
         }
@@ -86,6 +95,7 @@ export class App extends MobxLitElement {
           <page-header></page-header>
           <experiment-builder></experiment-builder>
         `;
+
       case Pages.PARTICIPANT:
         this.presenceService.setupPresence(
           this.routerService.activeRoute.params['experiment'],
@@ -146,6 +156,33 @@ export class App extends MobxLitElement {
             have them add your email address to the allowlist.
           </div>
           ${renderLogoutButton()}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderConnectionError() {
+    const isDev = process.env.NODE_ENV === 'development';
+
+    return html`
+      <div class="error-wrapper">
+        <div class="error">
+          <div><strong>Unable to connect to Firestore.</strong></div>
+          ${isDev
+            ? html`
+                <div>
+                  If you are running the application remotely (e.g., via SSH or
+                  VS Code Remote), please ensure that ports
+                  <strong>8080</strong> and <strong>9099</strong> are forwarded.
+                </div>
+              `
+            : html`
+                <div>
+                  We are unable to connect to our database at this time. Please
+                  try again later. If the problem persists, contact the site
+                  administrator.
+                </div>
+              `}
         </div>
       </div>
     `;

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -49,38 +49,46 @@ export class AuthService extends Service {
           // https://firebase.google.com/docs/reference/js/auth.user
           this.user = user;
 
-          const allowlistDoc = await getDoc(
-            doc(
-              this.sp.firebaseService.firestore,
-              'allowlist',
-              user.email ?? '',
-            ),
-          );
+          try {
+            const allowlistDoc = await getDoc(
+              doc(
+                this.sp.firebaseService.firestore,
+                'allowlist',
+                user.email ?? '',
+              ),
+            );
 
-          if (allowlistDoc.exists()) {
-            this.isExperimenter = true;
-            this.subscribe();
-            this.writeExperimenterProfile(user);
-            this.sp.homeService.subscribe();
-            const experimentId = this.sp.experimentManager.experimentId;
-            if (experimentId) {
-              this.sp.experimentManager.loadExperimentData(experimentId);
-            }
+            if (allowlistDoc.exists()) {
+              this.isExperimenter = true;
+              this.subscribe();
+              this.writeExperimenterProfile(user);
+              this.sp.homeService.subscribe();
+              const experimentId = this.sp.experimentManager.experimentId;
+              if (experimentId) {
+                this.sp.experimentManager.loadExperimentData(experimentId);
+              }
 
-            // Check if admin
-            if (allowlistDoc.data().isAdmin) {
-              this.sp.adminService.subscribe();
-              this.isAdmin = true;
+              // Check if admin
+              if (allowlistDoc.data().isAdmin) {
+                this.sp.adminService.subscribe();
+                this.isAdmin = true;
+              } else {
+                this.isAdmin = false;
+              }
+              // Check if user has access to research templates
+              if (allowlistDoc.data().hasResearchTemplateAccess) {
+                this.hasResearchTemplateAccess = true;
+              } else {
+                this.hasResearchTemplateAccess = false;
+              }
             } else {
+              this.isExperimenter = false;
               this.isAdmin = false;
             }
-            // Check if user has access to research templates
-            if (allowlistDoc.data().hasResearchTemplateAccess) {
-              this.hasResearchTemplateAccess = true;
-            } else {
-              this.hasResearchTemplateAccess = false;
-            }
-          } else {
+            this.firestoreConnectionError = false; // Reset on success
+          } catch (error) {
+            console.error('Failed to fetch allowlist', error);
+            this.firestoreConnectionError = true;
             this.isExperimenter = false;
             this.isAdmin = false;
           }
@@ -95,6 +103,8 @@ export class AuthService extends Service {
 
   @observable user: User | null | undefined = undefined;
   @observable isAdmin: boolean | null = null;
+  @observable firestoreConnectionError = false;
+
   @observable hasResearchTemplateAccess: boolean | null = null;
   @observable isExperimenter: boolean | null = null;
   @observable canEdit = false;

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -218,9 +218,13 @@ tail -f /dev/null | npx firebase emulators:start --import ./emulator_test_config
 EMULATORS_PID=$!
 
 # Wait for emulators to be ready
-wait_for_port 8080 "Firestore"
-wait_for_port 5001 "Functions"
 wait_for_port 4000 "Emulator UI"
+wait_for_port 5001 "Functions"
+wait_for_port 8080 "Firestore"
+wait_for_port 9000 "Database"
+wait_for_port 9099 "Auth"
+wait_for_port 9199 "Storage"
+
 
 # 4. Start frontend web app
 echo "--- [4/4] Starting frontend ---"


### PR DESCRIPTION
This change configures VS Code to name the necessary forwarding ports for when running Deliberate Lab on another machine using SSH tunneling.

We also now detect the case where Firestore can't be connected and provide a better error message. It now says:

> Unable to connect to Firestore.
> If you are running the application remotely (e.g., via SSH or VS Code Remote), please ensure that ports 8080 and 9099 are forwarded.