### PR TITLE
ci: bump astral-sh/setup-uv from v4 to v8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v8
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
The v4 tag no longer resolves on GitHub, causing the schemas CI job to fail on every run. The current stable major version per the project's README is v8.

Example failing build: https://github.com/PAIR-code/deliberate-lab/actions/runs/26447960440/job/77861726766?pr=1125

Excerpt from the log:

```
Download action repository 'actions/setup-java@v4' (SHA:c1e323688fd81a25caa38c78aa6df2d33d3e20d9)
Error: An action could not be found at the URI 'https://codeload.github.com/actions/setup-java/tar.gz/c1e323688fd81a25caa38c78aa6df2d33d3e20d9' (3000:16E4B4:1D64A8:2596F2:6A15929F)
Error: Failed to download archive 'https://codeload.github.com/actions/setup-java/tar.gz/c1e323688fd81a25caa38c78aa6df2d33d3e20d9' after 1 attempts.
```