### PR TITLE
chore: Use -w flag for workspace invocation rather than preemptory cd

### DIFF
--- a/docs/developers/run-locally.md
+++ b/docs/developers/run-locally.md
@@ -95,8 +95,7 @@ NOTE: The `utils` directory builds as the package `@deliberation-lab/utils`,
 which can then be used in `/functions` and `/frontend`.
 
 ```bash
-cd utils  # If navigating from top level
-npm run build:watch  # Build and listen to changes
+npm run build:watch -w utils  # Build and listen to changes
 ```
 
 The shared utilities are built using [`tsup`](https://tsup.egoist.dev) to
@@ -109,8 +108,7 @@ the directory that requires the utils (e.g., `frontend` or `functions`).
 ### 3. Build functions (needed for backend)
 
 ```bash
-cd functions  # If navigating from top level
-npm run build:watch  # Build and listen to changes
+npm run build:watch -w functions  # Build and listen to changes
 ```
 
 ### 4. Start Firebase emulators (used as backend)
@@ -150,18 +148,16 @@ http://localhost:4000.
 ### 5. Start frontend web app
 
 ```bash
-cd frontend  # If navigating from top level
-
 # Create an index.html file and (optionally) replace the placeholder
 # analytics ID (see TODOs in example file) with your Google Analytics ID
-cp index.example.html index.html
+cp frontend/index.example.html frontend/index.html
 
 # If you didn't already create a firebase_config.ts when setting up
 # the emulator, do so now:
 #
-# cp firebase_config.example.ts firebase_config.ts
+# cp frontend/firebase_config.example.ts frontend/firebase_config.ts
 
-npm run start
+npm run start -w frontend
 ```
 
 Then, view the app at http://localhost:4201.

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -192,24 +192,20 @@ trap cleanup SIGINT SIGTERM
 
 # 1. Build utils (needed for backend and frontend)
 echo "--- [1/4] Building utils ---"
-cd utils
-npm run build
+npm run build -w utils
 # Start utils watcher in background
 echo "Starting utils watcher..."
 # Use tail -f /dev/null to keep stdin open, preventing premature exit
-tail -f /dev/null | npm run build:watch &
+tail -f /dev/null | npm run build:watch -w utils &
 UTILS_PID=$!
-cd ..
 
 # 2. Build functions (needed for backend)
 echo "--- [2/4] Building functions ---"
-cd functions
-npm run build
+npm run build -w functions
 # Start functions watcher in background
 echo "Starting functions watcher..."
-tail -f /dev/null | npm run build:watch &
+tail -f /dev/null | npm run build:watch -w functions &
 FUNCTIONS_PID=$!
-cd ..
 
 # 3. Start Firebase emulators
 echo "--- [3/4] Starting Firebase emulators ---"
@@ -228,11 +224,9 @@ wait_for_port 9199 "Storage"
 
 # 4. Start frontend web app
 echo "--- [4/4] Starting frontend ---"
-cd frontend
 # npm run start includes 'npm run build' and 'npm run serve'
-tail -f /dev/null | npm run start &
+tail -f /dev/null | npm run start -w frontend &
 FRONTEND_PID=$!
-cd ..
 
 echo ""
 echo "=== All services started ==="


### PR DESCRIPTION
Fixes #1084 by switching to `-w` nomenclature for running workspace-scoped npm commands rather than requiring peremptory `cd` into and out of subdirectories.