### PR TITLE
feat(participant): expose variables via SYSTEM_VARIABLE_NAMESPACE

### DIFF
--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -28,6 +28,7 @@ import {
   RankingStagePublicData,
   RoleStagePublicData,
   StageConfig,
+  SYSTEM_VARIABLE_NAMESPACE,
   STAGE_KIND_REQUIRES_TRANSFER_MIGRATION,
   StageKind,
   StageParticipantAnswer,
@@ -1260,6 +1261,29 @@ function buildTargetValuesForParticipant(
     for (const [questionId, answer] of Object.entries(participantAnswers)) {
       const key = getConditionTargetKey({stageId, questionId});
       targetValues[key] = extractAnswerValue(answer);
+    }
+  }
+
+  if (participant.variableMap) {
+    for (const [varName, varValue] of Object.entries(participant.variableMap)) {
+      try {
+        const parsed = JSON.parse(varValue);
+        if (typeof parsed === 'object' && parsed !== null) {
+          for (const [key, val] of Object.entries(parsed)) {
+            const targetKey = getConditionTargetKey({
+              stageId: SYSTEM_VARIABLE_NAMESPACE,
+              questionId: `${varName}.${key}`,
+            });
+            targetValues[targetKey] = val;
+          }
+        }
+      } catch (e) {
+        const targetKey = getConditionTargetKey({
+          stageId: SYSTEM_VARIABLE_NAMESPACE,
+          questionId: varName,
+        });
+        targetValues[targetKey] = varValue;
+      }
     }
   }
 

--- a/utils/src/utils/condition.ts
+++ b/utils/src/utils/condition.ts
@@ -30,6 +30,8 @@ export interface ConditionGroup extends BaseCondition {
 }
 
 // Structured representation of a condition target
+export const SYSTEM_VARIABLE_NAMESPACE = '__system_variables__';
+
 export interface ConditionTargetReference {
   stageId: string;
   questionId: string;


### PR DESCRIPTION
The effect of this would be a "virtual stage" under which participant-specific variables could be mapped to, which would allow us to do things like cohort Transfer based on the specific policy a participant was assigned in the policy_mediation experiment (as opposed to now, where we need to compartmentalize each policy into its own experiment).