### PR TITLE
ci: add workflow to close stale issues and PRs (#1081)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+# Automatically close stale issues and pull requests.
+# https://github.com/actions/stale
+#
+# Resolves: https://github.com/PAIR-code/deliberate-lab/issues/1081
+
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    # Run daily at midnight UTC.
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual triggering.
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # --- Stale thresholds ---
+          days-before-stale: 90
+          days-before-close: 7
+
+          # --- Labels ---
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+
+          # --- Exempt labels (comma-separated) ---
+          exempt-issue-labels: 'pinned,security,good first issue'
+          exempt-pr-labels: 'pinned,security'
+
+          # --- Messages ---
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed in 7 days if no
+            further activity occurs. If this issue is still relevant, please
+            leave a comment or remove the `stale` label. Thank you for your
+            contributions!
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had recent activity. It will be closed in 7 days if
+            no further activity occurs. If this PR is still relevant, please
+            leave a comment or remove the `stale` label. Thank you for your
+            contributions!
+          close-issue-message: >
+            This issue was closed because it has been stale for 7 days with
+            no further activity. Feel free to reopen if this is still
+            relevant.
+          close-pr-message: >
+            This pull request was closed because it has been stale for
+            7 days with no further activity. Feel free to reopen if this is
+            still relevant.
+
+          # --- Behavior ---
+          remove-stale-when-updated: true
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,5 @@
 # Automatically close stale issues and pull requests.
 # https://github.com/actions/stale
-#
-# Resolves: https://github.com/PAIR-code/deliberate-lab/issues/1081
 
 name: 'Close stale issues and PRs'
 


### PR DESCRIPTION
Standard nightly GitHub Action which detects, marks, and closes issues and PRs without recent activity.