### PR TITLE
feat: allow conditional survey items to reference participant variables

### DIFF
--- a/frontend/src/components/experiment_builder/structured_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/structured_prompt_editor.ts
@@ -50,7 +50,11 @@ export class EditorComponent extends MobxLitElement {
     return getConditionTargetsFromStages(
       this.experimentEditor.stages,
       this.stageId,
-      {includeCurrentStage: true},
+      {
+        includeCurrentStage: true,
+        variableConfigs:
+          this.experimentEditor.experiment?.variableConfigs ?? [],
+      },
     );
   }
 

--- a/frontend/src/components/participant_view/participant_header.ts
+++ b/frontend/src/components/participant_view/participant_header.ts
@@ -12,6 +12,7 @@ import {customElement, property, state} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
 import {CohortService} from '../../services/cohort.service';
+import {ExperimentService} from '../../services/experiment.service';
 import {ParticipantService} from '../../services/participant.service';
 
 import {
@@ -21,7 +22,10 @@ import {
   StageConfig,
   StageKind,
 } from '@deliberation-lab/utils';
-import {getChatTimeRemainingInSeconds} from '../../shared/stage.utils';
+import {
+  getChatTimeRemainingInSeconds,
+  resolveStageName,
+} from '../../shared/stage.utils';
 import {styles} from './participant_header.scss';
 
 /** Header component for participant preview */
@@ -31,6 +35,7 @@ export class Header extends MobxLitElement {
 
   private readonly participantService = core.getService(ParticipantService);
   private readonly cohortService = core.getService(CohortService);
+  private readonly experimentService = core.getService(ExperimentService);
 
   @property() stage: StageConfig | undefined = undefined;
   @property() profile: ParticipantProfile | undefined = undefined;
@@ -93,10 +98,18 @@ export class Header extends MobxLitElement {
       return nothing;
     }
 
+    const stageName = resolveStageName(
+      this.stage.name,
+      this.experimentService.experiment?.variableConfigs ?? [],
+      this.experimentService.experiment?.variableMap ?? {},
+      this.cohortService.cohortConfig?.variableMap ?? {},
+      this.participantService.profile?.variableMap ?? {},
+    );
+
     return html`
       <div class="header">
         <div class="left">
-          ${this.renderMenu()} ${this.stage.name}${this.renderInfo()}
+          ${this.renderMenu()} ${stageName}${this.renderInfo()}
           ${this.renderTimer()}
         </div>
         <div class="right">

--- a/frontend/src/components/participant_view/participant_nav.ts
+++ b/frontend/src/components/participant_view/participant_nav.ts
@@ -9,10 +9,12 @@ import {classMap} from 'lit/directives/class-map.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
+import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
 import {HomeService} from '../../services/home.service';
 import {ParticipantService} from '../../services/participant.service';
 import {StageConfig} from '@deliberation-lab/utils';
+import {resolveStageName} from '../../shared/stage.utils';
 
 import {styles} from './participant_nav.scss';
 
@@ -22,6 +24,7 @@ export class ParticipantNav extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly authService = core.getService(AuthService);
+  private readonly cohortService = core.getService(CohortService);
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
@@ -67,7 +70,16 @@ export class ParticipantNav extends MobxLitElement {
     return html`
       <div class="nav-item-wrapper">
         <div class=${navItemClasses} role="button" @click=${navigate}>
-          <div>${index + 1}. ${stage.name}</div>
+          <div>
+            ${index + 1}.
+            ${resolveStageName(
+              stage.name,
+              this.experimentService.experiment?.variableConfigs ?? [],
+              this.experimentService.experiment?.variableMap ?? {},
+              this.cohortService.cohortConfig?.variableMap ?? {},
+              this.participantService.profile?.variableMap ?? {},
+            )}
+          </div>
           ${this.participantService.isCurrentStage(stage.id)
             ? html`<div class="chip tertiary">current</div>`
             : nothing}

--- a/frontend/src/components/stages/condition_editor.ts
+++ b/frontend/src/components/stages/condition_editor.ts
@@ -81,7 +81,7 @@ export class ConditionEditor extends MobxLitElement {
                 </div>
               `
             : group.conditions.map(
-                (c, index) => html`
+                (c: Condition, index: number) => html`
                   ${index > 0
                     ? html`
                         <div class="operator-connector">
@@ -166,15 +166,20 @@ export class ConditionEditor extends MobxLitElement {
 
   private renderComparisonCondition(condition: ComparisonCondition) {
     const conditionKey = this.getTargetKey(condition.target);
+
     const target = this.targets.find(
       (t) => this.getTargetKey(t.ref) === conditionKey,
     );
+
+    const matchedTargetKey = target
+      ? this.getTargetKey(target.ref)
+      : conditionKey;
 
     return html`
       <div class="comparison-condition">
         <md-outlined-select
           class="target-select"
-          .value=${conditionKey}
+          .value=${matchedTargetKey}
           @change=${(e: Event) =>
             this.updateComparisonTarget(
               condition,

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -217,7 +217,12 @@ export class SurveyEditor extends MobxLitElement {
     const targets = getConditionTargetsFromStages(
       this.experimentEditor.stages,
       this.stage.id,
-      {includeCurrentStage: true, currentStageQuestionIndex: index},
+      {
+        includeCurrentStage: true,
+        currentStageQuestionIndex: index,
+        variableConfigs:
+          this.experimentEditor.experiment?.variableConfigs ?? [],
+      },
     );
 
     return renderConditionEditor({

--- a/frontend/src/components/stages/survey_per_participant_view.ts
+++ b/frontend/src/components/stages/survey_per_participant_view.ts
@@ -116,6 +116,7 @@ export class SurveyView extends MobxLitElement {
           answerMap,
           allStageAnswers,
           participant.publicId,
+          participant.variableMap,
         );
 
         if (!isSurveyComplete(visibleQuestions, answerMap)) {
@@ -215,6 +216,7 @@ export class SurveyView extends MobxLitElement {
       currentAnswers,
       allStageAnswers,
       participant.publicId, // Pass which participant is being evaluated
+      participant.variableMap,
     );
   }
 

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -72,6 +72,8 @@ export class SurveyView extends MobxLitElement {
         this.stage.id,
         currentSurveyAnswers,
         allStageAnswers,
+        undefined,
+        this.participantService.profile?.variableMap,
       );
 
       return isSurveyComplete(visibleQuestions, currentSurveyAnswers);
@@ -118,6 +120,8 @@ export class SurveyView extends MobxLitElement {
       this.stage.id,
       currentSurveyAnswers,
       allStageAnswers,
+      undefined,
+      this.participantService.profile?.variableMap,
     );
   }
 

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -14,6 +14,7 @@ import {
   ProlificConfig,
   StageConfig,
   StageKind,
+  SYSTEM_VARIABLE_NAMESPACE,
   VariableConfig,
   MultiValueVariableConfigType,
   requiresValues,
@@ -186,6 +187,13 @@ export class ExperimentEditor extends Service {
     renderApiErrorMessage(ApiKeyType.OLLAMA_CUSTOM_URL);
 
     for (const stage of this.stages) {
+      // Block save if any stage's id collides with the participant-variable
+      // sentinel, since condition-dependency fetching would silently skip it.
+      if (stage.id === SYSTEM_VARIABLE_NAMESPACE) {
+        errors.push(
+          `The stage id "${SYSTEM_VARIABLE_NAMESPACE}" is reserved for tracking the system variables. Please rename it.`,
+        );
+      }
       if (
         stage.kind === StageKind.SURVEY ||
         stage.kind === StageKind.SURVEY_PER_PARTICIPANT

--- a/frontend/src/shared/stage.utils.ts
+++ b/frontend/src/shared/stage.utils.ts
@@ -1,5 +1,35 @@
-import {ChatMessage, UnifiedTimestamp} from '@deliberation-lab/utils';
+import {
+  ChatMessage,
+  UnifiedTimestamp,
+  VariableConfig,
+  extractVariablesFromVariableConfigs,
+  resolveTemplateVariables,
+} from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase/firestore';
+
+/**
+ * Resolve template variables in a stage name for the current participant.
+ * Merges experiment-, cohort-, and participant-scoped value maps (participant
+ * takes precedence). Missing variables resolve to an empty string, matching
+ * prompt/description behavior.
+ */
+export function resolveStageName(
+  name: string,
+  variableConfigs: VariableConfig[],
+  experimentVariableMap: Record<string, string> = {},
+  cohortVariableMap: Record<string, string> = {},
+  participantVariableMap: Record<string, string> = {},
+): string {
+  return resolveTemplateVariables(
+    name,
+    extractVariablesFromVariableConfigs(variableConfigs),
+    {
+      ...experimentVariableMap,
+      ...cohortVariableMap,
+      ...participantVariableMap,
+    },
+  );
+}
 
 /** Returns the timestamp of the first chat message, or null if none. */
 export function getChatStartTimestamp(

--- a/functions/src/structured_prompt.utils.test.ts
+++ b/functions/src/structured_prompt.utils.test.ts
@@ -4,8 +4,15 @@ import {
   MediatorProfileExtended,
   BasePromptConfig,
   PromptItemType,
+  StageKind,
+  ComparisonOperator,
+  ComparisonCondition,
+  SYSTEM_VARIABLE_NAMESPACE,
 } from '@deliberation-lab/utils';
-import {getFirestoreDataForStructuredPrompt} from './structured_prompt.utils';
+import {
+  getFirestoreDataForStructuredPrompt,
+  shouldIncludePromptItem,
+} from './structured_prompt.utils';
 import * as firestoreUtils from './utils/firestore';
 
 // Mock firestore utilities
@@ -249,6 +256,72 @@ describe('structured_prompt.utils', () => {
 
       // Should fall back to default mediator behavior (all participants)
       expect(result.participants).toHaveLength(2);
+    });
+  });
+  describe('shouldIncludePromptItem (participant-variable conditions)', () => {
+    const variableCondition = (value: string): ComparisonCondition => ({
+      id: 'c1',
+      type: 'comparison',
+      target: {stageId: SYSTEM_VARIABLE_NAMESPACE, questionId: 'treatment'},
+      operator: ComparisonOperator.EQUALS,
+      value,
+    });
+    const participant = (treatment: string): ParticipantProfileExtended =>
+      ({
+        publicId: 'participant-public-1',
+        variableMap: {treatment},
+      }) as unknown as ParticipantProfileExtended;
+
+    it('includes a private-chat item when the participant variable matches', () => {
+      const item = {
+        type: PromptItemType.TEXT,
+        text: 'x',
+        condition: variableCondition('A'),
+      };
+      expect(
+        shouldIncludePromptItem(
+          item,
+          StageKind.PRIVATE_CHAT,
+          [participant('A')],
+          {},
+        ),
+      ).toBe(true);
+    });
+
+    it('excludes a private-chat item when the participant variable does not match', () => {
+      const item = {
+        type: PromptItemType.TEXT,
+        text: 'x',
+        condition: variableCondition('A'),
+      };
+      expect(
+        shouldIncludePromptItem(
+          item,
+          StageKind.PRIVATE_CHAT,
+          [participant('B')],
+          {},
+        ),
+      ).toBe(false);
+    });
+
+    it('includes items with no condition, and does not filter outside private chat', () => {
+      const noCond = {type: PromptItemType.TEXT, text: 'x'};
+      expect(
+        shouldIncludePromptItem(
+          noCond,
+          StageKind.PRIVATE_CHAT,
+          [participant('A')],
+          {},
+        ),
+      ).toBe(true);
+      const item = {
+        type: PromptItemType.TEXT,
+        text: 'x',
+        condition: variableCondition('A'),
+      };
+      expect(
+        shouldIncludePromptItem(item, StageKind.CHAT, [participant('B')], {}),
+      ).toBe(true);
     });
   });
 });

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -505,7 +505,7 @@ function buildStageAnswersForParticipant(
  * Returns true if the condition is met (or if there's no condition).
  * Only works for private chat contexts with a single participant.
  */
-function shouldIncludePromptItem(
+export function shouldIncludePromptItem(
   promptItem: PromptItem,
   stageKind: StageKind,
   participants: ParticipantProfileExtended[],

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_PROMPT_INSTRUCTIONS,
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
+  SYSTEM_VARIABLE_NAMESPACE,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -452,7 +453,9 @@ async function fetchConditionDependencies(
   data: Record<string, StageContextData>,
 ): Promise<void> {
   const dependencies = extractConditionDependencies(condition);
-  const requiredStageIds = [...new Set(dependencies.map((dep) => dep.stageId))];
+  const requiredStageIds = [
+    ...new Set(dependencies.map((dep) => dep.stageId)),
+  ].filter((id) => id !== SYSTEM_VARIABLE_NAMESPACE);
 
   // Find stages not already in data
   const missingStageIds = requiredStageIds.filter((stageId) => !data[stageId]);
@@ -519,7 +522,12 @@ function shouldIncludePromptItem(
     stageContextData,
     participants[0].publicId,
   );
-  return evaluateConditionWithStageAnswers(promptItem.condition, stageAnswers);
+  return evaluateConditionWithStageAnswers(
+    promptItem.condition,
+    stageAnswers,
+    undefined,
+    participants[0].variableMap,
+  );
 }
 
 /**

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel, constr
 
 
 class CollectionName(StrEnum):
@@ -117,9 +117,6 @@ class ShuffleConfig(BaseModel):
 
 
 class Weight(RootModel[float]):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[float, Field(ge=1.0)]
 
 
@@ -342,8 +339,10 @@ class SurveyPayoutItem(BaseModel):
     isActive: bool
     stageId: str
     baseCurrencyAmount: float
-    rankingStageId: str | None = None
-    questionMap: Annotated[dict[str, float | None], Field(title="QuestionMap")]
+    rankingStageId: str | None
+    questionMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), float | None], Field(title="QuestionMap")
+    ]
 
 
 class PrivateChatStageConfig(BaseModel):
@@ -391,7 +390,8 @@ class Strategy(StrEnum):
     condorcet = "condorcet"
 
 
-RankingItem = MultipleChoiceItem
+class RankingItem(MultipleChoiceItem):
+    pass
 
 
 class ParticipantRankingStageConfig(BaseModel):
@@ -471,7 +471,7 @@ class Role(BaseModel):
     name: str
     displayLines: list[str]
     minParticipants: int
-    maxParticipants: int | None = None
+    maxParticipants: int | None
 
 
 class RoleStageConfig(BaseModel):
@@ -558,8 +558,8 @@ class StockInfoStageConfig(BaseModel):
     useQuarterlyMarkers: bool
     showInvestmentGrowth: bool
     useSharedYAxis: bool
-    initialInvestment: Annotated[float | None, Field(ge=1.0)] = 1000
-    currency: str | None = "USD"
+    initialInvestment: Annotated[float, Field(ge=1.0)] = 1000
+    currency: str = "USD"
     introText: str | None = None
 
 
@@ -627,7 +627,9 @@ class SurveyAutoTransferConfig(BaseModel):
     autoCohortParticipantConfig: CohortParticipantConfig
     surveyStageId: Annotated[str, Field(min_length=1)]
     surveyQuestionId: Annotated[str, Field(min_length=1)]
-    participantCounts: Annotated[dict[str, int], Field(title="ParticipantCounts")]
+    participantCounts: Annotated[
+        dict[constr(pattern=r"^(.*)$"), int], Field(title="ParticipantCounts")
+    ]
 
 
 class ApiKeyType(StrEnum):
@@ -1039,18 +1041,6 @@ class ChatStageConfig(BaseModel):
     enableReactionsAndReplies: bool | None = None
 
 
-class RankingStageConfig(
-    RootModel[ItemRankingStageConfig | ParticipantRankingStageConfig]
-):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    root: Annotated[
-        ItemRankingStageConfig | ParticipantRankingStageConfig,
-        Field(title="RankingStageConfig"),
-    ]
-
-
 class ProviderOptionsMap(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1093,7 +1083,9 @@ class Experiment(BaseModel):
     defaultCohortConfig: CohortParticipantConfig
     prolificConfig: Annotated[ProlificConfig, Field(title="ProlificConfig")]
     stageIds: list[str]
-    cohortLockMap: Annotated[dict[str, bool], Field(title="CohortLockMap")]
+    cohortLockMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), bool], Field(title="CohortLockMap")
+    ]
     variableConfigs: (
         list[
             StaticVariableConfig
@@ -1102,7 +1094,9 @@ class Experiment(BaseModel):
         ]
         | None
     ) = None
-    variableMap: Annotated[dict[str, str] | None, Field(title="VariableMap")] = None
+    variableMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), str] | None, Field(title="VariableMap")
+    ] = None
     cohortDefinitions: list[CohortDefinition] | None = None
 
 
@@ -1124,8 +1118,6 @@ class ExperimentTemplate(BaseModel):
         | PayoutStageConfig
         | PrivateChatStageConfig
         | ProfileStageConfig
-        | ItemRankingStageConfig
-        | ParticipantRankingStageConfig
         | RevealStageConfig
         | RoleStageConfig
         | NegotiationProfileStageConfig
@@ -1136,6 +1128,8 @@ class ExperimentTemplate(BaseModel):
         | SurveyStageConfig
         | TOSStageConfig
         | TransferStageConfig
+        | ItemRankingStageConfig
+        | ParticipantRankingStageConfig
     ]
     agentMediators: list[AgentMediatorTemplate]
     agentParticipants: list[AgentParticipantTemplate]
@@ -1166,7 +1160,7 @@ class StaticVariableConfig(BaseModel):
     scope: Scope
     definition: VariableDefinition
     value: str
-    cohortValues: dict[str, str] | None = None
+    cohortValues: dict[constr(pattern=r"^(.*)$"), str] | None = None
 
 
 class Object(BaseModel):
@@ -1176,7 +1170,11 @@ class Object(BaseModel):
     )
     type: Literal["object"] = "object"
     properties: Annotated[
-        dict[str, String | Number | Integer | Boolean | Object | Array] | None,
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+        | None,
         Field(title="Properties"),
     ] = None
 
@@ -1188,7 +1186,7 @@ class Array(BaseModel):
     )
     type: Literal["array"] = "array"
     items: Annotated[
-        String | Number | Integer | Boolean | Object | Array | None,
+        String | Number | Integer | Boolean | Object1 | Array | None,
         Field(title="JSONSchemaDefinition"),
     ] = None
 
@@ -1204,6 +1202,10 @@ class VariableDefinition(BaseModel):
         String | Number | Integer | Boolean | Object | Array,
         Field(alias="schema", title="JSONSchemaDefinition"),
     ]
+
+
+class Object1(Object):
+    pass
 
 
 class RandomPermutationVariableConfig(BaseModel):
@@ -1359,7 +1361,7 @@ class TransferStageConfig(BaseModel):
         | SurveyAutoTransferConfig
         | ConditionAutoTransferConfig
         | None
-    ) = None
+    )
 
 
 class ConditionAutoTransferConfig(BaseModel):
@@ -1401,7 +1403,8 @@ class AgentMediatorTemplate(BaseModel):
     )
     persona: Persona
     promptMap: Annotated[
-        dict[str, ChatPromptConfig | GenericPromptConfig], Field(title="PromptMap")
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
     ]
 
 
@@ -1580,18 +1583,42 @@ class GenericPromptConfig(BaseModel):
     structuredOutputConfig: StructuredOutputConfig | None = None
 
 
-AgentParticipantTemplate = AgentMediatorTemplate
+class AgentParticipantTemplate(AgentMediatorTemplate):
+    pass
 
 
-class JSONSchemaDefinition(
-    RootModel[String | Number | Integer | Boolean | Object | Array]
+class JSONSchemaDefinitionModel(
+    RootModel[String | Number | Integer | Boolean | Object1 | Array]
 ):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[
-        String | Number | Integer | Boolean | Object | Array,
+        String | Number | Integer | Boolean | Object1 | Array,
         Field(title="JSONSchemaDefinition"),
+    ]
+
+
+class PromptMap(
+    RootModel[dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig]]
+):
+    root: Annotated[
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
+    ]
+
+
+class Properties(
+    RootModel[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+    ]
+):
+    root: Annotated[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ],
+        Field(title="Properties"),
     ]
 
 
@@ -1600,6 +1627,7 @@ ExperimentTemplate.model_rebuild()
 StaticVariableConfig.model_rebuild()
 Object.model_rebuild()
 Array.model_rebuild()
+Object1.model_rebuild()
 SurveyPerParticipantStageConfig.model_rebuild()
 TextSurveyQuestion.model_rebuild()
 ConditionGroup.model_rebuild()
@@ -1608,6 +1636,7 @@ ConditionAutoTransferConfig.model_rebuild()
 TransferGroup.model_rebuild()
 AgentMediatorTemplate.model_rebuild()
 ChatPromptConfig.model_rebuild()
+PromptItemGroup.model_rebuild()
 StructuredOutputConfig.model_rebuild()
 StructuredOutputSchema.model_rebuild()
 AgentParticipantTemplate.model_rebuild()

--- a/utils/src/stages/stage.handler.ts
+++ b/utils/src/stages/stage.handler.ts
@@ -24,7 +24,12 @@ export class BaseStageHandler {
     variableDefinitions: Record<string, VariableDefinition>,
     valueMap: Record<string, string>,
   ) {
-    // By default, resolve variables in stage descriptions
+    // By default, resolve variables in the stage name and descriptions
+    const name = resolveTemplateVariables(
+      stage.name,
+      variableDefinitions,
+      valueMap,
+    );
     const primaryText = resolveTemplateVariables(
       stage.descriptions.primaryText,
       variableDefinitions,
@@ -36,7 +41,7 @@ export class BaseStageHandler {
       valueMap,
     );
     const descriptions = {...stage.descriptions, primaryText, infoText};
-    return {...stage, descriptions};
+    return {...stage, name, descriptions};
   }
 
   getAgentParticipantActionsForStage(

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -327,6 +327,7 @@ export function getVisibleSurveyQuestions(
   currentStageAnswers: Record<string, SurveyAnswer>,
   allStageAnswers?: Record<string, StageParticipantAnswer>, // Map of stageId to answer data
   targetParticipantId?: string, // For survey-per-participant: which participant is being evaluated
+  variableMap?: Record<string, string>,
 ): SurveyQuestion[] {
   // Extract all dependencies from all question conditions
   const allDependencies = extractMultipleConditionDependencies(
@@ -340,6 +341,7 @@ export function getVisibleSurveyQuestions(
     currentStageAnswers,
     allStageAnswers,
     targetParticipantId,
+    variableMap,
   );
 
   return questions.filter((question) => {
@@ -357,6 +359,7 @@ export function isQuestionVisible(
   currentStageAnswers: Record<string, SurveyAnswer>,
   allStageAnswers?: Record<string, StageParticipantAnswer>,
   targetParticipantId?: string, // For survey-per-participant: which participant is being evaluated
+  variableMap?: Record<string, string>,
 ): boolean {
   if (!question.condition) {
     return true; // No condition means always show
@@ -372,6 +375,7 @@ export function isQuestionVisible(
     currentStageAnswers,
     allStageAnswers,
     targetParticipantId,
+    variableMap,
   );
 
   return evaluateCondition(question.condition, targetValues);

--- a/utils/src/utils/condition.utils.test.ts
+++ b/utils/src/utils/condition.utils.test.ts
@@ -11,6 +11,7 @@ import {
   ComparisonCondition,
   ConditionGroup,
   ConditionTargetReference,
+  SYSTEM_VARIABLE_NAMESPACE,
 } from './condition';
 import {StageKind, StageParticipantAnswer} from '../stages/stage';
 import {
@@ -770,6 +771,71 @@ describe('condition.utils', () => {
 
       const result = filterByCondition(items, stageAnswers);
       expect(result.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd']);
+    });
+  });
+  describe('participant variables (SYSTEM_VARIABLE_NAMESPACE)', () => {
+    const ns = SYSTEM_VARIABLE_NAMESPACE;
+
+    test('resolves a participant variable value directly', () => {
+      const dependencies: ConditionTargetReference[] = [
+        {stageId: ns, questionId: 'treatment'},
+      ];
+      const result = getConditionDependencyValues(dependencies, {}, undefined, {
+        treatment: 'A',
+      });
+      expect(result).toEqual({[`${ns}::treatment`]: 'A'});
+    });
+
+    test('resolves a nested value from a JSON variable via dot path', () => {
+      const variableMap = {
+        treatment: JSON.stringify({displayName: 'Group A', _isObserver: true}),
+      };
+      const dependencies: ConditionTargetReference[] = [
+        {stageId: ns, questionId: 'treatment.displayName'},
+        {stageId: ns, questionId: 'treatment._isObserver'},
+      ];
+      const result = getConditionDependencyValues(
+        dependencies,
+        {},
+        undefined,
+        variableMap,
+      );
+      expect(result).toEqual({
+        [`${ns}::treatment.displayName`]: 'Group A',
+        [`${ns}::treatment._isObserver`]: true,
+      });
+    });
+
+    test('omits unknown participant variables and a missing variableMap', () => {
+      const dependencies: ConditionTargetReference[] = [
+        {stageId: ns, questionId: 'missing'},
+      ];
+      expect(
+        getConditionDependencyValues(dependencies, {}, undefined, {
+          treatment: 'A',
+        }),
+      ).toEqual({});
+      expect(getConditionDependencyValues(dependencies, {})).toEqual({});
+    });
+
+    test('evaluates a comparison against a participant variable', () => {
+      const condition: ComparisonCondition = {
+        id: '1',
+        type: 'comparison',
+        target: {stageId: ns, questionId: 'treatment'},
+        operator: ComparisonOperator.EQUALS,
+        value: 'A',
+      };
+      expect(
+        evaluateConditionWithStageAnswers(condition, {}, undefined, {
+          treatment: 'A',
+        }),
+      ).toBe(true);
+      expect(
+        evaluateConditionWithStageAnswers(condition, {}, undefined, {
+          treatment: 'B',
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/utils/src/utils/condition.utils.ts
+++ b/utils/src/utils/condition.utils.ts
@@ -13,8 +13,12 @@ import {
   extractConditionDependencies,
   evaluateCondition,
   Condition,
+  SYSTEM_VARIABLE_NAMESPACE,
 } from './condition';
+import type {TSchema} from '@sinclair/typebox';
 import {StageKind, StageConfig, StageParticipantAnswer} from '../stages/stage';
+import {VariableConfig, VariableConfigType} from '../variables';
+import {getItemSchemaIfArray} from '../variables.utils';
 import {
   SurveyStageConfig,
   SurveyPerParticipantStageConfig,
@@ -26,6 +30,37 @@ import {
   MultipleChoiceSurveyQuestion,
   extractAnswerValue,
 } from '../stages/survey_stage';
+
+/** Resolve a participant-variable target with one-level JSON-object flatten, matching upstream's buildTargetValuesForParticipant. */
+function resolveSystemVariableValue(
+  variableMap: Record<string, string> | undefined,
+  questionId: string,
+): unknown {
+  if (!variableMap) return undefined;
+  if (questionId in variableMap) {
+    return variableMap[questionId];
+  }
+
+  const parts = questionId.split('.');
+  const varName = parts[0];
+  const raw = variableMap[varName];
+  if (raw === undefined) return undefined;
+
+  try {
+    let parsed = JSON.parse(raw);
+    for (let i = 1; i < parts.length; i++) {
+      if (parsed && typeof parsed === 'object') {
+        parsed = (parsed as Record<string, unknown>)[parts[i]];
+      } else {
+        return undefined;
+      }
+    }
+    return parsed;
+  } catch {
+    // Not JSON-parseable, so fall through.
+  }
+  return undefined;
+}
 
 /**
  * Get condition dependency values from a map of stage answers.
@@ -42,11 +77,21 @@ export function getConditionDependencyValues(
   dependencies: ConditionTargetReference[],
   stageAnswers: Record<string, StageParticipantAnswer>,
   targetParticipantId?: string,
+  variableMap?: Record<string, string>,
 ): Record<string, unknown> {
   const values: Record<string, unknown> = {};
 
   for (const targetRef of dependencies) {
     const dataKey = getConditionTargetKey(targetRef);
+
+    if (targetRef.stageId === SYSTEM_VARIABLE_NAMESPACE) {
+      const val = resolveSystemVariableValue(variableMap, targetRef.questionId);
+      if (val !== undefined) {
+        values[dataKey] = val;
+      }
+      continue;
+    }
+
     const stageAnswer = stageAnswers[targetRef.stageId];
 
     if (!stageAnswer || !('answerMap' in stageAnswer)) {
@@ -95,11 +140,20 @@ export function getConditionDependencyValuesWithCurrentStage(
   currentStageAnswers: Record<string, SurveyAnswer>,
   allStageAnswers?: Record<string, StageParticipantAnswer>,
   targetParticipantId?: string,
+  variableMap?: Record<string, string>,
 ): Record<string, unknown> {
   const values: Record<string, unknown> = {};
 
   for (const targetRef of dependencies) {
     const dataKey = getConditionTargetKey(targetRef);
+
+    if (targetRef.stageId === SYSTEM_VARIABLE_NAMESPACE) {
+      const val = resolveSystemVariableValue(variableMap, targetRef.questionId);
+      if (val !== undefined) {
+        values[dataKey] = val;
+      }
+      continue;
+    }
 
     if (targetRef.stageId === currentStageId) {
       // Reference to current stage - use local answers
@@ -113,6 +167,7 @@ export function getConditionDependencyValuesWithCurrentStage(
         [targetRef],
         allStageAnswers,
         targetParticipantId,
+        variableMap,
       );
       Object.assign(values, stageValues);
     }
@@ -136,6 +191,7 @@ export function evaluateConditionWithStageAnswers(
   condition: Condition | undefined,
   stageAnswers: Record<string, StageParticipantAnswer>,
   targetParticipantId?: string,
+  variableMap?: Record<string, string>,
 ): boolean {
   if (!condition) return true;
 
@@ -144,6 +200,7 @@ export function evaluateConditionWithStageAnswers(
     dependencies,
     stageAnswers,
     targetParticipantId,
+    variableMap,
   );
 
   return evaluateCondition(condition, targetValues);
@@ -163,6 +220,7 @@ export function filterByCondition<T extends {condition?: Condition}>(
   items: T[],
   stageAnswers: Record<string, StageParticipantAnswer>,
   targetParticipantId?: string,
+  variableMap?: Record<string, string>,
 ): T[] {
   // Extract all dependencies upfront for efficiency
   const allConditions = items
@@ -178,6 +236,7 @@ export function filterByCondition<T extends {condition?: Condition}>(
     allDependencies,
     stageAnswers,
     targetParticipantId,
+    variableMap,
   );
 
   return items.filter((item) => {
@@ -265,9 +324,14 @@ export function getConditionTargetsFromStages(
   options: {
     includeCurrentStage?: boolean;
     currentStageQuestionIndex?: number;
+    variableConfigs?: VariableConfig[];
   } = {},
 ): ConditionTarget[] {
-  const {includeCurrentStage = true, currentStageQuestionIndex} = options;
+  const {
+    includeCurrentStage = true,
+    currentStageQuestionIndex,
+    variableConfigs = [],
+  } = options;
 
   const currentStageIndex = stages.findIndex(
     (stage) => stage.id === currentStageId,
@@ -307,6 +371,86 @@ export function getConditionTargetsFromStages(
         stage.name,
       );
       targets.push(...stageTargets);
+    }
+  }
+
+  // Helper to extract nested paths from TypeBox schema
+  const extractVariableTargets = (
+    schema: TSchema,
+    variableName: string,
+    prefix: string = variableName,
+  ): ConditionTarget[] => {
+    const extracted: ConditionTarget[] = [];
+    if (!schema) return extracted;
+
+    if (schema.type === 'object' && schema.properties) {
+      for (const [key, propSchema] of Object.entries(schema.properties)) {
+        extracted.push(
+          ...extractVariableTargets(
+            propSchema as TSchema,
+            variableName,
+            `${prefix}.${key}`,
+          ),
+        );
+      }
+    } else {
+      let type: ConditionTarget['type'] = 'text';
+      if (schema.type === 'boolean') type = 'boolean';
+      else if (schema.type === 'number' || schema.type === 'integer')
+        type = 'number';
+
+      extracted.push({
+        ref: {
+          stageId: SYSTEM_VARIABLE_NAMESPACE,
+          questionId: prefix,
+        },
+        label: `Variable: ${prefix}`,
+        type,
+      });
+    }
+    return extracted;
+  };
+
+  for (const config of variableConfigs) {
+    switch (config.type) {
+      case VariableConfigType.STATIC:
+        targets.push(
+          ...extractVariableTargets(
+            config.definition.schema,
+            config.definition.name,
+          ),
+        );
+        break;
+      case VariableConfigType.RANDOM_PERMUTATION: {
+        const numToSelect = config.numToSelect ?? config.values.length;
+        const itemSchema = getItemSchemaIfArray(config.definition.schema);
+        if (config.expandListToSeparateVariables) {
+          for (let i = 1; i <= numToSelect; i++) {
+            const indexedName = `${config.definition.name}_${i}`;
+            targets.push(
+              ...extractVariableTargets(itemSchema, indexedName, indexedName),
+            );
+          }
+        } else {
+          for (let i = 0; i < numToSelect; i++) {
+            targets.push(
+              ...extractVariableTargets(
+                itemSchema,
+                config.definition.name,
+                `${config.definition.name}.${i}`,
+              ),
+            );
+          }
+        }
+        break;
+      }
+      case VariableConfigType.BALANCED_ASSIGNMENT: {
+        const itemSchema = getItemSchemaIfArray(config.definition.schema);
+        targets.push(
+          ...extractVariableTargets(itemSchema, config.definition.name),
+        );
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
# Description

Allows experimenters to make survey items conditionally appear not just based on responses to prior survey items (existing functionality) but also participant variables. For example, a survey question can only appear if a participant is in a certain treatment group. Variables appear under a protected "Variables" Stage ID.

# Example

<img width="561" height="309" alt="image" src="https://github.com/user-attachments/assets/90fabd25-9b26-472e-b0ff-eb40fe0590d4" />