### PR TITLE
feat: allow multi-turn private reasoning for agents

### DIFF
--- a/frontend/src/components/chat/chat_message.ts
+++ b/frontend/src/components/chat/chat_message.ts
@@ -68,7 +68,7 @@ export class ChatMessageComponent extends MobxLitElement {
   };
 
   override render() {
-    if (!this.chat || this.chat.isReasoningOnly) {
+    if (!this.chat || this.chat.isScratchpadOnly) {
       return nothing;
     }
 

--- a/frontend/src/components/chat/chat_message.ts
+++ b/frontend/src/components/chat/chat_message.ts
@@ -68,7 +68,7 @@ export class ChatMessageComponent extends MobxLitElement {
   };
 
   override render() {
-    if (!this.chat) {
+    if (!this.chat || this.chat.isReasoningOnly) {
       return nothing;
     }
 

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -371,6 +371,7 @@ export class CohortService extends Service {
                 explanation: '', // backwards compatibility pre version 16
                 ...doc.data(),
               } as ChatMessage;
+              if (message.isReasoningOnly) return;
               if (!message.discussionId) {
                 this.chatMap[stageId].push(message);
               } else {

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -371,7 +371,7 @@ export class CohortService extends Service {
                 explanation: '', // backwards compatibility pre version 16
                 ...doc.data(),
               } as ChatMessage;
-              if (message.isReasoningOnly) return;
+              if (message.isScratchpadOnly) return;
               if (!message.discussionId) {
                 this.chatMap[stageId].push(message);
               } else {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -200,10 +200,10 @@ export class ExperimentEditor extends Service {
     }
 
     for (const config of this.experiment.variableConfigs ?? []) {
-      // Block save and inform experimenter to avoid reasoning history name collision.
-      if (config.definition.name === '_scratchpad') {
+      // Names starting with "_" are reserved for system variables.
+      if (config.definition.name.startsWith('_')) {
         errors.push(
-          'The variable name "_scratchpad" is reserved for tracking the system\'s reasoning history. Please rename it.',
+          'Variables that begin with an underscore are not allowed unless they are established system variables.',
         );
       }
       if (requiresValues(config.type)) {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -17,6 +17,7 @@ import {
   VariableConfig,
   MultiValueVariableConfigType,
   requiresValues,
+  INTERNAL_VARIABLES,
   STAGE_MANAGER,
   checkApiKeyExists,
   SurveyQuestion,
@@ -200,8 +201,12 @@ export class ExperimentEditor extends Service {
     }
 
     for (const config of this.experiment.variableConfigs ?? []) {
-      // Names starting with "_" are reserved for internal variables.
-      if (config.definition.name.startsWith('_')) {
+      // Names starting with "_" are reserved for internal variables; only
+      // the ones in the registry may be used, and never defined here.
+      if (
+        config.definition.name.startsWith('_') &&
+        !INTERNAL_VARIABLES.has(config.definition.name)
+      ) {
         errors.push(
           'Variables that begin with an underscore are not allowed unless they are established internal variables.',
         );

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -201,9 +201,9 @@ export class ExperimentEditor extends Service {
 
     for (const config of this.experiment.variableConfigs ?? []) {
       // Block save and inform experimenter to avoid reasoning history name collision.
-      if (config.definition.name === '_reasoning') {
+      if (config.definition.name === '_scratchpad') {
         errors.push(
-          'The variable name "_reasoning" is reserved for tracking the system\'s reasoning history. Please rename it.',
+          'The variable name "_scratchpad" is reserved for tracking the system\'s reasoning history. Please rename it.',
         );
       }
       if (requiresValues(config.type)) {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -200,10 +200,10 @@ export class ExperimentEditor extends Service {
     }
 
     for (const config of this.experiment.variableConfigs ?? []) {
-      // Names starting with "_" are reserved for system variables.
+      // Names starting with "_" are reserved for internal variables.
       if (config.definition.name.startsWith('_')) {
         errors.push(
-          'Variables that begin with an underscore are not allowed unless they are established system variables.',
+          'Variables that begin with an underscore are not allowed unless they are established internal variables.',
         );
       }
       if (requiresValues(config.type)) {

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -200,6 +200,12 @@ export class ExperimentEditor extends Service {
     }
 
     for (const config of this.experiment.variableConfigs ?? []) {
+      // Block save and inform experimenter to avoid reasoning history name collision.
+      if (config.definition.name === '_reasoning') {
+        errors.push(
+          'The variable name "_reasoning" is reserved for tracking the system\'s reasoning history. Please rename it.',
+        );
+      }
       if (requiresValues(config.type)) {
         const multiConfig = config as MultiValueVariableConfigType;
         if (multiConfig.values.length === 0) {

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -375,7 +375,7 @@ export class ParticipantService extends Service {
             runInAction(() => {
               this.privateChatMap[stageId] = snapshot.docs
                 .map((doc) => doc.data() as ChatMessage)
-                .filter((message) => !message.isReasoningOnly);
+                .filter((message) => !message.isScratchpadOnly);
               this.isPrivateChatLoading = false;
             });
           },

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -377,9 +377,9 @@ export class ParticipantService extends Service {
           ),
           (snapshot) => {
             runInAction(() => {
-              this.privateChatMap[stageId] = snapshot.docs.map(
-                (doc) => doc.data() as ChatMessage,
-              );
+              this.privateChatMap[stageId] = snapshot.docs
+                .map((doc) => doc.data() as ChatMessage)
+                .filter((message) => !message.isReasoningOnly);
               this.isPrivateChatLoading = false;
             });
           },

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -7,7 +7,7 @@ import {
   ChatStagePublicData,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
-  injectReasoningField,
+  injectScratchpadField,
   MediatorProfileExtended,
   ModelResponseStatus,
   ParticipantProfileExtended,
@@ -24,7 +24,7 @@ import {
 import {Timestamp} from 'firebase-admin/firestore';
 import {processModelResponse} from '../agent.utils';
 import {
-  containsReasoningPlaceholder,
+  containsScratchpadPlaceholder,
   getPromptFromConfig,
   getStructuredPromptConfig,
 } from '../structured_prompt.utils';
@@ -390,12 +390,12 @@ export async function getAgentChatMessage(
       ? Math.max(0, turnBasedRetryDeadlineMs - Date.now())
       : null;
 
-  // When the magic variable {{_reasoning}} is present in the prompt,
-  // we auto-inject a _reasoning field at the start of the structured output.
+  // When the magic variable {{_scratchpad}} is present in the prompt,
+  // we auto-inject a _scratchpad field at the start of the structured output.
   const isReasoningEnabled = Boolean(
     (user.agentConfig?.promptContext &&
-      user.agentConfig.promptContext.includes('{{_reasoning}}')) ||
-    containsReasoningPlaceholder(promptConfig.prompt),
+      user.agentConfig.promptContext.includes('{{_scratchpad}}')) ||
+    containsScratchpadPlaceholder(promptConfig.prompt),
   );
 
   const effectiveStructuredOutputConfig = (() => {
@@ -417,7 +417,7 @@ export async function getAgentChatMessage(
       } as ChatMediatorStructuredOutputConfig;
     }
     if (isReasoningEnabled) {
-      config = injectReasoningField(config);
+      config = injectScratchpadField(config);
     }
     return config;
   })();
@@ -470,7 +470,7 @@ export async function getAgentChatMessage(
   let message = response.text || ''; // Use response.text as the default message
   let explanation = ''; // From structured output schema field only
   const reasoning = response.reasoning || undefined; // From model's internal thinking
-  let agentReasoning: string | undefined = undefined; // From structured output _reasoning field
+  let agentReasoning: string | undefined = undefined; // From structured output _scratchpad field
   let shouldRespond = true;
   let readyToEndChat = false;
 
@@ -486,8 +486,8 @@ export async function getAgentChatMessage(
       if (fields.explanation !== null) {
         explanation = fields.explanation;
       }
-      if (fields._reasoning !== null) {
-        agentReasoning = fields._reasoning;
+      if (fields._scratchpad !== null) {
+        agentReasoning = fields._scratchpad;
       }
       readyToEndChat = fields.readyToEndChat;
     }
@@ -563,12 +563,12 @@ export async function getAgentChatMessage(
     message: shouldRespond ? message : '',
     explanation,
     reasoning,
-    _reasoning: agentReasoning,
+    _scratchpad: agentReasoning,
     profile: createParticipantProfileBase(user),
     senderId: user.publicId,
     agentId: user.agentConfig.agentId,
     timestamp: Timestamp.now(),
-    isReasoningOnly: !shouldRespond,
+    isScratchpadOnly: !shouldRespond,
   });
 
   // Upload files to GCS
@@ -823,7 +823,7 @@ export async function sendAgentGroupChatMessage(
 ) {
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
-  if (chatSettings.wordsPerMinute && !chatMessage.isReasoningOnly) {
+  if (chatSettings.wordsPerMinute && !chatMessage.isScratchpadOnly) {
     await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
   }
 
@@ -898,7 +898,7 @@ export async function sendAgentPrivateChatMessage(
 ) {
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
-  if (chatSettings.wordsPerMinute && !chatMessage.isReasoningOnly) {
+  if (chatSettings.wordsPerMinute && !chatMessage.isScratchpadOnly) {
     await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
   }
 

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -7,6 +7,7 @@ import {
   ChatStagePublicData,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
+  injectReasoningField,
   MediatorProfileExtended,
   ModelResponseStatus,
   ParticipantProfileExtended,
@@ -23,6 +24,7 @@ import {
 import {Timestamp} from 'firebase-admin/firestore';
 import {processModelResponse} from '../agent.utils';
 import {
+  containsReasoningPlaceholder,
   getPromptFromConfig,
   getStructuredPromptConfig,
 } from '../structured_prompt.utils';
@@ -388,26 +390,36 @@ export async function getAgentChatMessage(
       ? Math.max(0, turnBasedRetryDeadlineMs - Date.now())
       : null;
 
-  // In turn-based mode the agent always responds when called — strip shouldRespond
-  // from the API-level schema constraint so the model isn't forced to output a
-  // field whose "stay silent" path would freeze the turn. The prompt text is
-  // already filtered in structured_prompt.utils.ts; this keeps the two in sync.
+  // When the magic variable {{_reasoning}} is present in the prompt,
+  // we auto-inject a _reasoning field at the start of the structured output.
+  const isReasoningEnabled = Boolean(
+    (user.agentConfig?.promptContext &&
+      user.agentConfig.promptContext.includes('{{_reasoning}}')) ||
+    containsReasoningPlaceholder(promptConfig.prompt),
+  );
+
   const effectiveStructuredOutputConfig = (() => {
-    const config = promptConfig.structuredOutputConfig as
+    let config = promptConfig.structuredOutputConfig as
       | ChatMediatorStructuredOutputConfig
       | undefined;
-    if (!isTurnBasedGroupChat || !config?.schema?.properties) return config;
-    const shouldRespondFieldName = config.shouldRespondField || 'shouldRespond';
-    return {
-      ...config,
-      schema: {
-        ...config.schema,
-        properties: config.schema.properties.filter(
-          (p) => p.name !== shouldRespondFieldName,
-        ),
-      },
-      shouldRespondField: '',
-    } as ChatMediatorStructuredOutputConfig;
+    if (isTurnBasedGroupChat && config?.schema?.properties) {
+      const shouldRespondFieldName =
+        config.shouldRespondField || 'shouldRespond';
+      config = {
+        ...config,
+        schema: {
+          ...config.schema,
+          properties: config.schema.properties.filter(
+            (p) => p.name !== shouldRespondFieldName,
+          ),
+        },
+        shouldRespondField: '',
+      } as ChatMediatorStructuredOutputConfig;
+    }
+    if (isReasoningEnabled) {
+      config = injectReasoningField(config);
+    }
+    return config;
   })();
 
   const {response, logId, retryTimedOut} = await processModelResponse(
@@ -458,6 +470,7 @@ export async function getAgentChatMessage(
   let message = response.text || ''; // Use response.text as the default message
   let explanation = ''; // From structured output schema field only
   const reasoning = response.reasoning || undefined; // From model's internal thinking
+  let agentReasoning: string | undefined = undefined; // From structured output _reasoning field
   let shouldRespond = true;
   let readyToEndChat = false;
 
@@ -473,17 +486,20 @@ export async function getAgentChatMessage(
       if (fields.explanation !== null) {
         explanation = fields.explanation;
       }
+      if (fields._reasoning !== null) {
+        agentReasoning = fields._reasoning;
+      }
       readyToEndChat = fields.readyToEndChat;
     }
   }
 
-  // No text and no files = failure
-  if (!response.text && (!response.files || response.files.length === 0)) {
+  if (!shouldRespond && isReasoningEnabled) {
+    // Silent turns are allowed to have empty text
+  } else if (
+    !response.text &&
+    (!response.files || response.files.length === 0)
+  ) {
     return {message: null, success: false, retryTimedOut};
-  }
-
-  if (!shouldRespond) {
-    // Logic for not responding (handled below)
   }
 
   // Only if agent participant is ready to end chat
@@ -518,7 +534,10 @@ export async function getAgentChatMessage(
       );
       await participantAnswerDoc.set({readyToEndChat: true}, {merge: true});
     }
-    return {message: null, success: true, retryTimedOut};
+    // If reasoning is not being tracked, bypass saving silent message
+    if (!isReasoningEnabled) {
+      return {message: null, success: true, retryTimedOut};
+    }
   }
 
   // If stage includes discussions, figure out what discussion ID should be
@@ -541,13 +560,15 @@ export async function getAgentChatMessage(
   const chatMessage = createChatMessage({
     type: user.type,
     discussionId,
-    message,
+    message: shouldRespond ? message : '',
     explanation,
     reasoning,
+    _reasoning: agentReasoning,
     profile: createParticipantProfileBase(user),
     senderId: user.publicId,
     agentId: user.agentConfig.agentId,
     timestamp: Timestamp.now(),
+    isReasoningOnly: !shouldRespond,
   });
 
   // Upload files to GCS
@@ -802,7 +823,7 @@ export async function sendAgentGroupChatMessage(
 ) {
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
-  if (chatSettings.wordsPerMinute) {
+  if (chatSettings.wordsPerMinute && !chatMessage.isReasoningOnly) {
     await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
   }
 
@@ -877,7 +898,7 @@ export async function sendAgentPrivateChatMessage(
 ) {
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
-  if (chatSettings.wordsPerMinute) {
+  if (chatSettings.wordsPerMinute && !chatMessage.isReasoningOnly) {
     await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
   }
 

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -35,7 +35,7 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_PROMPT_INSTRUCTIONS,
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
-  injectReasoningField,
+  injectScratchpadField,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -52,17 +52,19 @@ import {
 } from './utils/firestore';
 import {stageManager} from './app';
 
-// Recursively check whether `{{_reasoning}}` appears in prompt
-export function containsReasoningPlaceholder(items: PromptItem[]): boolean {
+// Recursively check whether `{{_scratchpad}}` appears in prompt
+export function containsScratchpadPlaceholder(items: PromptItem[]): boolean {
   return items.some((item) => {
     if (item.type === PromptItemType.TEXT) {
-      return (item as TextPromptItem).text?.includes('{{_reasoning}}') ?? false;
+      return (
+        (item as TextPromptItem).text?.includes('{{_scratchpad}}') ?? false
+      );
     }
     if (item.type === PromptItemType.GROUP) {
       const group = item as PromptItemGroup;
       return (
-        (group.title?.includes('{{_reasoning}}') ?? false) ||
-        containsReasoningPlaceholder(group.items ?? [])
+        (group.title?.includes('{{_scratchpad}}') ?? false) ||
+        containsScratchpadPlaceholder(group.items ?? [])
       );
     }
     return false;
@@ -382,13 +384,13 @@ export async function getPromptFromConfig(
     };
   }
 
-  // Auto-inject _reasoning at the start of the schema when {{_reasoning}} is present
+  // Auto-inject _scratchpad at the start of the schema when {{_scratchpad}} is present
   const usesReasoningPlaceholder =
-    (userProfile.agentConfig?.promptContext?.includes('{{_reasoning}}') ??
+    (userProfile.agentConfig?.promptContext?.includes('{{_scratchpad}}') ??
       false) ||
-    containsReasoningPlaceholder(promptConfig.prompt);
+    containsScratchpadPlaceholder(promptConfig.prompt);
   if (usesReasoningPlaceholder) {
-    structuredOutputConfig = injectReasoningField(structuredOutputConfig);
+    structuredOutputConfig = injectScratchpadField(structuredOutputConfig);
   }
 
   const structuredOutput = makeStructuredOutputPrompt(structuredOutputConfig);
@@ -629,9 +631,9 @@ async function processPromptItems(
   // When referenced, inject the agent's past reasoning history
   let reasoningText = '';
   const usesReasoning =
-    (userProfile.agentConfig?.promptContext?.includes('{{_reasoning}}') ??
+    (userProfile.agentConfig?.promptContext?.includes('{{_scratchpad}}') ??
       false) ||
-    containsReasoningPlaceholder(promptItems);
+    containsScratchpadPlaceholder(promptItems);
   const chatContext = usesReasoning ? promptData.data[stageId] : undefined;
   const messages = chatContext
     ? stageKind === StageKind.PRIVATE_CHAT
@@ -648,10 +650,10 @@ async function processPromptItems(
     messages.forEach((msg, idx) => {
       if (
         msg.senderId === userProfile.publicId &&
-        msg._reasoning &&
-        msg._reasoning.trim() !== ''
+        msg._scratchpad &&
+        msg._scratchpad.trim() !== ''
       ) {
-        agentReasonings.push({round: idx + 1, reasoning: msg._reasoning});
+        agentReasonings.push({round: idx + 1, reasoning: msg._scratchpad});
       }
     });
 
@@ -672,14 +674,14 @@ async function processPromptItems(
       }
       if (recentLines.length > 0) {
         reasoningText =
-          'Each line shows your reasoning for your messages sent in this conversation, in order:\n\n' +
+          'Each line shows your scratchpad for your messages sent in this conversation, in order:\n\n' +
           recentLines.join('');
         reasoningText = reasoningText.trim();
       }
     }
   }
 
-  valueMap['_reasoning'] = reasoningText;
+  valueMap['_scratchpad'] = reasoningText;
 
   for (const [itemIndex, promptItem] of promptItems.entries()) {
     // Check condition if present (only for private chat contexts)
@@ -736,8 +738,8 @@ async function processPromptItems(
         );
         if (profileContext) {
           const resolvedProfileContext = profileContext.replaceAll(
-            '{{_reasoning}}',
-            valueMap['_reasoning'] ?? '',
+            '{{_scratchpad}}',
+            valueMap['_scratchpad'] ?? '',
           );
           items.push(resolvedProfileContext);
         }

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -71,6 +71,21 @@ export function containsScratchpadPlaceholder(items: PromptItem[]): boolean {
   });
 }
 
+/** With no history, the placeholder and one adjacent blank line collapse. */
+function substituteScratchpad(text: string, block: string): string {
+  if (!block) {
+    return text
+      .replaceAll('{{_scratchpad}}\n\n', '')
+      .replaceAll('\n\n{{_scratchpad}}', '\n')
+      .replaceAll('{{_scratchpad}}', '');
+  }
+  const b = block.trim();
+  return text
+    .replaceAll('{{_scratchpad}}\n\n', `${b}\n\n`)
+    .replaceAll('\n\n{{_scratchpad}}', `\n\n${b}\n`)
+    .replaceAll('{{_scratchpad}}', b);
+}
+
 /** Attempts to fetch corresponding prompt config from storage,
  * else returns the stage's default config.
  */
@@ -681,7 +696,8 @@ async function processPromptItems(
     }
   }
 
-  valueMap['_scratchpad'] = reasoningText;
+  const scratchpadBlock = reasoningText;
+  valueMap['_scratchpad'] = '';
 
   for (const [itemIndex, promptItem] of promptItems.entries()) {
     // Check condition if present (only for private chat contexts)
@@ -700,7 +716,7 @@ async function processPromptItems(
       case PromptItemType.TEXT: {
         // Resolve template variables in text prompt items
         const resolvedText = resolveTemplateVariables(
-          promptItem.text,
+          substituteScratchpad(promptItem.text, scratchpadBlock),
           variableDefinitions,
           valueMap,
         );
@@ -737,11 +753,7 @@ async function processPromptItems(
           includeScaffolding,
         );
         if (profileContext) {
-          const resolvedProfileContext = profileContext.replaceAll(
-            '{{_scratchpad}}',
-            valueMap['_scratchpad'] ?? '',
-          );
-          items.push(resolvedProfileContext);
+          items.push(substituteScratchpad(profileContext, scratchpadBlock));
         }
         break;
       case PromptItemType.PROFILE_INFO:

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -15,6 +15,7 @@ import {
   PromptItemGroup,
   PromptItemType,
   StageConfig,
+  TextPromptItem,
   StageContextData,
   StageContextPromptItem,
   StageKind,
@@ -34,6 +35,7 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_PROMPT_INSTRUCTIONS,
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
+  injectReasoningField,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -49,6 +51,23 @@ import {
   getFirestorePrivateChatMessages,
 } from './utils/firestore';
 import {stageManager} from './app';
+
+// Recursively check whether `{{_reasoning}}` appears in prompt
+export function containsReasoningPlaceholder(items: PromptItem[]): boolean {
+  return items.some((item) => {
+    if (item.type === PromptItemType.TEXT) {
+      return (item as TextPromptItem).text?.includes('{{_reasoning}}') ?? false;
+    }
+    if (item.type === PromptItemType.GROUP) {
+      const group = item as PromptItemGroup;
+      return (
+        (group.title?.includes('{{_reasoning}}') ?? false) ||
+        containsReasoningPlaceholder(group.items ?? [])
+      );
+    }
+    return false;
+  });
+}
 
 /** Attempts to fetch corresponding prompt config from storage,
  * else returns the stage's default config.
@@ -363,6 +382,15 @@ export async function getPromptFromConfig(
     };
   }
 
+  // Auto-inject _reasoning at the start of the schema when {{_reasoning}} is present
+  const usesReasoningPlaceholder =
+    (userProfile.agentConfig?.promptContext?.includes('{{_reasoning}}') ??
+      false) ||
+    containsReasoningPlaceholder(promptConfig.prompt);
+  if (usesReasoningPlaceholder) {
+    structuredOutputConfig = injectReasoningField(structuredOutputConfig);
+  }
+
   const structuredOutput = makeStructuredOutputPrompt(structuredOutputConfig);
 
   return structuredOutput ? `${promptText}\n${structuredOutput}` : promptText;
@@ -589,6 +617,61 @@ async function processPromptItems(
     participantForVariables,
   );
 
+  // When referenced, inject the agent's past reasoning history
+  let reasoningText = '';
+  const usesReasoning =
+    (userProfile.agentConfig?.promptContext?.includes('{{_reasoning}}') ??
+      false) ||
+    containsReasoningPlaceholder(promptItems);
+  const chatContext = usesReasoning ? promptData.data[stageId] : undefined;
+  const messages = chatContext
+    ? stageKind === StageKind.PRIVATE_CHAT
+      ? (chatContext.privateChatMap[promptData.participants[0]?.publicId] ?? [])
+      : chatContext.publicChatMessages
+    : [];
+
+  if (messages && messages.length > 0) {
+    const maxReasoningChars = 20000; // Approx 5,000 tokens (4 chars per token)
+
+    // Filter messages sent by this agent that have reasoning
+    // Not msg.reasoning (the model's internal API reasoning, which is only available with some models)
+    const agentReasonings: {round: number; reasoning: string}[] = [];
+    messages.forEach((msg, idx) => {
+      if (
+        msg.senderId === userProfile.publicId &&
+        msg._reasoning &&
+        msg._reasoning.trim() !== ''
+      ) {
+        agentReasonings.push({round: idx + 1, reasoning: msg._reasoning});
+      }
+    });
+
+    if (agentReasonings.length > 0) {
+      const recentLines: string[] = [];
+      let charCount = 0;
+
+      // Begin with most recent context
+      for (let i = agentReasonings.length - 1; i >= 0; i--) {
+        const {reasoning} = agentReasonings[i];
+        const roundLine = `#${i + 1}\n${reasoning}\n\n`;
+        if (charCount + roundLine.length <= maxReasoningChars) {
+          recentLines.unshift(roundLine);
+          charCount += roundLine.length;
+        } else {
+          break;
+        }
+      }
+      if (recentLines.length > 0) {
+        reasoningText =
+          'Each line shows your reasoning for your messages sent in this conversation, in order:\n\n' +
+          recentLines.join('');
+        reasoningText = reasoningText.trim();
+      }
+    }
+  }
+
+  valueMap['_reasoning'] = reasoningText;
+
   for (const promptItem of promptItems) {
     // Check condition if present (only for private chat contexts)
     if (
@@ -643,7 +726,11 @@ async function processPromptItems(
           includeScaffolding,
         );
         if (profileContext) {
-          items.push(profileContext);
+          const resolvedProfileContext = profileContext.replaceAll(
+            '{{_reasoning}}',
+            valueMap['_reasoning'] ?? '',
+          );
+          items.push(resolvedProfileContext);
         }
         break;
       case PromptItemType.PROFILE_INFO:

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -43,7 +43,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
     timeoutSeconds: 300,
   },
   async (event) => {
-    if ((event.data?.data() as ChatMessage | undefined)?.isReasoningOnly) {
+    if ((event.data?.data() as ChatMessage | undefined)?.isScratchpadOnly) {
       return;
     }
 
@@ -617,7 +617,7 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
         .doc(event.params.chatId)
         .get()
     ).data() as ChatMessage;
-    if (message.isError || message.isReasoningOnly) {
+    if (message.isError || message.isScratchpadOnly) {
       return;
     }
 

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -43,6 +43,10 @@ export const onPublicChatMessageCreated = onDocumentCreated(
     timeoutSeconds: 300,
   },
   async (event) => {
+    if ((event.data?.data() as ChatMessage | undefined)?.isReasoningOnly) {
+      return;
+    }
+
     const stage = await getFirestoreStage(
       event.params.experimentId,
       event.params.stageId,
@@ -613,7 +617,7 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
         .doc(event.params.chatId)
         .get()
     ).data() as ChatMessage;
-    if (message.isError) {
+    if (message.isError || message.isReasoningOnly) {
       return;
     }
 

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel, constr
 
 
 class CollectionName(StrEnum):
@@ -117,9 +117,6 @@ class ShuffleConfig(BaseModel):
 
 
 class Weight(RootModel[float]):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[float, Field(ge=1.0)]
 
 
@@ -342,8 +339,10 @@ class SurveyPayoutItem(BaseModel):
     isActive: bool
     stageId: str
     baseCurrencyAmount: float
-    rankingStageId: str | None = None
-    questionMap: Annotated[dict[str, float | None], Field(title="QuestionMap")]
+    rankingStageId: str | None
+    questionMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), float | None], Field(title="QuestionMap")
+    ]
 
 
 class PrivateChatStageConfig(BaseModel):
@@ -391,7 +390,8 @@ class Strategy(StrEnum):
     condorcet = "condorcet"
 
 
-RankingItem = MultipleChoiceItem
+class RankingItem(MultipleChoiceItem):
+    pass
 
 
 class ParticipantRankingStageConfig(BaseModel):
@@ -471,7 +471,7 @@ class Role(BaseModel):
     name: str
     displayLines: list[str]
     minParticipants: int
-    maxParticipants: int | None = None
+    maxParticipants: int | None
 
 
 class RoleStageConfig(BaseModel):
@@ -558,8 +558,8 @@ class StockInfoStageConfig(BaseModel):
     useQuarterlyMarkers: bool
     showInvestmentGrowth: bool
     useSharedYAxis: bool
-    initialInvestment: Annotated[float | None, Field(ge=1.0)] = 1000
-    currency: str | None = "USD"
+    initialInvestment: Annotated[float, Field(ge=1.0)] = 1000
+    currency: str = "USD"
     introText: str | None = None
 
 
@@ -627,7 +627,9 @@ class SurveyAutoTransferConfig(BaseModel):
     autoCohortParticipantConfig: CohortParticipantConfig
     surveyStageId: Annotated[str, Field(min_length=1)]
     surveyQuestionId: Annotated[str, Field(min_length=1)]
-    participantCounts: Annotated[dict[str, int], Field(title="ParticipantCounts")]
+    participantCounts: Annotated[
+        dict[constr(pattern=r"^(.*)$"), int], Field(title="ParticipantCounts")
+    ]
 
 
 class ApiKeyType(StrEnum):
@@ -1039,18 +1041,6 @@ class ChatStageConfig(BaseModel):
     enableReactionsAndReplies: bool | None = None
 
 
-class RankingStageConfig(
-    RootModel[ItemRankingStageConfig | ParticipantRankingStageConfig]
-):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    root: Annotated[
-        ItemRankingStageConfig | ParticipantRankingStageConfig,
-        Field(title="RankingStageConfig"),
-    ]
-
-
 class ProviderOptionsMap(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1093,7 +1083,9 @@ class Experiment(BaseModel):
     defaultCohortConfig: CohortParticipantConfig
     prolificConfig: Annotated[ProlificConfig, Field(title="ProlificConfig")]
     stageIds: list[str]
-    cohortLockMap: Annotated[dict[str, bool], Field(title="CohortLockMap")]
+    cohortLockMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), bool], Field(title="CohortLockMap")
+    ]
     variableConfigs: (
         list[
             StaticVariableConfig
@@ -1102,7 +1094,9 @@ class Experiment(BaseModel):
         ]
         | None
     ) = None
-    variableMap: Annotated[dict[str, str] | None, Field(title="VariableMap")] = None
+    variableMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), str] | None, Field(title="VariableMap")
+    ] = None
     cohortDefinitions: list[CohortDefinition] | None = None
 
 
@@ -1124,8 +1118,6 @@ class ExperimentTemplate(BaseModel):
         | PayoutStageConfig
         | PrivateChatStageConfig
         | ProfileStageConfig
-        | ItemRankingStageConfig
-        | ParticipantRankingStageConfig
         | RevealStageConfig
         | RoleStageConfig
         | NegotiationProfileStageConfig
@@ -1136,6 +1128,8 @@ class ExperimentTemplate(BaseModel):
         | SurveyStageConfig
         | TOSStageConfig
         | TransferStageConfig
+        | ItemRankingStageConfig
+        | ParticipantRankingStageConfig
     ]
     agentMediators: list[AgentMediatorTemplate]
     agentParticipants: list[AgentParticipantTemplate]
@@ -1166,7 +1160,7 @@ class StaticVariableConfig(BaseModel):
     scope: Scope
     definition: VariableDefinition
     value: str
-    cohortValues: dict[str, str] | None = None
+    cohortValues: dict[constr(pattern=r"^(.*)$"), str] | None = None
 
 
 class Object(BaseModel):
@@ -1176,7 +1170,11 @@ class Object(BaseModel):
     )
     type: Literal["object"] = "object"
     properties: Annotated[
-        dict[str, String | Number | Integer | Boolean | Object | Array] | None,
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+        | None,
         Field(title="Properties"),
     ] = None
 
@@ -1188,7 +1186,7 @@ class Array(BaseModel):
     )
     type: Literal["array"] = "array"
     items: Annotated[
-        String | Number | Integer | Boolean | Object | Array | None,
+        String | Number | Integer | Boolean | Object1 | Array | None,
         Field(title="JSONSchemaDefinition"),
     ] = None
 
@@ -1204,6 +1202,10 @@ class VariableDefinition(BaseModel):
         String | Number | Integer | Boolean | Object | Array,
         Field(alias="schema", title="JSONSchemaDefinition"),
     ]
+
+
+class Object1(Object):
+    pass
 
 
 class RandomPermutationVariableConfig(BaseModel):
@@ -1359,7 +1361,7 @@ class TransferStageConfig(BaseModel):
         | SurveyAutoTransferConfig
         | ConditionAutoTransferConfig
         | None
-    ) = None
+    )
 
 
 class ConditionAutoTransferConfig(BaseModel):
@@ -1401,7 +1403,8 @@ class AgentMediatorTemplate(BaseModel):
     )
     persona: Persona
     promptMap: Annotated[
-        dict[str, ChatPromptConfig | GenericPromptConfig], Field(title="PromptMap")
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
     ]
 
 
@@ -1580,18 +1583,42 @@ class GenericPromptConfig(BaseModel):
     structuredOutputConfig: StructuredOutputConfig | None = None
 
 
-AgentParticipantTemplate = AgentMediatorTemplate
+class AgentParticipantTemplate(AgentMediatorTemplate):
+    pass
 
 
-class JSONSchemaDefinition(
-    RootModel[String | Number | Integer | Boolean | Object | Array]
+class JSONSchemaDefinitionModel(
+    RootModel[String | Number | Integer | Boolean | Object1 | Array]
 ):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[
-        String | Number | Integer | Boolean | Object | Array,
+        String | Number | Integer | Boolean | Object1 | Array,
         Field(title="JSONSchemaDefinition"),
+    ]
+
+
+class PromptMap(
+    RootModel[dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig]]
+):
+    root: Annotated[
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
+    ]
+
+
+class Properties(
+    RootModel[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+    ]
+):
+    root: Annotated[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ],
+        Field(title="Properties"),
     ]
 
 
@@ -1600,6 +1627,7 @@ ExperimentTemplate.model_rebuild()
 StaticVariableConfig.model_rebuild()
 Object.model_rebuild()
 Array.model_rebuild()
+Object1.model_rebuild()
 SurveyPerParticipantStageConfig.model_rebuild()
 TextSurveyQuestion.model_rebuild()
 ConditionGroup.model_rebuild()
@@ -1608,6 +1636,7 @@ ConditionAutoTransferConfig.model_rebuild()
 TransferGroup.model_rebuild()
 AgentMediatorTemplate.model_rebuild()
 ChatPromptConfig.model_rebuild()
+PromptItemGroup.model_rebuild()
 StructuredOutputConfig.model_rebuild()
 StructuredOutputSchema.model_rebuild()
 AgentParticipantTemplate.model_rebuild()

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -32,8 +32,10 @@ export interface ChatMessage {
   agentId: string; // agent persona used (or blank if none)
   explanation: string; // agent's explicit decision explanation from structured output
   reasoning?: string; // model's internal chain-of-thought (from thinking/reasoning features)
+  _reasoning?: string; // agent's structured-output reasoning field, auto-injected when {{_reasoning}} is in prompt
   isError: boolean; // is error message (used for private chats)
   files?: StoredFile[]; // uploaded files (images, documents, etc.)
+  isReasoningOnly?: boolean; // turn where the agent chose not to respond; retains reasoning history without showing in UI
 }
 
 // ************************************************************************* //
@@ -63,8 +65,10 @@ export function createChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
+    _reasoning: config._reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    isReasoningOnly: config.isReasoningOnly ?? undefined,
   };
 }
 
@@ -83,8 +87,10 @@ export function createParticipantChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
+    _reasoning: config._reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    isReasoningOnly: config.isReasoningOnly ?? undefined,
   };
 }
 
@@ -103,8 +109,10 @@ export function createMediatorChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
+    _reasoning: config._reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    isReasoningOnly: config.isReasoningOnly ?? undefined,
   };
 }
 
@@ -123,6 +131,7 @@ export function createExperimenterChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
+    _reasoning: config._reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
   };
@@ -143,6 +152,7 @@ export function createSystemChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
+    _reasoning: config._reasoning ?? undefined,
     isError: false,
     files: config.files ?? undefined,
   };

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -32,10 +32,10 @@ export interface ChatMessage {
   agentId: string; // agent persona used (or blank if none)
   explanation: string; // agent's explicit decision explanation from structured output
   reasoning?: string; // model's internal chain-of-thought (from thinking/reasoning features)
-  _reasoning?: string; // agent's structured-output reasoning field, auto-injected when {{_reasoning}} is in prompt
+  _scratchpad?: string; // agent's structured-output reasoning field, auto-injected when {{_scratchpad}} is in prompt
   isError: boolean; // is error message (used for private chats)
   files?: StoredFile[]; // uploaded files (images, documents, etc.)
-  isReasoningOnly?: boolean; // turn where the agent chose not to respond; retains reasoning history without showing in UI
+  isScratchpadOnly?: boolean; // turn where the agent chose not to respond; retains reasoning history without showing in UI
 }
 
 // ************************************************************************* //
@@ -65,10 +65,10 @@ export function createChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
-    _reasoning: config._reasoning ?? undefined,
+    _scratchpad: config._scratchpad ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
-    isReasoningOnly: config.isReasoningOnly ?? undefined,
+    isScratchpadOnly: config.isScratchpadOnly ?? undefined,
   };
 }
 
@@ -87,10 +87,10 @@ export function createParticipantChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
-    _reasoning: config._reasoning ?? undefined,
+    _scratchpad: config._scratchpad ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
-    isReasoningOnly: config.isReasoningOnly ?? undefined,
+    isScratchpadOnly: config.isScratchpadOnly ?? undefined,
   };
 }
 
@@ -109,10 +109,10 @@ export function createMediatorChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
-    _reasoning: config._reasoning ?? undefined,
+    _scratchpad: config._scratchpad ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
-    isReasoningOnly: config.isReasoningOnly ?? undefined,
+    isScratchpadOnly: config.isScratchpadOnly ?? undefined,
   };
 }
 
@@ -131,7 +131,7 @@ export function createExperimenterChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
-    _reasoning: config._reasoning ?? undefined,
+    _scratchpad: config._scratchpad ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
   };
@@ -152,7 +152,7 @@ export function createSystemChatMessage(
     agentId: config.agentId ?? '',
     explanation: config.explanation ?? '',
     reasoning: config.reasoning ?? undefined,
-    _reasoning: config._reasoning ?? undefined,
+    _scratchpad: config._scratchpad ?? undefined,
     isError: false,
     files: config.files ?? undefined,
   };

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -58,7 +58,7 @@ export interface ChatMediatorStructuredFields {
   message: string | null; // The message to send (null if not responding)
   explanation: string | null; // Why the mediator made this decision
   readyToEndChat: boolean; // Is the mediator ready to end the conversation?
-  _reasoning: string | null; // Auto-injected reasoning field when {{_reasoning}} is in prompt
+  _scratchpad: string | null; // Auto-injected reasoning field when {{_scratchpad}} is in prompt
 }
 
 /**
@@ -94,9 +94,9 @@ export function extractChatMediatorStructuredFields(
     ? Boolean(parsed[config.readyToEndField])
     : false;
 
-  const _reasoning =
-    typeof parsed['_reasoning'] === 'string'
-      ? (parsed['_reasoning'] as string)
+  const _scratchpad =
+    typeof parsed['_scratchpad'] === 'string'
+      ? (parsed['_scratchpad'] as string)
       : null;
 
   return {
@@ -104,35 +104,35 @@ export function extractChatMediatorStructuredFields(
     message,
     explanation,
     readyToEndChat,
-    _reasoning,
+    _scratchpad,
   };
 }
 
 /**
- * Prepend the `_reasoning` field to the structured output schema when:
+ * Prepend the `_scratchpad` field to the structured output schema when:
  * (a) the field is not already present, and
- * (b) reasoning placeholders are in use.
+ * (b) scratchpad placeholders are in use.
  */
-export function injectReasoningField<
+export function injectScratchpadField<
   T extends StructuredOutputConfig | undefined,
 >(config: T): T {
   if (!config?.schema?.properties) return config;
-  if (config.schema.properties.some((p) => p.name === '_reasoning')) {
+  if (config.schema.properties.some((p) => p.name === '_scratchpad')) {
     return config;
   }
-  const reasoningProperty = {
-    name: '_reasoning',
+  const scratchpadProperty = {
+    name: '_scratchpad',
     schema: {
       type: StructuredOutputDataType.STRING,
       description:
-        'Your private reasoning for this turn. This field is shown back to you in later turns, so you can, for example, make plans and test beliefs.',
+        'Your private scratchpad for this turn. This field is shown back to you in later turns, so you can, for example, make plans and test beliefs.',
     },
   };
   return {
     ...config,
     schema: {
       ...config.schema,
-      properties: [reasoningProperty, ...config.schema.properties],
+      properties: [scratchpadProperty, ...config.schema.properties],
     },
   };
 }

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -58,6 +58,7 @@ export interface ChatMediatorStructuredFields {
   message: string | null; // The message to send (null if not responding)
   explanation: string | null; // Why the mediator made this decision
   readyToEndChat: boolean; // Is the mediator ready to end the conversation?
+  _reasoning: string | null; // Auto-injected reasoning field when {{_reasoning}} is in prompt
 }
 
 /**
@@ -93,11 +94,46 @@ export function extractChatMediatorStructuredFields(
     ? Boolean(parsed[config.readyToEndField])
     : false;
 
+  const _reasoning =
+    typeof parsed['_reasoning'] === 'string'
+      ? (parsed['_reasoning'] as string)
+      : null;
+
   return {
     shouldRespond,
     message,
     explanation,
     readyToEndChat,
+    _reasoning,
+  };
+}
+
+/**
+ * Prepend the `_reasoning` field to the structured output schema when:
+ * (a) the field is not already present, and
+ * (b) reasoning placeholders are in use.
+ */
+export function injectReasoningField<
+  T extends StructuredOutputConfig | undefined,
+>(config: T): T {
+  if (!config?.schema?.properties) return config;
+  if (config.schema.properties.some((p) => p.name === '_reasoning')) {
+    return config;
+  }
+  const reasoningProperty = {
+    name: '_reasoning',
+    schema: {
+      type: StructuredOutputDataType.STRING,
+      description:
+        'Your private reasoning for this turn. This field is shown back to you in later turns, so you can, for example, make plans and test beliefs.',
+    },
+  };
+  return {
+    ...config,
+    schema: {
+      ...config.schema,
+      properties: [reasoningProperty, ...config.schema.properties],
+    },
   };
 }
 

--- a/utils/src/variables.template.test.ts
+++ b/utils/src/variables.template.test.ts
@@ -3,6 +3,8 @@ import {
   findUnusedVariables,
   resolveTemplateVariables,
   validateTemplateVariables,
+  formatInvalidVariable,
+  INTERNAL_VARIABLES,
 } from './variables.template';
 
 describe('Mustache Template Resolution', () => {
@@ -422,5 +424,43 @@ describe('Mustache Template Resolution', () => {
       const result = findUnusedVariables(stages, variableDefinitions);
       expect(result).toEqual(['city']);
     });
+  });
+});
+
+describe('internal variables (reserved _ prefix)', () => {
+  it('treats a known internal variable as valid', () => {
+    const result = validateTemplateVariables('Notes: {{_scratchpad}}', {});
+    expect(result.valid).toBe(true);
+    expect(result.invalidVariables).toEqual([]);
+  });
+
+  it('flags an unknown _-prefixed variable as internal, not undefined', () => {
+    const result = validateTemplateVariables('Oops {{_scratchpat}}', {});
+    expect(result.valid).toBe(false);
+    expect(result.invalidVariables).toEqual([
+      {path: '_scratchpat', reason: 'internal'},
+    ]);
+  });
+
+  it('lists the valid internal variables in the error message', () => {
+    const msg = formatInvalidVariable({
+      path: '_scratchpat',
+      reason: 'internal',
+    });
+    expect(msg).toContain('not a known internal variable');
+    for (const name of INTERNAL_VARIABLES) {
+      expect(msg).toContain(name);
+    }
+  });
+
+  it('resolves a known internal variable from the value map', () => {
+    const out = resolveTemplateVariables(
+      'Notes: {{_scratchpad}}',
+      {},
+      {
+        _scratchpad: 'my note',
+      },
+    );
+    expect(out).toBe('Notes: my note');
   });
 });

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -41,9 +41,9 @@ export function formatInvalidVariable(invalid: InvalidVariable): string {
     case 'object_needs_property':
       return `'${invalid.path}' is an object - access a property like '${invalid.path}.propertyName'`;
     case 'internal':
-      return `'${invalid.path}' is not a known internal variable (valid: ${[
+      return `'${invalid.path}' is not a known internal variable. Names that begin with '_' are reserved for internal variables (valid: ${[
         ...INTERNAL_VARIABLES,
-      ].join(', ')})`;
+      ].join(', ')}).`;
     case 'syntax':
       return invalid.path || 'Invalid template syntax';
   }

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -79,6 +79,13 @@ export function resolveTemplateVariables(
     const variable = variableDefinitions[variableName];
     const schemaType = variable?.schema?.type;
 
+    if (!variable) {
+      if (variableName === '_reasoning') {
+        typedValueMap[variableName] = valueMap[variableName] ?? '';
+      }
+      return;
+    }
+
     switch (schemaType) {
       case 'string':
         typedValueMap[variableName] = valueMap[variableName] ?? '';
@@ -203,6 +210,9 @@ function validateTokens(
     const schema = resolvePathInContextStack(value, contextStack);
 
     if (!schema) {
+      if (value === '_reasoning') {
+        continue;
+      }
       invalidVariables.set(value, {path: value, reason: 'undefined'});
     } else if (isDirectOutput && schema.type === 'object') {
       // Using {{object}} directly will render as "[object Object]"

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -13,18 +13,18 @@ import {
 Mustache.escape = (text: string) => text;
 
 /**
- * System variables: `_`-prefixed template tokens the platform provides and the
+ * Internal variables: `_`-prefixed template tokens the platform provides and the
  * experimenter can reference but cannot define. The `_` prefix is reserved for
  * these; this set is the registry the template logic consults.
  */
-export const SYSTEM_VARIABLES: ReadonlySet<string> = new Set(['_scratchpad']);
-export type SystemVariableName = '_scratchpad';
+export const INTERNAL_VARIABLES: ReadonlySet<string> = new Set(['_scratchpad']);
+export type InternalVariableName = '_scratchpad';
 
 /** Reason why a variable reference is invalid */
 export type InvalidVariableReason =
   | 'undefined'
   | 'object_needs_property'
-  | 'system'
+  | 'internal'
   | 'syntax';
 
 /** An invalid variable reference in a template */
@@ -40,9 +40,9 @@ export function formatInvalidVariable(invalid: InvalidVariable): string {
       return `'${invalid.path}' is not defined`;
     case 'object_needs_property':
       return `'${invalid.path}' is an object - access a property like '${invalid.path}.propertyName'`;
-    case 'system':
-      return `'${invalid.path}' is not a known system variable (valid: ${[
-        ...SYSTEM_VARIABLES,
+    case 'internal':
+      return `'${invalid.path}' is not a known internal variable (valid: ${[
+        ...INTERNAL_VARIABLES,
       ].join(', ')})`;
     case 'syntax':
       return invalid.path || 'Invalid template syntax';
@@ -93,7 +93,7 @@ export function resolveTemplateVariables(
     const schemaType = variable?.schema?.type;
 
     if (!variable) {
-      if (SYSTEM_VARIABLES.has(variableName)) {
+      if (INTERNAL_VARIABLES.has(variableName)) {
         typedValueMap[variableName] = valueMap[variableName] ?? '';
       }
       return;
@@ -223,11 +223,11 @@ function validateTokens(
     const schema = resolvePathInContextStack(value, contextStack);
 
     if (!schema) {
-      if (SYSTEM_VARIABLES.has(value)) {
+      if (INTERNAL_VARIABLES.has(value)) {
         continue;
       }
       if (value.startsWith('_')) {
-        invalidVariables.set(value, {path: value, reason: 'system'});
+        invalidVariables.set(value, {path: value, reason: 'internal'});
         continue;
       }
       invalidVariables.set(value, {path: value, reason: 'undefined'});

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -80,7 +80,7 @@ export function resolveTemplateVariables(
     const schemaType = variable?.schema?.type;
 
     if (!variable) {
-      if (variableName === '_reasoning') {
+      if (variableName === '_scratchpad') {
         typedValueMap[variableName] = valueMap[variableName] ?? '';
       }
       return;
@@ -210,7 +210,7 @@ function validateTokens(
     const schema = resolvePathInContextStack(value, contextStack);
 
     if (!schema) {
-      if (value === '_reasoning') {
+      if (value === '_scratchpad') {
         continue;
       }
       invalidVariables.set(value, {path: value, reason: 'undefined'});

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -12,10 +12,19 @@ import {
 // Disable HTML escaping (prevents quotes from being rendered as `&quot;`)
 Mustache.escape = (text: string) => text;
 
+/**
+ * System variables: `_`-prefixed template tokens the platform provides and the
+ * experimenter can reference but cannot define. The `_` prefix is reserved for
+ * these; this set is the registry the template logic consults.
+ */
+export const SYSTEM_VARIABLES: ReadonlySet<string> = new Set(['_scratchpad']);
+export type SystemVariableName = '_scratchpad';
+
 /** Reason why a variable reference is invalid */
 export type InvalidVariableReason =
   | 'undefined'
   | 'object_needs_property'
+  | 'system'
   | 'syntax';
 
 /** An invalid variable reference in a template */
@@ -31,6 +40,10 @@ export function formatInvalidVariable(invalid: InvalidVariable): string {
       return `'${invalid.path}' is not defined`;
     case 'object_needs_property':
       return `'${invalid.path}' is an object - access a property like '${invalid.path}.propertyName'`;
+    case 'system':
+      return `'${invalid.path}' is not a known system variable (valid: ${[
+        ...SYSTEM_VARIABLES,
+      ].join(', ')})`;
     case 'syntax':
       return invalid.path || 'Invalid template syntax';
   }
@@ -80,7 +93,7 @@ export function resolveTemplateVariables(
     const schemaType = variable?.schema?.type;
 
     if (!variable) {
-      if (variableName === '_scratchpad') {
+      if (SYSTEM_VARIABLES.has(variableName)) {
         typedValueMap[variableName] = valueMap[variableName] ?? '';
       }
       return;
@@ -210,7 +223,11 @@ function validateTokens(
     const schema = resolvePathInContextStack(value, contextStack);
 
     if (!schema) {
-      if (value === '_scratchpad') {
+      if (SYSTEM_VARIABLES.has(value)) {
+        continue;
+      }
+      if (value.startsWith('_')) {
+        invalidVariables.set(value, {path: value, reason: 'system'});
         continue;
       }
       invalidVariables.set(value, {path: value, reason: 'undefined'});

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -19,9 +19,19 @@ Mustache.escape = (text: string) => text;
  */
 export const INTERNAL_VARIABLES: ReadonlySet<string> = new Set([
   '_scratchpad',
+  '_profileName',
+  '_profileAvatar',
+  '_profilePronouns',
+  '_profileId',
   '_turnCycleStatus',
 ]);
-export type InternalVariableName = '_scratchpad' | '_turnCycleStatus';
+export type InternalVariableName =
+  | '_scratchpad'
+  | '_profileName'
+  | '_profileAvatar'
+  | '_profilePronouns'
+  | '_profileId'
+  | '_turnCycleStatus';
 
 /** Reason why a variable reference is invalid */
 export type InvalidVariableReason =

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -17,8 +17,11 @@ Mustache.escape = (text: string) => text;
  * experimenter can reference but cannot define. The `_` prefix is reserved for
  * these; this set is the registry the template logic consults.
  */
-export const INTERNAL_VARIABLES: ReadonlySet<string> = new Set(['_scratchpad']);
-export type InternalVariableName = '_scratchpad';
+export const INTERNAL_VARIABLES: ReadonlySet<string> = new Set([
+  '_scratchpad',
+  '_turnCycleStatus',
+]);
+export type InternalVariableName = '_scratchpad' | '_turnCycleStatus';
 
 /** Reason why a variable reference is invalid */
 export type InvalidVariableReason =


### PR DESCRIPTION
# Description
Adds multi-turn private reasoning for AI agents. When the experimenter includes `{{_reasoning}}` in an agent's prompt, the system adds an output field `_reasoning` to that agent's API queries. The agent is prompted to use the field for private reasoning. This allows the agent to make multi-turn plans without including them in their message.

For example, an agent could ask a participant, "Are apples your favorite food?" with the 'intention' of accounting for that information in a follow-up offer of apple pie for a lower price (if not favorite) or higher price (if favorite).

This feature does not affect functionality if the magic ``{{_reasoning}}`` placeholder is not used.

These reasoning traces are available in the database for future use. An explicit `_reasoning` field is used because not all models make their implicit reasoning traces available.

# Example
Example agent mediator prompt written by experimenter:

```
Your task is to mediate the conversation. {{_reasoning}}
```

Example prompt received by the model in the third round of a chat:

```
Your task is to mediate the conversation. Each line shows your reasoning for your messages sent in this conversation, in order:

#1
I will send the user a polite greeting. Then, before offering them the apple pie, I will ask if apples are their favorite food, so I can change my price accordingly.

#2
I will ask the user if apples are their favorite food, so I can change my price accordingly.
```

