### PR TITLE
fix: render markdown in multiple-choice survey options

### DIFF
--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -189,7 +189,9 @@ export class SurveyView extends MobxLitElement {
           disabled
         >
         </md-radio>
-        <label for=${id}>${choice.text}</label>
+        <label for=${id}
+          >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+        >
       </div>
     `;
   }

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -47,6 +47,7 @@
 
 .radio-question {
   @include common.flex-column;
+  @include common.html-preview;
   gap: common.$spacing-medium;
 }
 

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -324,7 +324,9 @@ export class SurveyView extends MobxLitElement {
                 value=${option.id}
                 ?selected=${selectedChoiceId === option.id}
               >
-                <div slot="headline">${option.text}</div>
+                <div slot="headline">
+                  ${unsafeHTML(convertMarkdownToHTML(option.text))}
+                </div>
               </md-select-option>
             `,
           )}
@@ -381,7 +383,9 @@ export class SurveyView extends MobxLitElement {
               ?disabled=${this.participantService.disableStage}
             >
             </md-radio>
-            <label for=${id}>${choice.text}</label>
+            <label for=${id}
+              >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+            >
           </div>
         </div>
       `;
@@ -399,7 +403,9 @@ export class SurveyView extends MobxLitElement {
           @change=${handleMultipleChoiceClick}
         >
         </md-radio>
-        <label for=${id}>${choice.text}</label>
+        <label for=${id}
+          >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+        >
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Survey question titles are rendered through `convertMarkdownToHTML`, but
multiple-choice **option text** was interpolated raw. Markdown such as
`**bold**` therefore displayed literally in radio-button labels and dropdown
options, in both the participant survey view and the experimenter summary view.

## Changes

- **`survey_view.ts`** (participant view) — render markdown for radio-button
  option labels (regular and image variants) and dropdown options.
- **`survey_summary_view.ts`** (experimenter summary view) — same fix for
  radio-button option labels.
- **`survey_view.scss`** — add the `html-preview` mixin to `.radio-question`
  so the `<p>` wrapper emitted by the markdown converter does not introduce
  stray margins. `.question` already includes this mixin.

Option text is now rendered the same way question titles already are
(`unsafeHTML(convertMarkdownToHTML(...))`). `aria-label` attributes are
intentionally left as plain text.

## Testing

- Ran locally against the Firebase emulator.
- Created a survey stage with a multiple-choice question containing markdown
  (`**bold**`, `_italic_`) in both the question title and the options.
- Confirmed the options now render markdown in the participant view,
  consistent with the question title.

Fixes #1097
