### PR TITLE
ci: Record previous configurations during Cloud Build deployment (#995)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -102,6 +102,16 @@ steps:
         attempt=$(( attempt + 1 ))
       done
     }
+
+    # Fetch a GCP access token from the instance metadata server.
+    # Outputs the raw token string to stdout.
+    # Usage: local token; token=$(fetch_gcp_token)
+    fetch_gcp_token() {
+      local token_json
+      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+      node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json"
+    }
     SHARED_SCRIPT
     chmod +x shared.sh
     echo "shared.sh written successfully."
@@ -483,11 +493,8 @@ steps:
 
     # Fetch Firestore rules from the Firebase Rules REST API.
     fetch_firestore_rules() {
-      local token_json
-      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
+      token=$(fetch_gcp_token)
 
       local release_json
       release_json=$(retry curl -sSf \
@@ -561,11 +568,8 @@ steps:
 
     # Fetch Database rules from the Realtime Database REST API.
     fetch_database_rules() {
-      local token_json
-      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
+      token=$(fetch_gcp_token)
 
       retry curl -sSf \
         -H "Authorization: Bearer $token" \
@@ -630,11 +634,8 @@ steps:
 
     # Fetch Storage rules from the Firebase Rules REST API.
     fetch_storage_rules() {
-      local token_json
-      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
+      token=$(fetch_gcp_token)
 
       local release_json
       release_json=$(retry curl -sSf \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,6 +69,44 @@ options:
   automapSubstitutions: true
 
 steps:
+# Write Shared Script
+# Writes a shared.sh file with reusable shell helpers (e.g. retry logic for
+# transient network failures). Later steps source this file instead of
+# duplicating the same functions inline.
+- name: 'bash:5'
+  id: WriteSharedScript
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cat > shared.sh << 'SHARED_SCRIPT'
+    # shared.sh — Reusable shell helpers for Cloud Build steps.
+    # Source this file at the top of any step that needs these utilities:
+    #   source ./shared.sh
+
+    # Retry helper for transient network failures (read-only commands only).
+    # Usage: retry <command> [args...]
+    # Honors the RETRIES env var (default: 3). Uses exponential backoff
+    # starting at 5 seconds.
+    retry() {
+      local retries="${RETRIES:-3}" delay=5 attempt=1
+      while true; do
+        "$@" && return 0
+        local exit_code=$?
+        if (( attempt >= retries )); then
+          echo "❌ Command failed after $retries attempts: $*" >&2
+          return $exit_code
+        fi
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+        attempt=$(( attempt + 1 ))
+      done
+    }
+    SHARED_SCRIPT
+    chmod +x shared.sh
+    echo "shared.sh written successfully."
+  waitFor: ['-']  # No dependencies, runs immediately.
+  dir: '.'
 # Validate Substitution Values
 - name: 'node:22'
   id: ValidateSubstitutionValues
@@ -441,22 +479,7 @@ steps:
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
 
-    # Retry helper for transient network failures (read-only commands only).
-    retry() {
-      local retries="${RETRIES:-3}" delay=5 attempt=1
-      while true; do
-        "$@" && return 0
-        local exit_code=$?
-        if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*" >&2
-          return $exit_code
-        fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
-        sleep "$delay"
-        delay=$(( delay * 2 ))
-        attempt=$(( attempt + 1 ))
-      done
-    }
+    source ./shared.sh
 
     # Fetch Firestore rules from the Firebase Rules REST API.
     fetch_firestore_rules() {
@@ -521,7 +544,7 @@ steps:
     else
       echo "Skipping Firestore rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['TestFunctions']
+  waitFor: ['TestFunctions', 'WriteSharedScript']
   dir: '.'
 
 # Deploy Database Rules Step
@@ -534,22 +557,7 @@ steps:
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
 
-    # Retry helper for transient network failures (read-only commands only).
-    retry() {
-      local retries="${RETRIES:-3}" delay=5 attempt=1
-      while true; do
-        "$@" && return 0
-        local exit_code=$?
-        if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*" >&2
-          return $exit_code
-        fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
-        sleep "$delay"
-        delay=$(( delay * 2 ))
-        attempt=$(( attempt + 1 ))
-      done
-    }
+    source ./shared.sh
 
     # Fetch Database rules from the Realtime Database REST API.
     fetch_database_rules() {
@@ -605,7 +613,7 @@ steps:
     else
       echo "Skipping Database rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['TestFunctions']
+  waitFor: ['TestFunctions', 'WriteSharedScript']
   dir: '.'
 
 # Deploy Storage Rules Step
@@ -618,22 +626,7 @@ steps:
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
 
-    # Retry helper for transient network failures (read-only commands only).
-    retry() {
-      local retries="${RETRIES:-3}" delay=5 attempt=1
-      while true; do
-        "$@" && return 0
-        local exit_code=$?
-        if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*" >&2
-          return $exit_code
-        fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
-        sleep "$delay"
-        delay=$(( delay * 2 ))
-        attempt=$(( attempt + 1 ))
-      done
-    }
+    source ./shared.sh
 
     # Fetch Storage rules from the Firebase Rules REST API.
     fetch_storage_rules() {
@@ -698,7 +691,7 @@ steps:
     else
       echo "Skipping Storage rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['TestFunctions']
+  waitFor: ['TestFunctions', 'WriteSharedScript']
   dir: '.'
 
 # Deploy Indexes Step
@@ -711,22 +704,7 @@ steps:
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
 
-    # Retry helper for transient network failures (read-only commands only).
-    retry() {
-      local retries="${RETRIES:-3}" delay=5 attempt=1
-      while true; do
-        "$@" && return 0
-        local exit_code=$?
-        if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*" >&2
-          return $exit_code
-        fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
-        sleep "$delay"
-        delay=$(( delay * 2 ))
-        attempt=$(( attempt + 1 ))
-      done
-    }
+    source ./shared.sh
 
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
 
@@ -773,7 +751,7 @@ steps:
     else
       echo "Skipping Firebase indexes deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
-  waitFor: ['TestFunctions']
+  waitFor: ['TestFunctions', 'WriteSharedScript']
   dir: '.'
 
 # Deploy Frontend

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -460,21 +460,24 @@ steps:
 
     # Fetch Firestore rules from the Firebase Rules REST API.
     fetch_firestore_rules() {
+      local token_json
+      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
+      local release_json
+      release_json=$(retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/cloud.firestore")
       local ruleset_name
-      ruleset_name=$(retry curl -sf \
-        -H "Authorization: Bearer $token" \
-        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/cloud.firestore" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName')
+      ruleset_name=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName' <<< "$release_json")
 
-      retry curl -sf \
+      local ruleset_json
+      ruleset_json=$(retry curl -sf \
         -H "Authorization: Bearer $token" \
-        "https://firebaserules.googleapis.com/v1/${ruleset_name}" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content'
+        "https://firebaserules.googleapis.com/v1/${ruleset_name}")
+      node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content' <<< "$ruleset_json"
     }
 
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
@@ -550,10 +553,11 @@ steps:
 
     # Fetch Database rules from the Realtime Database REST API.
     fetch_database_rules() {
+      local token_json
+      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
       retry curl -sf \
         -H "Authorization: Bearer $token" \
@@ -633,21 +637,24 @@ steps:
 
     # Fetch Storage rules from the Firebase Rules REST API.
     fetch_storage_rules() {
+      local token_json
+      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
-      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+      token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
+      local release_json
+      release_json=$(retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage")
       local ruleset_name
-      ruleset_name=$(retry curl -sf \
-        -H "Authorization: Bearer $token" \
-        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName')
+      ruleset_name=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName' <<< "$release_json")
 
-      retry curl -sf \
+      local ruleset_json
+      ruleset_json=$(retry curl -sf \
         -H "Authorization: Bearer $token" \
-        "https://firebaserules.googleapis.com/v1/${ruleset_name}" \
-        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content'
+        "https://firebaserules.googleapis.com/v1/${ruleset_name}")
+      node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content' <<< "$ruleset_json"
     }
 
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -448,10 +448,10 @@ steps:
         "$@" && return 0
         local exit_code=$?
         if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*"
+          echo "❌ Command failed after $retries attempts: $*" >&2
           return $exit_code
         fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
         sleep "$delay"
         delay=$(( delay * 2 ))
         attempt=$(( attempt + 1 ))
@@ -538,10 +538,10 @@ steps:
         "$@" && return 0
         local exit_code=$?
         if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*"
+          echo "❌ Command failed after $retries attempts: $*" >&2
           return $exit_code
         fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
         sleep "$delay"
         delay=$(( delay * 2 ))
         attempt=$(( attempt + 1 ))
@@ -621,10 +621,10 @@ steps:
         "$@" && return 0
         local exit_code=$?
         if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*"
+          echo "❌ Command failed after $retries attempts: $*" >&2
           return $exit_code
         fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
         sleep "$delay"
         delay=$(( delay * 2 ))
         attempt=$(( attempt + 1 ))
@@ -711,10 +711,10 @@ steps:
         "$@" && return 0
         local exit_code=$?
         if (( attempt >= retries )); then
-          echo "❌ Command failed after $retries attempts: $*"
+          echo "❌ Command failed after $retries attempts: $*" >&2
           return $exit_code
         fi
-        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..." >&2
         sleep "$delay"
         delay=$(( delay * 2 ))
         attempt=$(( attempt + 1 ))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -440,7 +440,52 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
+
+    # Retry helper for transient network failures (read-only commands only).
+    retry() {
+      local retries="${RETRIES:-3}" delay=5 attempt=1
+      while true; do
+        "$@" && return 0
+        local exit_code=$?
+        if (( attempt >= retries )); then
+          echo "❌ Command failed after $retries attempts: $*"
+          return $exit_code
+        fi
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+        attempt=$(( attempt + 1 ))
+      done
+    }
+
+    # Fetch Firestore rules from the Firebase Rules REST API.
+    fetch_firestore_rules() {
+      local token
+      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+
+      local ruleset_name
+      ruleset_name=$(retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/cloud.firestore" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName')
+
+      retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/${ruleset_name}" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content'
+    }
+
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+
+      echo "Fetching current production Firestore rules (Backup)..."
+      fetch_firestore_rules > existing_firestore_rules.txt
+
+      echo "--- EXISTING FIRESTORE RULES BACKUP: START ---"
+      cat existing_firestore_rules.txt
+      echo "--- EXISTING FIRESTORE RULES BACKUP: END ---"
+
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Firestore Rules..."
         npx firebase deploy \
@@ -458,6 +503,18 @@ steps:
           --non-interactive \
           --dry-run
       fi
+
+      echo "Fetching deployed production Firestore rules..."
+      fetch_firestore_rules > deployed_firestore_rules.txt
+
+      if cmp -s "existing_firestore_rules.txt" "deployed_firestore_rules.txt"; then
+        echo "Deployed Firestore Rules match existing (no change)."
+      else
+        echo "--- DEPLOYED FIRESTORE RULES: START ---"
+        cat deployed_firestore_rules.txt
+        echo "--- DEPLOYED FIRESTORE RULES: END ---"
+      fi
+
     else
       echo "Skipping Firestore rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
@@ -473,7 +530,45 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
+
+    # Retry helper for transient network failures (read-only commands only).
+    retry() {
+      local retries="${RETRIES:-3}" delay=5 attempt=1
+      while true; do
+        "$@" && return 0
+        local exit_code=$?
+        if (( attempt >= retries )); then
+          echo "❌ Command failed after $retries attempts: $*"
+          return $exit_code
+        fi
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+        attempt=$(( attempt + 1 ))
+      done
+    }
+
+    # Fetch Database rules from the Realtime Database REST API.
+    fetch_database_rules() {
+      local token
+      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+
+      retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://${PROJECT_ID}-default-rtdb.firebaseio.com/.settings/rules.json"
+    }
+
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+
+      echo "Fetching current production Database rules (Backup)..."
+      fetch_database_rules > existing_database_rules.json
+
+      echo "--- EXISTING DATABASE RULES BACKUP: START ---"
+      cat existing_database_rules.json
+      echo "--- EXISTING DATABASE RULES BACKUP: END ---"
+
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Database Rules..."
         npx firebase deploy \
@@ -491,6 +586,18 @@ steps:
           --non-interactive \
           --dry-run
       fi
+
+      echo "Fetching deployed production Database rules..."
+      fetch_database_rules > deployed_database_rules.json
+
+      if cmp -s "existing_database_rules.json" "deployed_database_rules.json"; then
+        echo "Deployed Database Rules match existing (no change)."
+      else
+        echo "--- DEPLOYED DATABASE RULES: START ---"
+        cat deployed_database_rules.json
+        echo "--- DEPLOYED DATABASE RULES: END ---"
+      fi
+
     else
       echo "Skipping Database rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
@@ -506,7 +613,52 @@ steps:
     #!/usr/bin/env bash
     set -euo pipefail
     trap 'echo "❌ STEP FAILED: Command \"$BASH_COMMAND\" exited with code $?"' ERR
+
+    # Retry helper for transient network failures (read-only commands only).
+    retry() {
+      local retries="${RETRIES:-3}" delay=5 attempt=1
+      while true; do
+        "$@" && return 0
+        local exit_code=$?
+        if (( attempt >= retries )); then
+          echo "❌ Command failed after $retries attempts: $*"
+          return $exit_code
+        fi
+        echo "⚠️ Attempt $attempt/$retries failed (exit code $exit_code). Retrying in ${delay}s..."
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+        attempt=$(( attempt + 1 ))
+      done
+    }
+
+    # Fetch Storage rules from the Firebase Rules REST API.
+    fetch_storage_rules() {
+      local token
+      token=$(retry curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token')
+
+      local ruleset_name
+      ruleset_name=$(retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName')
+
+      retry curl -sf \
+        -H "Authorization: Bearer $token" \
+        "https://firebaserules.googleapis.com/v1/${ruleset_name}" \
+        | node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content'
+    }
+
     if [[ "${DEPLOYMENT_TYPES}" == *" ${_DEPLOYMENT_TYPE} "* ]]; then
+
+      echo "Fetching current production Storage rules (Backup)..."
+      fetch_storage_rules > existing_storage_rules.txt
+
+      echo "--- EXISTING STORAGE RULES BACKUP: START ---"
+      cat existing_storage_rules.txt
+      echo "--- EXISTING STORAGE RULES BACKUP: END ---"
+
       if [[ "${_DEPLOY}" == "true" ]]; then
         echo "Deploying Storage Rules..."
         npx firebase deploy \
@@ -524,13 +676,25 @@ steps:
           --non-interactive \
           --dry-run
       fi
+
+      echo "Fetching deployed production Storage rules..."
+      fetch_storage_rules > deployed_storage_rules.txt
+
+      if cmp -s "existing_storage_rules.txt" "deployed_storage_rules.txt"; then
+        echo "Deployed Storage Rules match existing (no change)."
+      else
+        echo "--- DEPLOYED STORAGE RULES: START ---"
+        cat deployed_storage_rules.txt
+        echo "--- DEPLOYED STORAGE RULES: END ---"
+      fi
+
     else
       echo "Skipping Storage rules deploy for '${_DEPLOYMENT_TYPE}' deployment."
     fi
   waitFor: ['TestFunctions']
   dir: '.'
 
-# Deploy Indexes Step (With Backup)
+# Deploy Indexes Step
 - name: 'node:22'
   id: DeployFirebaseIndexes
   env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -461,20 +461,20 @@ steps:
     # Fetch Firestore rules from the Firebase Rules REST API.
     fetch_firestore_rules() {
       local token_json
-      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
       token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
       local release_json
-      release_json=$(retry curl -sf \
+      release_json=$(retry curl -sSf \
         -H "Authorization: Bearer $token" \
         "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/cloud.firestore")
       local ruleset_name
       ruleset_name=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName' <<< "$release_json")
 
       local ruleset_json
-      ruleset_json=$(retry curl -sf \
+      ruleset_json=$(retry curl -sSf \
         -H "Authorization: Bearer $token" \
         "https://firebaserules.googleapis.com/v1/${ruleset_name}")
       node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content' <<< "$ruleset_json"
@@ -554,12 +554,12 @@ steps:
     # Fetch Database rules from the Realtime Database REST API.
     fetch_database_rules() {
       local token_json
-      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
       token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
-      retry curl -sf \
+      retry curl -sSf \
         -H "Authorization: Bearer $token" \
         "https://${PROJECT_ID}-default-rtdb.firebaseio.com/.settings/rules.json"
     }
@@ -638,20 +638,20 @@ steps:
     # Fetch Storage rules from the Firebase Rules REST API.
     fetch_storage_rules() {
       local token_json
-      token_json=$(retry curl -sf -H "Metadata-Flavor: Google" \
+      token_json=$(retry curl -sSf -H "Metadata-Flavor: Google" \
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
       local token
       token=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).access_token' <<< "$token_json")
 
       local release_json
-      release_json=$(retry curl -sf \
+      release_json=$(retry curl -sSf \
         -H "Authorization: Bearer $token" \
         "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage")
       local ruleset_name
       ruleset_name=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName' <<< "$release_json")
 
       local ruleset_json
-      ruleset_json=$(retry curl -sf \
+      ruleset_json=$(retry curl -sSf \
         -H "Authorization: Bearer $token" \
         "https://firebaserules.googleapis.com/v1/${ruleset_name}")
       node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).source.files[0].content' <<< "$ruleset_json"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -646,7 +646,7 @@ steps:
       local release_json
       release_json=$(retry curl -sSf \
         -H "Authorization: Bearer $token" \
-        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage")
+        "https://firebaserules.googleapis.com/v1/projects/${PROJECT_ID}/releases/firebase.storage/${PROJECT_ID}.appspot.com")
       local ruleset_name
       ruleset_name=$(node -p 'JSON.parse(require("fs").readFileSync(0,"utf-8")).rulesetName' <<< "$release_json")
 


### PR DESCRIPTION
Currently, there are four different Firebase deployment steps. Of them, only updating indexes records the before and after state.

This change upgrades the deployment process so that all four Firebase deployment steps record the before and after state of deployed configs. That way, if there is ever a Firebase-based deployment issue, the Cloud Build logs will show what the configurations were just prior to the breaking change.

Fixes #995 