### PR TITLE
fix: render markdown in multiple-choice survey options

### DIFF
--- a/frontend/src/components/stages/survey_summary_view.ts
+++ b/frontend/src/components/stages/survey_summary_view.ts
@@ -189,7 +189,9 @@ export class SurveyView extends MobxLitElement {
           disabled
         >
         </md-radio>
-        <label for=${id}>${choice.text}</label>
+        <label for=${id}
+          >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+        >
       </div>
     `;
   }

--- a/frontend/src/components/stages/survey_view.scss
+++ b/frontend/src/components/stages/survey_view.scss
@@ -47,6 +47,7 @@
 
 .radio-question {
   @include common.flex-column;
+  @include common.html-preview;
   gap: common.$spacing-medium;
 }
 

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -324,7 +324,9 @@ export class SurveyView extends MobxLitElement {
                 value=${option.id}
                 ?selected=${selectedChoiceId === option.id}
               >
-                <div slot="headline">${option.text}</div>
+                <div slot="headline">
+                  ${unsafeHTML(convertMarkdownToHTML(option.text))}
+                </div>
               </md-select-option>
             `,
           )}
@@ -381,7 +383,9 @@ export class SurveyView extends MobxLitElement {
               ?disabled=${this.participantService.disableStage}
             >
             </md-radio>
-            <label for=${id}>${choice.text}</label>
+            <label for=${id}
+              >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+            >
           </div>
         </div>
       `;
@@ -399,7 +403,9 @@ export class SurveyView extends MobxLitElement {
           @change=${handleMultipleChoiceClick}
         >
         </md-radio>
-        <label for=${id}>${choice.text}</label>
+        <label for=${id}
+          >${unsafeHTML(convertMarkdownToHTML(choice.text))}</label
+        >
       </div>
     `;
   }


### PR DESCRIPTION
Survey question titles were passed through convertMarkdownToHTML, but multiple-choice option text was interpolated raw. As a result, markdown such as **bold** showed literally in radio-button labels and dropdown options, both in the participant survey view and the experimenter summary view.

Render option text with convertMarkdownToHTML + unsafeHTML, matching how titles are rendered. Add the html-preview mixin to .radio-question so the <p> wrapper emitted by the markdown converter does not introduce stray margins.

Fixes #1097

## Description
<!-- Briefly describe the changes introduced by this PR. -->

- [ ] [Documentation](https://pair-code.github.io/deliberate-lab/) updated as needed

---

## Verification
- [ ] *Screenshots or videos* included (if applicable)
- [ ] Clear reproduction steps provided to invoke the feature (if applicable)
- [ ] All tests pass (if applicable)

---

## Related issues
This PR fixes: #<issue_number>
> It’s recommended to [open an issue](https://github.com/orgs/PAIR-code/projects) for discussion before submitting a PR.

---
