### PR TITLE
docs(skills): add read-github skill for API-based issue/PR reading (#1135)

### DIFF
--- a/.gemini/skills/read-github/SKILL.md
+++ b/.gemini/skills/read-github/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: read-github
+description: >
+  Read GitHub issues and pull requests via the REST API instead of
+  scraping HTML pages.
+---
+
+# Read GitHub Issues and PRs
+
+When a user references a GitHub issue or PR URL (e.g.
+`https://github.com/PAIR-code/deliberate-lab/issues/NNN` or
+`.../pull/NNN`), use the **GitHub REST API** to fetch clean JSON rather
+than fetching the HTML page. The HTML is dominated by navigation chrome,
+CSS, and JavaScript — making it difficult to extract the actual content.
+
+API endpoints follow the standard pattern:
+
+- **Issues**: `https://api.github.com/repos/{owner}/{repo}/issues/{number}`
+- **PRs**: `https://api.github.com/repos/{owner}/{repo}/pulls/{number}`
+
+## Always fetch comments
+
+The issue/PR endpoint does **not** include comments inline — they are
+only available via a separate request. Check the `comments` field in the
+response. If it is greater than zero, fetch them:
+
+- `https://api.github.com/repos/{owner}/{repo}/issues/{number}/comments`
+
+Issue and PR comments often contain supplementary guidance, research
+findings, design decisions, and other context critical to understanding
+the work. Do not skip them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ and optional helper scripts, examples, and resources.
 |-------|---------|
 | [`sync-fork`](.gemini/skills/sync-fork/SKILL.md) | Sync fork's `main` with upstream and rebase feature branches |
 | [`eval-pr`](.gemini/skills/eval-pr/SKILL.md) | Set up a git worktree to run and evaluate an upstream Pull Request locally |
+| [`read-github`](.gemini/skills/read-github/SKILL.md) | Read GitHub issues and PRs via the REST API instead of scraping HTML |
 
 ## Common pitfalls
 


### PR DESCRIPTION
When pasting a GitHub URL to an Issue or PR, often AI agents will try to read the URL directly. Instead, they're more successful using GitHub's read only API, which they can do when nudged. This skill also prompts the agent to fetch comments, since these often include additional guidance. Fixes #1135