### PR TITLE
fix: separate variables are randomized separately

### DIFF
--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -614,7 +614,7 @@ async function getNextTurnBasedSpeakerAfterSkippedAgent(
           missingMediators.length > 1
             ? shuffleWithSeed(
                 missingMediators,
-                `${cohortId}-new-mediators-${cycleIndex}`,
+                `${cohortId}-${stage.id}-new-mediators-${cycleIndex}`,
               )
             : missingMediators;
         const nextMediators = [
@@ -626,7 +626,7 @@ async function getNextTurnBasedSpeakerAfterSkippedAgent(
         if (hadMediators) {
           const shuffledParticipants = shuffleWithSeed(
             participantIds,
-            `${cohortId}-${cycleIndex}`,
+            `${cohortId}-${stage.id}-${cycleIndex}`,
           );
           nextTurnOrder = [...nextMediators, ...shuffledParticipants];
         } else {
@@ -1114,7 +1114,7 @@ async function sendInitialGroupChatMessages(
       const allMediatorIds = agentMediators.map((m) => m.publicId);
 
       // Shuffle participants with seed
-      const seedString = `${cohortId}-0`;
+      const seedString = `${cohortId}-${stageId}-0`;
       const shuffledParticipants = shuffleWithSeed(
         allPublicParticipantIds,
         seedString,
@@ -1123,7 +1123,7 @@ async function sendInitialGroupChatMessages(
       // Shuffle mediator order when conversation begins (only if multiple)
       const shuffledMediators =
         allMediatorIds.length > 1
-          ? shuffleWithSeed(allMediatorIds, `${cohortId}-mediators`)
+          ? shuffleWithSeed(allMediatorIds, `${cohortId}-${stageId}-mediators`)
           : allMediatorIds;
 
       const turnOrder = [...shuffledMediators, ...shuffledParticipants];

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -562,6 +562,8 @@ async function processPromptItems(
   },
   userProfile: ParticipantProfileExtended | MediatorProfileExtended,
   includeScaffolding: boolean,
+  // Position prefix for nested groups, mixed into shuffle seeds.
+  seedNamespace = '',
 ): Promise<string> {
   const experiment = promptData.experiment;
   const items: string[] = [];
@@ -589,7 +591,13 @@ async function processPromptItems(
     participantForVariables,
   );
 
-  for (const promptItem of promptItems) {
+  // The first shuffled group keeps the bare seed (see the GROUP case).
+  const firstShuffledGroupIndex = promptItems.findIndex(
+    (it) =>
+      it.type === PromptItemType.GROUP &&
+      (it as PromptItemGroup).shuffleConfig?.shuffle,
+  );
+  for (const [itemIndex, promptItem] of promptItems.entries()) {
     // Check condition if present (only for private chat contexts)
     if (
       !shouldIncludePromptItem(
@@ -715,7 +723,18 @@ async function processPromptItems(
               seedString = promptGroup.shuffleConfig.customSeed;
               break;
           }
-          groupItems = shuffleWithSeed(groupItems, seedString);
+          // The first shuffled group keeps the bare seed, so existing
+          // prompts are unchanged. Later groups mix the stage and their
+          // position into the seed so distinct groups shuffle independently,
+          // across stages too.
+          const isFirstShuffledGroup =
+            seedNamespace === '' && itemIndex === firstShuffledGroupIndex;
+          groupItems = shuffleWithSeed(
+            groupItems,
+            isFirstShuffledGroup
+              ? seedString
+              : `${seedString}::${stageId}::${seedNamespace}${itemIndex}`,
+          );
         }
 
         const groupText = await processPromptItems(
@@ -726,6 +745,7 @@ async function processPromptItems(
           promptData,
           userProfile,
           includeScaffolding,
+          `${seedNamespace}${itemIndex}.`,
         );
         if (groupText) items.push(groupText);
         break;

--- a/functions/src/triggers/chat.triggers.test.ts
+++ b/functions/src/triggers/chat.triggers.test.ts
@@ -303,7 +303,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
       // Assert cycleIndex is 0 and seed string matches 'cohortId-cycleIndex'
       expect(mockShuffleWithSeed).toHaveBeenCalledWith(
         ['p1', 'p2', 'p3'],
-        'cohort123-0',
+        'cohort123-stage123-0',
       );
 
       // Shuffled order from deterministic seed is ['p3', 'p1', 'p2']
@@ -629,10 +629,10 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
 
       await onPublicChatMessageCreated.run(event as any);
 
-      // Assert cycleIndex incremented to 1 and shuffleWithSeed called with seed string 'cohort123-1'
+      // Assert cycleIndex incremented to 1 and shuffleWithSeed called with seed string 'cohort123-stage123-1'
       expect(mockShuffleWithSeed).toHaveBeenCalledWith(
         ['p1', 'p2', 'p3'],
-        'cohort123-1',
+        'cohort123-stage123-1',
       );
 
       const expectedShuffled = mockShuffleWithSeed.mock.results[0].value;
@@ -754,7 +754,10 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
       await onPublicChatMessageCreated.run(event as any);
 
       // Shuffled active participants (only p1) for cycle 1
-      expect(mockShuffleWithSeed).toHaveBeenCalledWith(['p1'], 'cohort123-1');
+      expect(mockShuffleWithSeed).toHaveBeenCalledWith(
+        ['p1'],
+        'cohort123-stage123-1',
+      );
 
       const expectedShuffled = mockShuffleWithSeed.mock.results[0].value; // ['p1']
       const expectedTurnOrder = ['m1', ...expectedShuffled]; // ['m1', 'p1']

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -238,7 +238,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                 missingMediators.length > 1
                   ? shuffleWithSeed(
                       missingMediators,
-                      `${event.params.cohortId}-new-mediators-${cycleIndex}`,
+                      `${event.params.cohortId}-${event.params.stageId}-new-mediators-${cycleIndex}`,
                     )
                   : missingMediators;
               const nextMediators = [
@@ -250,7 +250,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                 allMediatorIds.includes(id),
               );
               if (hadMediators) {
-                const seedString = `${event.params.cohortId}-${cycleIndex}`;
+                const seedString = `${event.params.cohortId}-${event.params.stageId}-${cycleIndex}`;
                 const shuffledParticipants = shuffleWithSeed(
                   allPublicParticipantIds,
                   seedString,
@@ -271,7 +271,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
         // 1. Initialize turn order if uninitialized or empty
         if (!currentTurnParticipantId || turnOrder.length === 0) {
           cycleIndex = 0;
-          const seedString = `${event.params.cohortId}-${cycleIndex}`;
+          const seedString = `${event.params.cohortId}-${event.params.stageId}-${cycleIndex}`;
           const shuffledParticipants = shuffleWithSeed(
             allPublicParticipantIds,
             seedString,
@@ -282,7 +282,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
             allMediatorIds.length > 1
               ? shuffleWithSeed(
                   allMediatorIds,
-                  `${event.params.cohortId}-mediators`,
+                  `${event.params.cohortId}-${event.params.stageId}-mediators`,
                 )
               : allMediatorIds;
 
@@ -371,7 +371,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                   missingMediators.length > 1
                     ? shuffleWithSeed(
                         missingMediators,
-                        `${event.params.cohortId}-new-mediators-${cycleIndex}`,
+                        `${event.params.cohortId}-${event.params.stageId}-new-mediators-${cycleIndex}`,
                       )
                     : missingMediators;
                 const nextMediators = [
@@ -384,7 +384,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                 );
 
                 if (hadMediators) {
-                  const seedString = `${event.params.cohortId}-${cycleIndex}`;
+                  const seedString = `${event.params.cohortId}-${event.params.stageId}-${cycleIndex}`;
                   const shuffledParticipants = shuffleWithSeed(
                     allPublicParticipantIds,
                     seedString,

--- a/functions/src/triggers/participant.triggers.ts
+++ b/functions/src/triggers/participant.triggers.ts
@@ -173,7 +173,7 @@ async function advanceTurnBasedChatIfCurrentParticipantLeft(
               missingMediators.length > 1
                 ? shuffleWithSeed(
                     missingMediators,
-                    `${cohortId}-new-mediators-${cycleIndex}`,
+                    `${cohortId}-${stageId}-new-mediators-${cycleIndex}`,
                   )
                 : missingMediators;
             const nextMediators = [
@@ -186,7 +186,7 @@ async function advanceTurnBasedChatIfCurrentParticipantLeft(
             if (hadMediators) {
               const shuffledParticipants = shuffleWithSeed(
                 allPublicParticipantIds,
-                `${cohortId}-${cycleIndex}`,
+                `${cohortId}-${stageId}-${cycleIndex}`,
               );
               nextTurnOrderNew = [...nextMediators, ...shuffledParticipants];
             } else {

--- a/functions/src/variables.utils.test.ts
+++ b/functions/src/variables.utils.test.ts
@@ -114,6 +114,45 @@ describe('generateVariablesForScope', () => {
       expect(result['items_2']).toBe(JSON.stringify('B'));
       expect(result['items_3']).toBeUndefined();
     });
+
+    it('keeps the first shuffled variable stable and randomizes later ones by position', async () => {
+      const mk = (name: string) =>
+        createRandomPermutationVariableConfig({
+          scope: VariableScope.COHORT,
+          definition: {
+            name,
+            description: '',
+            schema: VariableType.array(VariableType.STRING),
+          },
+          values: ['a', 'b', 'c', 'd', 'e'].map((v) => JSON.stringify(v)),
+          numToSelect: 5,
+          expandListToSeparateVariables: false,
+          shuffleConfig: {
+            shuffle: true,
+            seed: SeedStrategy.COHORT,
+            customSeed: '',
+          },
+        });
+      const ctx = {
+        scope: VariableScope.COHORT,
+        experimentId: 'exp-1',
+        cohortId: 'cohort-1',
+      };
+      const alone = (await generateVariablesForScope([mk('colorVar')], ctx))[
+        'colorVar'
+      ];
+      const both = await generateVariablesForScope(
+        [mk('colorVar'), mk('animalVar')],
+        ctx,
+      );
+      expect(both['colorVar']).toBe(alone);
+      expect(both['animalVar']).not.toBe(both['colorVar']);
+      // Removing a variable re-randomizes the ones after it.
+      const animalAlone = (
+        await generateVariablesForScope([mk('animalVar')], ctx)
+      )['animalVar'];
+      expect(animalAlone).not.toBe(both['animalVar']);
+    });
   });
 
   describe('balanced assignment variables', () => {

--- a/functions/src/variables.utils.ts
+++ b/functions/src/variables.utils.ts
@@ -143,7 +143,10 @@ export async function generateVariablesForScope(
     (c) => c.scope === context.scope,
   );
 
-  for (const config of scopedConfigs) {
+  // Seed handling is described in generateRandomPermutationValue.
+  let firstShuffled = true;
+
+  for (const [seedIndex, config] of scopedConfigs.entries()) {
     let generatedVariables: Record<string, string> = {};
 
     switch (config.type) {
@@ -155,7 +158,9 @@ export async function generateVariablesForScope(
         generatedVariables = generateRandomPermutationVariables(
           config,
           context,
+          firstShuffled ? null : seedIndex,
         );
+        if (config.shuffleConfig?.shuffle) firstShuffled = false;
         break;
 
       case VariableConfigType.BALANCED_ASSIGNMENT:

--- a/utils/src/variables.utils.test.ts
+++ b/utils/src/variables.utils.test.ts
@@ -179,6 +179,55 @@ describe('generateRandomPermutationVariables', () => {
     expect(JSON.parse(result['item_2'])).toEqual({name: 'Item B', value: 200});
     expect(result['item']).toBeUndefined();
   });
+
+  const permConfig = (name: string, values: string[]) =>
+    createRandomPermutationVariableConfig({
+      id: name,
+      type: VariableConfigType.RANDOM_PERMUTATION,
+      scope: VariableScope.PARTICIPANT,
+      definition: {name, description: '', schema: Type.Array(Type.String())},
+      shuffleConfig: createShuffleConfig({
+        shuffle: true,
+        seed: SeedStrategy.PARTICIPANT,
+      }),
+      values,
+      numToSelect: values.length,
+      expandListToSeparateVariables: false,
+    });
+
+  it('randomizes each position independently', () => {
+    const pool = ['a', 'b', 'c', 'd', 'e'].map((v) => JSON.stringify(v));
+    const c = {
+      scope: VariableScope.PARTICIPANT as const,
+      experimentId: 'exp',
+      cohortId: 'cohort',
+      participantId: 'subject-1',
+    };
+    const perm = (name: string, seedIndex: number | null) =>
+      generateRandomPermutationVariables(permConfig(name, pool), c, seedIndex)[
+        name
+      ];
+    expect(perm('colorVar', null)).toBe(perm('animalVar', null));
+    expect(perm('colorVar', 1)).not.toBe(perm('colorVar', null));
+    expect(perm('colorVar', 1)).not.toBe(perm('colorVar', 2));
+  });
+
+  it('is deterministic for the same variable and seed', () => {
+    const colors = ['red', 'green', 'blue'].map((v) => JSON.stringify(v));
+    const c = {
+      scope: VariableScope.PARTICIPANT as const,
+      experimentId: 'exp',
+      cohortId: 'cohort',
+      participantId: 'subject-1',
+    };
+    const a = generateRandomPermutationVariables(permConfig('v', colors), c)[
+      'v'
+    ];
+    const b = generateRandomPermutationVariables(permConfig('v', colors), c)[
+      'v'
+    ];
+    expect(a).toBe(b);
+  });
 });
 
 describe('generateStaticVariables', () => {

--- a/utils/src/variables.utils.ts
+++ b/utils/src/variables.utils.ts
@@ -216,6 +216,7 @@ export function createBalancedAssignmentVariableConfig(
 function generateRandomPermutationValue(
   config: RandomPermutationVariableConfig,
   context: ScopeContext,
+  seedIndex: number | null,
 ): unknown {
   const {shuffle, seed: seedStrategy, customSeed} = config.shuffleConfig;
   const maxAvailable = config.values.length;
@@ -252,8 +253,13 @@ function generateRandomPermutationValue(
         break;
     }
 
-    // seed() is called inside choices() if a seed value is provided
-    selectedValues = choices(config.values, numToSelect, seedValue);
+    // The first shuffled variable keeps the bare seed, so existing
+    // deployments keep the sequences they already had. Later ones mix their
+    // position into the seed so distinct variables are randomized
+    // independently.
+    const effectiveSeed =
+      seedIndex === null ? seedValue : `${seedValue}::${seedIndex}`;
+    selectedValues = choices(config.values, numToSelect, effectiveSeed);
   } else {
     selectedValues = config.values.slice(0, numToSelect);
   }
@@ -303,8 +309,11 @@ export function generateStaticVariables(
 export function generateRandomPermutationVariables(
   config: RandomPermutationVariableConfig,
   context: ScopeContext,
+  // Position of the variable in its scope's config list; null keeps the bare
+  // seed.
+  seedIndex: number | null = null,
 ): Record<string, string> {
-  const value = generateRandomPermutationValue(config, context);
+  const value = generateRandomPermutationValue(config, context, seedIndex);
   const variables: Record<string, string> = {};
 
   // Check if we should flatten the array into indexed variables


### PR DESCRIPTION
Fixes an issue where variables and other randomized objects had dependent, rather than independent, randomization: for example, say that you assign participant variable `A` with values `1`, `2`, `3` and participant variable `B` with values `4`, `5`, `6`...

**Before**: You would only assign participantas`A1+B4`, `A2+B5`, and `A3+B6`.

**After**: You get the full randomization: `A1+B4`, `A1+B5`, `A1+B6`, `A2+B4`, `A2+B5`, etc.…

Everything stays deterministic, and existing functionality is unchanged: the first variable keeps the same sequence it had.