### PR TITLE
feat: add Experimenter initiated alerting (addresses #757)

### DIFF
--- a/frontend/src/components/experiment_dashboard/participant_summary.ts
+++ b/frontend/src/components/experiment_dashboard/participant_summary.ts
@@ -14,7 +14,7 @@ import {core} from '../../core/core';
 import {AnalyticsService, ButtonClick} from '../../services/analytics.service';
 import {ExperimentManager} from '../../services/experiment.manager';
 import {ExperimentService} from '../../services/experiment.service';
-import {Pages, RouterService} from '../../services/router.service';
+import {RouterService} from '../../services/router.service';
 
 import {
   ParticipantProfileExtended,
@@ -81,7 +81,8 @@ export class ParticipantSummary extends MobxLitElement {
           >
           </participant-progress-bar>
           ${this.renderPauseButton()} ${this.renderCopyButton()}
-          ${this.renderAttentionButton()} ${this.renderBootButton()}
+          ${this.renderMessageButton()} ${this.renderAttentionButton()}
+          ${this.renderBootButton()}
         </div>
       </div>
     `;
@@ -327,6 +328,36 @@ export class ParticipantSummary extends MobxLitElement {
           variant="default"
           ?disabled=${!this.participant}
           @click=${this.copyParticipantLink}
+        >
+        </pr-icon-button>
+      </pr-tooltip>
+    `;
+  }
+
+  private renderMessageButton() {
+    const messageParticipant = () => {
+      if (!this.participant) return;
+      this.analyticsService.trackButtonClick(ButtonClick.PARTICIPANT_MESSAGE);
+
+      // Select the participant
+      this.experimentManager.setCurrentParticipantId(
+        this.participant.privateId,
+      );
+      // Open the alerts panel
+      this.experimentManager.setActivePanel('alerts');
+      // Pre-populate alert compose target
+      this.experimentManager.alertComposeTarget = this.participant.privateId;
+    };
+
+    return html`
+      <pr-tooltip text="Message participant" position="LEFT_START">
+        <pr-icon-button
+          icon="mail"
+          color="neutral"
+          variant="default"
+          ?disabled=${!this.participant ||
+          isParticipantEndedExperiment(this.participant)}
+          @click=${messageParticipant}
         >
         </pr-icon-button>
       </pr-tooltip>

--- a/frontend/src/components/experiment_dashboard/participant_summary.ts
+++ b/frontend/src/components/experiment_dashboard/participant_summary.ts
@@ -335,6 +335,10 @@ export class ParticipantSummary extends MobxLitElement {
   }
 
   private renderMessageButton() {
+    if (!this.participant || this.participant.agentConfig) {
+      return nothing;
+    }
+
     const messageParticipant = () => {
       if (!this.participant) return;
       this.analyticsService.trackButtonClick(ButtonClick.PARTICIPANT_MESSAGE);

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -312,3 +312,63 @@ pr-button pr-icon {
     gap: common.$spacing-small;
   }
 }
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+
+  &.outgoing-badge {
+    background: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary);
+  }
+}
+
+.alert.outgoing {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  border-color: var(--md-sys-color-secondary);
+
+  .alert-top {
+    border-bottom: 2px solid var(--md-sys-color-outline-variant);
+  }
+}
+
+.compose-section {
+  @include common.flex-column;
+  background: var(--md-sys-color-surface-variant);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-medium;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-large;
+  margin-bottom: common.$spacing-large;
+
+  .compose-header {
+    @include typescale.title-small;
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .compose-fields {
+    @include common.flex-column;
+    gap: common.$spacing-medium;
+  }
+
+  .participant-select {
+    @include typescale.body-medium;
+    background: var(--md-sys-color-surface);
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: common.$spacing-small;
+    color: var(--md-sys-color-on-surface);
+    padding: common.$spacing-medium;
+    width: 100%;
+    outline: none;
+
+    &:focus {
+      border-color: var(--md-sys-color-primary);
+    }
+  }
+}

--- a/frontend/src/components/experimenter/experimenter_panel.scss
+++ b/frontend/src/components/experimenter/experimenter_panel.scss
@@ -233,7 +233,7 @@ pr-button pr-icon {
   gap: common.$spacing-xs;
 }
 
-.alert-response-input {
+.alert-input-wrapper {
   @include common.flex-row-align-center;
   border: 1px solid var(--md-sys-color-outline);
   border-radius: common.$spacing-small;

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -17,7 +17,7 @@ import {customElement, state} from 'lit/decorators.js';
 import {repeat} from 'lit/directives/repeat.js';
 
 import {core} from '../../core/core';
-import {AnalyticsService} from '../../services/analytics.service';
+import {AnalyticsService, ButtonClick} from '../../services/analytics.service';
 import {AuthService} from '../../services/auth.service';
 import {ExperimentManager} from '../../services/experiment.manager';
 import {ExperimentService} from '../../services/experiment.service';

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -593,7 +593,10 @@ export class Panel extends MobxLitElement {
             <option value="">-- Select Participant --</option>
             ${participants.map(
               (p) => html`
-                <option value=${p.privateId}>
+                <option
+                  value=${p.privateId}
+                  ?selected=${p.privateId === targetParticipantId}
+                >
                   ${p.name ? `${p.name} (${p.publicId})` : p.publicId}
                 </option>
               `,

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -14,11 +14,10 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {reaction} from 'mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {classMap} from 'lit/directives/class-map.js';
 import {repeat} from 'lit/directives/repeat.js';
 
 import {core} from '../../core/core';
-import {ButtonClick, AnalyticsService} from '../../services/analytics.service';
+import {AnalyticsService} from '../../services/analytics.service';
 import {AuthService} from '../../services/auth.service';
 import {ExperimentManager} from '../../services/experiment.manager';
 import {ExperimentService} from '../../services/experiment.service';
@@ -35,6 +34,7 @@ import {
 
 import {styles} from './experimenter_panel.scss';
 import {convertUnifiedTimestampToDate} from '../../shared/utils';
+import {isObsoleteParticipant} from '../../shared/participant.utils';
 
 enum PanelView {
   DEFAULT = 'default',
@@ -57,11 +57,28 @@ export class Panel extends MobxLitElement {
   private readonly participantService = core.getService(ParticipantService);
   private readonly routerService = core.getService(RouterService);
 
-  @state() panelView: PanelView = PanelView.DEFAULT;
+  get panelView() {
+    return this.experimentManager.activePanel as PanelView;
+  }
+
+  set panelView(val: PanelView) {
+    this.experimentManager.setActivePanel(
+      val as
+        | 'default'
+        | 'alerts'
+        | 'manual_chat'
+        | 'api_key'
+        | 'participant_search'
+        | 'logs',
+    );
+  }
   @state() isLoading = false;
   @state() isAckAlertLoading = false;
   @state() participantSearchQuery = '';
   @state() showToast = false;
+  @state() private composeParticipantId = '';
+  @state() private composeMessage = '';
+  @state() private isSendingComposeAlert = false;
 
   private titleInterval: number | undefined = undefined;
   private originalTitle = document.title;
@@ -412,8 +429,14 @@ export class Panel extends MobxLitElement {
         this.isAckAlertLoading = false;
       };
 
+      const isOutgoing = alert.isExperimenterInitiated === true;
+
       return html`
-        <div class="alert ${alert.status === AlertStatus.NEW ? 'new' : ''}">
+        <div
+          class="alert ${alert.status === AlertStatus.NEW
+            ? 'new'
+            : ''} ${isOutgoing ? 'outgoing' : ''}"
+        >
           <div
             class="alert-top clickable"
             @click=${() => {
@@ -430,6 +453,9 @@ export class Panel extends MobxLitElement {
                 <div class="subtitle">
                   (${cohort?.metadata.name ?? 'Unknown cohort'})
                 </div>
+                ${isOutgoing
+                  ? html`<div class="chip outgoing-badge">Outgoing Alert</div>`
+                  : nothing}
               </div>
               <div class="subtitle">
                 ${convertUnifiedTimestampToDate(alert.timestamp)}
@@ -438,48 +464,60 @@ export class Panel extends MobxLitElement {
             <div class="alert-content">${alert.message}</div>
           </div>
           <div class="alert-bottom">
-            <div class="subtitle">Your responses</div>
-            ${alert.responses.map(
-              (response) => html` <div class="response">${response}</div> `,
-            )}
-            <div class="alert-response-options">
-              <div class="alert-response-input">
-                <pr-textarea
-                  .value=${this.alertResponseMap.get(alert.id) ?? ''}
-                  placeholder="Send a response"
-                  @input=${(e: Event) => {
-                    this.alertResponseMap.set(
-                      alert.id,
-                      (e.target as HTMLTextAreaElement).value,
-                    );
-                  }}
-                >
-                </pr-textarea>
-                <pr-icon-button
-                  icon="send"
-                  variant="default"
-                  @click=${async () => {
-                    onAck(this.alertResponseMap.get(alert.id) ?? '');
-                  }}
-                >
-                </pr-icon-button>
-              </div>
-              ${alert.status === AlertStatus.NEW
-                ? html`
-                    <pr-tooltip text="Mark as read" position="TOP_END">
+            ${alert.responses.length > 0
+              ? html`
+                  <div class="subtitle">
+                    ${isOutgoing ? 'Participant replies' : 'Your responses'}
+                  </div>
+                  ${alert.responses.map(
+                    (response) => html`
+                      <div class="response">${response}</div>
+                    `,
+                  )}
+                `
+              : nothing}
+            ${!isOutgoing
+              ? html`
+                  <div class="alert-response-options">
+                    <div class="alert-response-input">
+                      <pr-textarea
+                        .value=${this.alertResponseMap.get(alert.id) ?? ''}
+                        placeholder="Send a response"
+                        @input=${(e: Event) => {
+                          this.alertResponseMap.set(
+                            alert.id,
+                            (e.target as HTMLTextAreaElement).value,
+                          );
+                        }}
+                      >
+                      </pr-textarea>
                       <pr-icon-button
-                        icon="check_circle"
+                        icon="send"
                         variant="default"
-                        ?loading=${this.isAckAlertLoading}
-                        @click=${() => {
-                          onAck('');
+                        @click=${async () => {
+                          onAck(this.alertResponseMap.get(alert.id) ?? '');
                         }}
                       >
                       </pr-icon-button>
-                    </pr-tooltip>
-                  `
-                : nothing}
-            </div>
+                    </div>
+                    ${alert.status === AlertStatus.NEW
+                      ? html`
+                          <pr-tooltip text="Mark as read" position="TOP_END">
+                            <pr-icon-button
+                              icon="check_circle"
+                              variant="default"
+                              ?loading=${this.isAckAlertLoading}
+                              @click=${() => {
+                                onAck('');
+                              }}
+                            >
+                            </pr-icon-button>
+                          </pr-tooltip>
+                        `
+                      : nothing}
+                  </div>
+                `
+              : nothing}
           </div>
         </div>
       `;
@@ -488,6 +526,7 @@ export class Panel extends MobxLitElement {
     return html`
       <div class="main">
         <div class="top">
+          ${this.renderComposeSection()}
           <div class="header">New Alerts</div>
           ${repeat(
             newAlerts,
@@ -500,6 +539,81 @@ export class Panel extends MobxLitElement {
             (alert) => alert.id,
             (alert) => renderAlert(alert),
           )}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderComposeSection() {
+    const targetParticipantId =
+      this.composeParticipantId ||
+      this.experimentManager.alertComposeTarget ||
+      '';
+    const participants = Object.values(this.experimentManager.participantMap)
+      .filter((p) => !isObsoleteParticipant(p))
+      .sort((a, b) =>
+        (a.name || a.publicId).localeCompare(b.name || b.publicId),
+      );
+
+    const onSend = async () => {
+      if (!targetParticipantId || !this.composeMessage.trim()) return;
+      this.isSendingComposeAlert = true;
+      try {
+        const participant =
+          this.experimentManager.participantMap[targetParticipantId];
+        await this.experimentManager.sendExperimenterAlert(
+          targetParticipantId,
+          this.composeMessage.trim(),
+          participant?.currentCohortId || '',
+          participant?.currentStageId || '',
+        );
+        this.composeMessage = '';
+        this.experimentManager.alertComposeTarget = undefined;
+        this.composeParticipantId = '';
+      } catch (err) {
+        console.error('Failed to send alert', err);
+      } finally {
+        this.isSendingComposeAlert = false;
+      }
+    };
+
+    return html`
+      <div class="compose-section">
+        <div class="compose-header">Send Alert to Participant</div>
+        <div class="compose-fields">
+          <select
+            class="participant-select"
+            .value=${targetParticipantId}
+            @change=${(e: Event) => {
+              const val = (e.target as HTMLSelectElement).value;
+              this.composeParticipantId = val;
+              this.experimentManager.alertComposeTarget = val || undefined;
+            }}
+          >
+            <option value="">-- Select Participant --</option>
+            ${participants.map(
+              (p) => html`
+                <option value=${p.privateId}>
+                  ${p.name ? `${p.name} (${p.publicId})` : p.publicId}
+                </option>
+              `,
+            )}
+          </select>
+          <pr-textarea
+            placeholder="Type your message here..."
+            .value=${this.composeMessage}
+            @input=${(e: Event) => {
+              this.composeMessage = (e.target as HTMLTextAreaElement).value;
+            }}
+          >
+          </pr-textarea>
+          <pr-button
+            ?disabled=${!targetParticipantId || !this.composeMessage.trim()}
+            ?loading=${this.isSendingComposeAlert}
+            @click=${onSend}
+          >
+            Send Alert Message
+          </pr-button>
         </div>
       </div>
     `;

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -479,7 +479,7 @@ export class Panel extends MobxLitElement {
             ${!isOutgoing
               ? html`
                   <div class="alert-response-options">
-                    <div class="alert-response-input">
+                    <div class="alert-input-wrapper">
                       <pr-textarea
                         .value=${this.alertResponseMap.get(alert.id) ?? ''}
                         placeholder="Send a response"
@@ -599,21 +599,24 @@ export class Panel extends MobxLitElement {
               `,
             )}
           </select>
-          <pr-textarea
-            placeholder="Type your message here..."
-            .value=${this.composeMessage}
-            @input=${(e: Event) => {
-              this.composeMessage = (e.target as HTMLTextAreaElement).value;
-            }}
-          >
-          </pr-textarea>
-          <pr-button
-            ?disabled=${!targetParticipantId || !this.composeMessage.trim()}
-            ?loading=${this.isSendingComposeAlert}
-            @click=${onSend}
-          >
-            Send Alert Message
-          </pr-button>
+          <div class="alert-input-wrapper">
+            <pr-textarea
+              placeholder="Type your message here..."
+              .value=${this.composeMessage}
+              @input=${(e: Event) => {
+                this.composeMessage = (e.target as HTMLTextAreaElement).value;
+              }}
+            >
+            </pr-textarea>
+            <pr-icon-button
+              icon="send"
+              variant="default"
+              ?disabled=${!targetParticipantId || !this.composeMessage.trim()}
+              ?loading=${this.isSendingComposeAlert}
+              @click=${onSend}
+            >
+            </pr-icon-button>
+          </div>
         </div>
       </div>
     `;

--- a/frontend/src/components/experimenter/experimenter_panel.ts
+++ b/frontend/src/components/experimenter/experimenter_panel.ts
@@ -550,7 +550,7 @@ export class Panel extends MobxLitElement {
       this.experimentManager.alertComposeTarget ||
       '';
     const participants = Object.values(this.experimentManager.participantMap)
-      .filter((p) => !isObsoleteParticipant(p))
+      .filter((p) => !isObsoleteParticipant(p) && !p.agentConfig)
       .sort((a, b) =>
         (a.name || a.publicId).localeCompare(b.name || b.publicId),
       );

--- a/frontend/src/components/participant_view/participant_help_panel.scss
+++ b/frontend/src/components/participant_view/participant_help_panel.scss
@@ -66,3 +66,51 @@
 .error {
   color: var(--md-sys-color-error);
 }
+
+.alert.experimenter-alert {
+  background: var(--md-sys-color-primary-container-low);
+  border-color: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container-low);
+
+  .subtitle {
+    color: var(--md-sys-color-primary);
+  }
+}
+
+.alert-header {
+  @include common.flex-row-align-center;
+  justify-content: space-between;
+  gap: common.$spacing-small;
+  margin-bottom: common.$spacing-small;
+}
+
+.message-label {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-top: common.$spacing-small;
+}
+
+.responses-list {
+  @include common.flex-column;
+  gap: common.$spacing-xs;
+  padding-left: common.$spacing-medium;
+  border-left: 2px solid var(--md-sys-color-outline-variant);
+  margin-top: common.$spacing-xs;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 9px;
+  font-weight: bold;
+  padding: 1px 5px;
+  border-radius: 3px;
+  text-transform: uppercase;
+
+  &.experimenter-badge {
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+  }
+}

--- a/frontend/src/components/participant_view/participant_help_panel.ts
+++ b/frontend/src/components/participant_view/participant_help_panel.ts
@@ -7,12 +7,11 @@ import {AlertMessage, AlertStatus} from '@deliberation-lab/utils';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
-import {HomeService} from '../../services/home.service';
 import {ParticipantService} from '../../services/participant.service';
 
 import {convertUnifiedTimestampToDate} from '../../shared/utils';
@@ -30,10 +29,6 @@ export class HelpPanel extends MobxLitElement {
   @state() message = '';
 
   override render() {
-    const close = () => {
-      this.participantService.setShowHelpPanel(false);
-    };
-
     const classes = classMap({
       nav: true,
       'full-view': !this.authService.isExperimenter,
@@ -91,16 +86,54 @@ export class HelpPanel extends MobxLitElement {
     `;
   }
 
+  override updated(changedProperties: Map<PropertyKey, unknown>) {
+    super.updated(changedProperties);
+
+    // Auto-acknowledge new experimenter-initiated alerts when the help panel is open.
+    const unackedAlerts = this.participantService.alerts.filter(
+      (alert) =>
+        alert.isExperimenterInitiated && alert.status === AlertStatus.NEW,
+    );
+    for (const alert of unackedAlerts) {
+      this.participantService.ackExperimenterAlert(alert.id);
+    }
+  }
+
   renderAlert(alert: AlertMessage) {
+    const isExperimenterAlert = alert.isExperimenterInitiated === true;
+
     return html`
-      <div class="alert">
-        <div class="subtitle">
-          ${convertUnifiedTimestampToDate(alert.timestamp)}
+      <div class="alert ${isExperimenterAlert ? 'experimenter-alert' : ''}">
+        <div class="alert-header">
+          <div class="subtitle">
+            ${convertUnifiedTimestampToDate(alert.timestamp)}
+          </div>
+          ${isExperimenterAlert
+            ? html`<span class="chip experimenter-badge"
+                >Experimenter Message</span
+              >`
+            : nothing}
+        </div>
+        <div class="message-label">
+          ${isExperimenterAlert ? 'Message' : 'Your request'}
         </div>
         <div class="message">${alert.message}</div>
-        <div class="subtitle">Experimenter response</div>
-        ${alert.responses.map((response) => html`<div>${response}</div>`)}
-        ${this.renderAlertStatus(alert)}
+
+        ${alert.responses.length > 0
+          ? html`
+              <div class="subtitle">
+                ${isExperimenterAlert
+                  ? 'Your replies'
+                  : 'Experimenter response'}
+              </div>
+              <div class="responses-list">
+                ${alert.responses.map(
+                  (response) => html`<div>${response}</div>`,
+                )}
+              </div>
+            `
+          : nothing}
+        ${!isExperimenterAlert ? this.renderAlertStatus(alert) : nothing}
       </div>
     `;
   }

--- a/frontend/src/services/analytics.service.ts
+++ b/frontend/src/services/analytics.service.ts
@@ -37,6 +37,7 @@ export enum ButtonClick {
   LOGIN = 'click_login',
   MANUAL_CHAT_SEND = 'click_manual_chat_send',
   PARTICIPANT_BOOT = 'click_participant_boot',
+  PARTICIPANT_MESSAGE = 'click_participant_message',
   PARTICIPANT_ADD = 'click_participant_add',
   PARTICIPANT_JOIN = 'click_participant_join',
   PERSONA_ENHANCE = 'click_persona_enhance',

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -45,6 +45,7 @@ import {
 
 import {
   ackAlertMessageCallable,
+  sendExperimenterAlertCallable,
   bootParticipantCallable,
   createChatMessageCallable,
   createCohortCallable,
@@ -145,6 +146,26 @@ export class ExperimentManager extends Service {
   @observable showCohortList = false;
   @observable showParticipantStats = false;
   @observable showParticipantPreview = true;
+  @observable activePanel:
+    | 'default'
+    | 'alerts'
+    | 'manual_chat'
+    | 'api_key'
+    | 'participant_search'
+    | 'logs' = 'default';
+  @observable alertComposeTarget: string | undefined = undefined;
+
+  setActivePanel(
+    panel:
+      | 'default'
+      | 'alerts'
+      | 'manual_chat'
+      | 'api_key'
+      | 'participant_search'
+      | 'logs',
+  ) {
+    this.activePanel = panel;
+  }
   @observable hideLockedCohorts = false;
   @observable expandAllCohorts = true;
   @observable showMediatorsInCohortSummary = false;
@@ -1109,6 +1130,29 @@ export class ExperimentManager extends Service {
           participantId,
           alertId,
           response,
+        },
+      );
+    }
+    return output;
+  }
+
+  /** Send experimenter-initiated alert message. */
+  async sendExperimenterAlert(
+    participantId: string,
+    message: string,
+    cohortId = '',
+    stageId = '',
+  ) {
+    let output = {};
+    if (this.experimentId) {
+      output = await sendExperimenterAlertCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          cohortId,
+          stageId,
+          participantId,
+          message,
         },
       );
     }

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -1,18 +1,16 @@
 import {
   AlertMessage,
+  AlertStatus,
   AssetAllocation,
   ChatMessage,
   ChatStageParticipantAnswer,
   ChipOffer,
   CreateChatMessageData,
   FlipCardStageParticipantAnswer,
-  RankingItem,
   MultiAssetAllocationStageParticipantAnswer,
   ParticipantProfileBase,
   ParticipantProfileExtended,
   ParticipantStatus,
-  RoleStageConfig,
-  StageKind,
   StageParticipantAnswer,
   SurveyAnswer,
   SurveyPerParticipantStageParticipantAnswer,
@@ -34,8 +32,6 @@ import {
   onSnapshot,
   orderBy,
   query,
-  setDoc,
-  updateDoc,
 } from 'firebase/firestore';
 import {action, computed, makeObservable, observable, runInAction} from 'mobx';
 import {CohortService} from './cohort.service';
@@ -71,6 +67,7 @@ import {
   updateSurveyPerParticipantStageParticipantAnswerCallable,
   updateSurveyStageParticipantAnswerCallable,
   updateRankingStageParticipantAnswerCallable,
+  ackExperimenterAlertCallable,
 } from '../shared/callables';
 import {PROLIFIC_COMPLETION_URL_PREFIX} from '../shared/constants';
 import {
@@ -80,7 +77,6 @@ import {
   isPendingParticipant,
   isParticipantEndedExperiment,
 } from '../shared/participant.utils';
-import {ElectionStrategy} from '@deliberation-lab/utils';
 
 interface ServiceProvider {
   cohortService: CohortService;
@@ -217,7 +213,7 @@ export class ParticipantService extends Service {
   isReadyToEndChatDiscussion(stageId: string, discussionId: string) {
     // Use public stage data as source of truth
     // (since public stage data is used to determine current discussion ID)
-    const {completed, notCompleted} =
+    const {completed} =
       this.sp.cohortService.getParticipantsByChatDiscussionCompletion(
         stageId,
         discussionId,
@@ -388,9 +384,9 @@ export class ParticipantService extends Service {
     }
   }
 
-  /** Subscribe to participant's private alerts. */
   async loadAlertMessages() {
     if (!this.experimentId || !this.participantId) return;
+    let isInitial = true;
     this.unsubscribe.push(
       onSnapshot(
         query(
@@ -405,17 +401,24 @@ export class ParticipantService extends Service {
           orderBy('timestamp', 'asc'),
         ),
         (snapshot) => {
-          let changedDocs = snapshot.docChanges().map((change) => change.doc);
-          if (changedDocs.length === 0) {
-            changedDocs = snapshot.docs;
-          }
-
           runInAction(() => {
-            changedDocs.forEach((doc) => {
-              const alert = doc.data() as AlertMessage;
+            snapshot.docChanges().forEach((change) => {
+              const alert = change.doc.data() as AlertMessage;
+              const isNew = change.type === 'added' && !this.alertMap[alert.id];
               this.alertMap[alert.id] = alert;
+
+              // Auto-pop help panel on receiving a new experimenter alert
+              if (
+                !isInitial &&
+                isNew &&
+                alert.isExperimenterInitiated &&
+                alert.status === AlertStatus.NEW
+              ) {
+                this.showHelpPanel = true;
+              }
             });
           });
+          isInitial = false;
         },
       ),
     );
@@ -1089,5 +1092,20 @@ export class ParticipantService extends Service {
       );
     }
     return response;
+  }
+
+  async ackExperimenterAlert(alertId: string) {
+    let output = {};
+    if (this.experimentId && this.profile) {
+      output = await ackExperimenterAlertCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          participantId: this.profile.privateId,
+          alertId,
+        },
+      );
+    }
+    return output;
   }
 }

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -22,6 +22,8 @@ import {
   ParticipantNextStageResponse,
   RequestChipAssistanceData,
   SendAlertMessageData,
+  SendExperimenterAlertData,
+  AckExperimenterAlertData,
   SendChipOfferData,
   SendChipResponseData,
   SendParticipantCheckData,
@@ -766,5 +768,35 @@ export const revokeDeliberateLabAPIKeyCallable = async (
     functions,
     'revokeDeliberateLabAPIKey',
   )({keyId});
+  return data;
+};
+
+/** Send experimenter-initiated alert. */
+export const sendExperimenterAlertCallable = async (
+  functions: Functions,
+  config: SendExperimenterAlertData,
+) => {
+  const {data} = await httpsCallable<
+    SendExperimenterAlertData,
+    SimpleResponse<string>
+  >(
+    functions,
+    'sendExperimenterAlert',
+  )(config);
+  return data;
+};
+
+/** Acknowledge experimenter-initiated alert (called by participant). */
+export const ackExperimenterAlertCallable = async (
+  functions: Functions,
+  config: AckExperimenterAlertData,
+) => {
+  const {data} = await httpsCallable<
+    AckExperimenterAlertData,
+    SimpleResponse<string>
+  >(
+    functions,
+    'ackExperimenterAlert',
+  )(config);
   return data;
 };

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,7 @@
     "node": "22"
   },
   "config": {
-    "firestore_tests": "src/data.test.ts src/log.utils.test.ts src/dl_api/experiments.dl_api.integration.test.ts src/dl_api/cohorts.dl_api.integration.test.ts src/variables.utils.test.ts src/cohort_definitions.integration.test.ts"
+    "firestore_tests": "src/data.test.ts src/log.utils.test.ts src/dl_api/experiments.dl_api.integration.test.ts src/dl_api/cohorts.dl_api.integration.test.ts src/variables.utils.test.ts src/cohort_definitions.integration.test.ts src/alert.endpoints.test.ts"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/alert.endpoints.test.ts
+++ b/functions/src/alert.endpoints.test.ts
@@ -1,0 +1,349 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import firebaseFunctionsTest from 'firebase-functions-test';
+import {
+  RulesTestEnvironment,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  AlertMessage,
+  AlertStatus,
+  createAlertMessage,
+  generateId,
+} from '@deliberation-lab/utils';
+import {
+  sendAlertMessage,
+  ackAlertMessage,
+  sendExperimenterAlert,
+  ackExperimenterAlert,
+} from './alert.endpoints';
+import {Timestamp} from 'firebase-admin/firestore';
+import {app} from './app';
+
+const testEnv = firebaseFunctionsTest({projectId: 'demo-deliberate-lab'});
+const firestore = app.firestore();
+
+describe('Alert Endpoints Unit Tests', () => {
+  let rulesEnv: RulesTestEnvironment;
+  const experimentId = 'test-exp-id';
+  const cohortId = 'test-cohort-id';
+  const stageId = 'test-stage-id';
+  const participantId = 'test-participant-id';
+  const experimenterEmail = 'experimenter@test.com';
+  const unauthorizedEmail = 'unauthorized@test.com';
+
+  beforeAll(async () => {
+    rulesEnv = await initializeTestEnvironment({
+      projectId: 'demo-deliberate-lab',
+      firestore: process.env.FIRESTORE_EMULATOR_HOST
+        ? undefined
+        : {
+            host: 'localhost',
+            port: 8081,
+          },
+    });
+  });
+
+  beforeEach(async () => {
+    await rulesEnv.clearFirestore();
+
+    // Seed the allowlist for the experimenter user
+    await firestore
+      .collection('allowlist')
+      .doc(experimenterEmail)
+      .set({email: experimenterEmail, isAdmin: false});
+  });
+
+  afterAll(async () => {
+    await rulesEnv.cleanup();
+  });
+
+  describe('sendAlertMessage', () => {
+    const wrapped = testEnv.wrap(sendAlertMessage);
+
+    it('should allow writing participant-initiated alerts without experimenter auth', async () => {
+      const messageText = 'Need assistance!';
+      const result = await wrapped({
+        auth: {
+          uid: 'part-uid',
+          token: {email: 'participant@test.com'},
+        } as any,
+        data: {
+          experimentId,
+          cohortId,
+          stageId,
+          participantId,
+          message: messageText,
+        },
+      } as any);
+
+      expect(result.success).toBe(true);
+
+      // Verify alert exists in participant alerts collection
+      const participantAlerts = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .get();
+
+      expect(participantAlerts.size).toBe(1);
+      const alertDoc = participantAlerts.docs[0].data() as AlertMessage;
+      expect(alertDoc.message).toBe(messageText);
+      expect(alertDoc.isExperimenterInitiated).toBe(false);
+      expect(alertDoc.status).toBe(AlertStatus.NEW);
+
+      // Verify alert exists in global experiment alerts collection
+      const globalAlerts = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertDoc.id)
+        .get();
+
+      expect(globalAlerts.exists).toBe(true);
+      expect((globalAlerts.data() as AlertMessage).message).toBe(messageText);
+    });
+  });
+
+  describe('ackAlertMessage', () => {
+    const wrapped = testEnv.wrap(ackAlertMessage);
+    let alertId: string;
+
+    beforeEach(async () => {
+      alertId = generateId();
+      const alert = createAlertMessage({
+        id: alertId,
+        experimentId,
+        cohortId,
+        stageId,
+        participantId,
+        message: 'Help!',
+        isExperimenterInitiated: false,
+        timestamp: Timestamp.now() as any,
+      });
+
+      // Seed alert in both places
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .doc(alertId)
+        .set(alert);
+
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertId)
+        .set(alert);
+    });
+
+    it('should reject non-experimenters', async () => {
+      await expect(
+        wrapped({
+          auth: {
+            uid: 'bad-uid',
+            token: {email: unauthorizedEmail},
+          } as any,
+          data: {
+            experimentId,
+            alertId,
+            participantId,
+            response: 'On my way!',
+          },
+        } as any),
+      ).rejects.toThrow();
+    });
+
+    it('should allow experimenter to acknowledge and append response', async () => {
+      const responseText = 'On my way!';
+      const result = await wrapped({
+        auth: {
+          uid: 'exp-uid',
+          token: {email: experimenterEmail},
+        } as any,
+        data: {
+          experimentId,
+          alertId,
+          participantId,
+          response: responseText,
+        },
+      } as any);
+
+      expect(result.success).toBe(true);
+
+      // Verify alert is marked as READ in participant's alerts collection
+      const partAlertDoc = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .doc(alertId)
+        .get();
+
+      const partAlert = partAlertDoc.data() as AlertMessage;
+      expect(partAlert.status).toBe(AlertStatus.READ);
+      expect(partAlert.responses).toContain(responseText);
+
+      // Verify alert is marked as READ in global experiment alerts collection
+      const globAlertDoc = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertId)
+        .get();
+
+      const globAlert = globAlertDoc.data() as AlertMessage;
+      expect(globAlert.status).toBe(AlertStatus.READ);
+      expect(globAlert.responses).toContain(responseText);
+    });
+  });
+
+  describe('sendExperimenterAlert', () => {
+    const wrapped = testEnv.wrap(sendExperimenterAlert);
+
+    it('should reject non-experimenters', async () => {
+      await expect(
+        wrapped({
+          auth: {
+            uid: 'bad-uid',
+            token: {email: unauthorizedEmail},
+          } as any,
+          data: {
+            experimentId,
+            cohortId,
+            stageId,
+            participantId,
+            message: 'Attention!',
+          },
+        } as any),
+      ).rejects.toThrow();
+    });
+
+    it('should allow experimenter to send proactive alerts to participant', async () => {
+      const messageText = 'Attention participant!';
+      const result = await wrapped({
+        auth: {
+          uid: 'exp-uid',
+          token: {email: experimenterEmail},
+        } as any,
+        data: {
+          experimentId,
+          cohortId,
+          stageId,
+          participantId,
+          message: messageText,
+        },
+      } as any);
+
+      expect(result.success).toBe(true);
+
+      // Verify alert exists in participant alerts collection
+      const participantAlerts = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .get();
+
+      expect(participantAlerts.size).toBe(1);
+      const alertDoc = participantAlerts.docs[0].data() as AlertMessage;
+      expect(alertDoc.message).toBe(messageText);
+      expect(alertDoc.isExperimenterInitiated).toBe(true);
+      expect(alertDoc.status).toBe(AlertStatus.NEW);
+
+      // Verify alert exists in global experiment alerts collection
+      const globalAlerts = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertDoc.id)
+        .get();
+
+      expect(globalAlerts.exists).toBe(true);
+      expect((globalAlerts.data() as AlertMessage).message).toBe(messageText);
+    });
+  });
+
+  describe('ackExperimenterAlert', () => {
+    const wrapped = testEnv.wrap(ackExperimenterAlert);
+    let alertId: string;
+
+    beforeEach(async () => {
+      alertId = generateId();
+      const alert = createAlertMessage({
+        id: alertId,
+        experimentId,
+        cohortId,
+        stageId,
+        participantId,
+        message: 'Experimenter message!',
+        isExperimenterInitiated: true,
+        status: AlertStatus.NEW,
+        timestamp: Timestamp.now() as any,
+      });
+
+      // Seed alert in both places
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .doc(alertId)
+        .set(alert);
+
+      await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertId)
+        .set(alert);
+    });
+
+    it('should allow participant to acknowledge experimenter-initiated alert', async () => {
+      const result = await wrapped({
+        auth: {
+          uid: 'part-uid',
+          token: {email: 'participant@test.com'},
+        } as any,
+        data: {
+          experimentId,
+          alertId,
+          participantId,
+        },
+      } as any);
+
+      expect(result.success).toBe(true);
+
+      // Verify alert is marked as READ in participant's alerts collection
+      const partAlertDoc = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('participants')
+        .doc(participantId)
+        .collection('alerts')
+        .doc(alertId)
+        .get();
+
+      const partAlert = partAlertDoc.data() as AlertMessage;
+      expect(partAlert.status).toBe(AlertStatus.READ);
+
+      // Verify alert is marked as READ in global experiment alerts collection
+      const globAlertDoc = await firestore
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('alerts')
+        .doc(alertId)
+        .get();
+
+      const globAlert = globAlertDoc.data() as AlertMessage;
+      expect(globAlert.status).toBe(AlertStatus.READ);
+    });
+  });
+});

--- a/functions/src/alert.endpoints.ts
+++ b/functions/src/alert.endpoints.ts
@@ -98,3 +98,90 @@ export const ackAlertMessage = onCall(async (request) => {
 
   return {success: true};
 });
+
+// Send alert message from experimenter to participant
+export const sendExperimenterAlert = onCall(async (request) => {
+  const {data} = request;
+  const experimentId = data.experimentId;
+  const cohortId = data.cohortId;
+  const stageId = data.stageId;
+  const participantId = data.participantId;
+  const message = data.message;
+
+  // Only allow experimenters to send experimenter alerts
+  await AuthGuard.isExperimenter(request);
+
+  const alert: AlertMessage = createAlertMessage({
+    experimentId,
+    cohortId,
+    stageId,
+    participantId,
+    message,
+    isExperimenterInitiated: true,
+    timestamp: Timestamp.now(),
+    status: AlertStatus.NEW,
+  });
+
+  // Store alert message under participant's alerts collection
+  const participantAlertDoc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('alerts')
+    .doc(alert.id);
+
+  // Also store alert message under experiment's alerts collection
+  const experimenterAlertDoc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('alerts')
+    .doc(alert.id);
+
+  // Run document write as transaction to ensure consistency
+  await app.firestore().runTransaction(async (transaction) => {
+    transaction.set(participantAlertDoc, alert);
+    transaction.set(experimenterAlertDoc, alert);
+  });
+
+  return {success: true};
+});
+
+// Acknowledge alert message from experimenter (called by participant)
+export const ackExperimenterAlert = onCall(async (request) => {
+  const {data} = request;
+  const experimentId = data.experimentId;
+  const alertId = data.alertId;
+  const participantId = data.participantId;
+
+  const doc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('alerts')
+    .doc(alertId);
+
+  // Also store alert message under experiment's alerts collection
+  const experimenterAlertDoc = await app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('alerts')
+    .doc(alertId);
+
+  // Run document write as transaction to ensure consistency
+  await app.firestore().runTransaction(async (transaction) => {
+    const alert = (await doc.get()).data() as AlertMessage;
+    if (alert) {
+      alert.status = AlertStatus.READ;
+      transaction.set(doc, alert);
+      transaction.set(experimenterAlertDoc, alert);
+    }
+  });
+
+  return {success: true};
+});

--- a/utils/src/alert.ts
+++ b/utils/src/alert.ts
@@ -13,6 +13,7 @@ export interface AlertMessage {
   timestamp: UnifiedTimestamp; // time that message was sent
   responses: string[]; // responses from experimenter
   status: AlertStatus;
+  isExperimenterInitiated?: boolean;
 }
 
 export enum AlertStatus {
@@ -34,5 +35,6 @@ export function createAlertMessage(
     responses: config.responses ?? [],
     timestamp: config.timestamp ?? Timestamp.now(),
     status: config.status ?? AlertStatus.NEW,
+    isExperimenterInitiated: config.isExperimenterInitiated ?? false,
   };
 }

--- a/utils/src/alert.validation.ts
+++ b/utils/src/alert.validation.ts
@@ -37,3 +37,39 @@ export const AckAlertMessageData = Type.Object(
 );
 
 export type AckAlertMessageData = Static<typeof AckAlertMessageData>;
+
+// ****************************************************************************
+// sendExperimenterAlert
+// ****************************************************************************
+
+/** SendExperimenterAlert input validation. */
+export const SendExperimenterAlertData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    cohortId: Type.String(),
+    stageId: Type.String(),
+    participantId: Type.String({minLength: 1}),
+    message: Type.String({minLength: 1}),
+  },
+  strict,
+);
+
+export type SendExperimenterAlertData = Static<
+  typeof SendExperimenterAlertData
+>;
+
+// ****************************************************************************
+// ackExperimenterAlert
+// ****************************************************************************
+
+/** AckExperimenterAlert input validation. */
+export const AckExperimenterAlertData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    participantId: Type.String({minLength: 1}),
+    alertId: Type.String({minLength: 1}),
+  },
+  strict,
+);
+
+export type AckExperimenterAlertData = Static<typeof AckExperimenterAlertData>;


### PR DESCRIPTION
Fixes #757 

## Description

Adds a Message button to Participant entries in the cohort dashboard. When clicked, it opens the Experimenter alerting panel where they can send an outgoing message to a participant.

## Verification

Screenshots showing the Messagebuttons for Participants in the cohort dashboard:

![Screenshot showing the Message buttons for Participants in the cohort dashboard](https://github.com/user-attachments/assets/2edf7096-ada7-4ca3-95fe-591a63e40dd1)

Screenshot showing the new outgoing message dialog:

![Screenshot showing the new outgoing message dialog](https://github.com/user-attachments/assets/babfa06e-bacc-4cf8-a142-2a49a29d6abd)

Screenshot showing outgoing message received by participant:

![Screenshot showing outgoing message received by participant](https://github.com/user-attachments/assets/3311a9ff-07c0-4590-8c67-ec6e713b04f0)