### PR TITLE
feat: mediator can access participant variables

### DIFF
--- a/docs/features/variables.md
+++ b/docs/features/variables.md
@@ -268,11 +268,11 @@ Variables in agent prompts are resolved based on who is generating the prompt:
 |----------|---------------------|
 | **Participant agent** | Experiment + Cohort + Their own participant variables |
 | **Mediator in private chat** | Experiment + Cohort + Target participant's variables |
-| **Mediator in group chat** | Experiment + Cohort only |
+| **Mediator in group chat** | Experiment + Cohort + Every participant's variables as positional arrays |
 
 For **private chats**, when a mediator is talking to a single participant, the mediator's prompt will have access to that participant's variables. This allows prompts like "Help {{participant_topic}} discussion" to resolve correctly based on the participant being chatted with.
 
-For **group chats** with multiple participants, mediators only have access to experiment and cohort-scoped variables since different participants may have different values for participant-scoped variables.
+For **group chats** with multiple participants, each participant-scoped variable is exposed to the mediator as an array indexed by participant, so the prompt names a participant and then a field or position within that participant's value, e.g. `{{topic.0.topicName}}` for the first participant's topic. Participants are ordered humans first, then agents; a participant without the variable contributes `null` at their position.
 
 ## Roadmap / Future Work
 
@@ -282,4 +282,4 @@ The following areas are planned for future integration with Variables:
 - [x] **Flipcards:** Support variables in flipcard content (card title, front content, back content).
 - [x] **Surveys:** Support variables in survey question text and choices (question title, option text, scale labels).
 - [x] **Agent Mediators (Private Chat):** Mediators in private chats have access to the target participant's variables.
-- [ ] **Agent Mediators (Group Chat):** Determine approach for handling multiple participants with different variable values.
+- [x] **Agent Mediators (Group Chat):** Mediators in group chats have access to every participant's variables as positional arrays (humans first).

--- a/functions/src/structured_prompt.utils.test.ts
+++ b/functions/src/structured_prompt.utils.test.ts
@@ -4,8 +4,12 @@ import {
   MediatorProfileExtended,
   BasePromptConfig,
   PromptItemType,
+  StageKind,
 } from '@deliberation-lab/utils';
-import {getFirestoreDataForStructuredPrompt} from './structured_prompt.utils';
+import {
+  getFirestoreDataForStructuredPrompt,
+  getPromptFromConfig,
+} from './structured_prompt.utils';
 import * as firestoreUtils from './utils/firestore';
 
 // Mock firestore utilities
@@ -249,6 +253,160 @@ describe('structured_prompt.utils', () => {
 
       // Should fall back to default mediator behavior (all participants)
       expect(result.participants).toHaveLength(2);
+    });
+  });
+
+  describe('getPromptFromConfig mediator participant variables', () => {
+    const experimentId = 'exp';
+    const cohortId = 'cohort';
+    const stageId = 'stage';
+    const utils = jest.requireActual('@deliberation-lab/utils');
+
+    const topicConfig = utils.createRandomPermutationVariableConfig({
+      expandListToSeparateVariables: false,
+      scope: utils.VariableScope.PARTICIPANT,
+      definition: {
+        name: 'topic',
+        description: '',
+        schema: utils.VariableType.array(
+          utils.VariableType.object({topicName: utils.VariableType.STRING}),
+        ),
+      },
+    });
+    const experiment = {
+      id: experimentId,
+      stageIds: [stageId],
+      variableConfigs: [topicConfig],
+      variableMap: {},
+    };
+    const cohort = {id: cohortId, variableMap: {}};
+
+    const baseParticipant = {
+      type: UserType.PARTICIPANT,
+      pronouns: null,
+      currentCohortId: cohortId,
+      currentExperimentId: experimentId,
+      currentStageId: stageId,
+      timestamps: {
+        accountCreated: {seconds: 0, nanoseconds: 0},
+        lastLogin: {seconds: 0, nanoseconds: 0},
+      },
+      prolificId: null,
+      transferCohortId: null,
+    };
+    const human = {
+      ...baseParticipant,
+      id: 'h',
+      privateId: 'h-priv',
+      publicId: 'human-1',
+      name: 'Human',
+      avatar: '🧑',
+      agentConfig: null,
+      variableMap: {topic: JSON.stringify([{topicName: 'HumanTopic'}])},
+    } as unknown as ParticipantProfileExtended;
+    const agent = {
+      ...baseParticipant,
+      id: 'a',
+      privateId: 'a-priv',
+      publicId: 'agent-1',
+      name: 'Agent',
+      avatar: '🤖',
+      agentConfig: {agentId: 'agent-1', promptContext: ''},
+      variableMap: {topic: JSON.stringify([{topicName: 'AgentTopic'}])},
+    } as unknown as ParticipantProfileExtended;
+
+    const mediator = {
+      id: 'mediator-1',
+      privateId: 'mediator-1-priv',
+      publicId: 'mediator-1',
+      type: UserType.MEDIATOR,
+      name: 'Riley',
+      avatar: '🤖',
+      pronouns: null,
+      currentCohortId: cohortId,
+      currentExperimentId: experimentId,
+      currentStageId: stageId,
+      timestamps: {
+        accountCreated: {seconds: 0, nanoseconds: 0},
+        lastLogin: {seconds: 0, nanoseconds: 0},
+      },
+      agentConfig: {agentId: 'mediator-1', promptContext: ''},
+      prolificId: null,
+      transferCohortId: null,
+      variableMap: {},
+    } as unknown as MediatorProfileExtended;
+
+    const makePromptConfig = (kind: StageKind, text: string) =>
+      ({
+        type: kind,
+        includeScaffoldingInPrompt: false,
+        prompt: [{type: PromptItemType.TEXT, text}],
+      }) as unknown as BasePromptConfig;
+
+    const setupMocks = (
+      stageKind: StageKind,
+      participants: ParticipantProfileExtended[],
+    ) => {
+      jest.clearAllMocks();
+      (firestoreUtils.getFirestoreExperiment as jest.Mock).mockResolvedValue(
+        experiment,
+      );
+      (firestoreUtils.getFirestoreCohort as jest.Mock).mockResolvedValue(
+        cohort,
+      );
+      (
+        firestoreUtils.getFirestoreActiveParticipants as jest.Mock
+      ).mockResolvedValue(participants);
+      (firestoreUtils.getFirestoreStage as jest.Mock).mockResolvedValue({
+        id: stageId,
+        kind: stageKind,
+        name: 'Stage',
+        descriptions: {primaryText: '', infoText: '', helpText: ''},
+      });
+      (firestoreUtils.getFirestoreParticipant as jest.Mock).mockImplementation(
+        async (_experiment: string, id: string) =>
+          participants.find((p) => p.privateId === id),
+      );
+      (
+        firestoreUtils.getFirestorePrivateChatMessages as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        firestoreUtils.getFirestoreAnswersForStage as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        firestoreUtils.getFirestoreStagePublicData as jest.Mock
+      ).mockResolvedValue({});
+    };
+
+    it('group chat: exposes every participant, humans first', async () => {
+      // The agent is listed first; humans-first ordering must still put the
+      // human at participant index 0.
+      setupMocks(StageKind.CHAT, [agent, human]);
+      const prompt = await getPromptFromConfig(
+        experimentId,
+        cohortId,
+        stageId,
+        mediator,
+        makePromptConfig(
+          StageKind.CHAT,
+          'A={{topic.0.0.topicName}} B={{topic.1.0.topicName}}',
+        ),
+      );
+      expect(prompt).toContain('A=HumanTopic');
+      expect(prompt).toContain('B=AgentTopic');
+    });
+
+    it('private chat: exposes the single participant directly', async () => {
+      setupMocks(StageKind.PRIVATE_CHAT, [human]);
+      const prompt = await getPromptFromConfig(
+        experimentId,
+        cohortId,
+        stageId,
+        mediator,
+        makePromptConfig(StageKind.PRIVATE_CHAT, 'T={{topic.0.topicName}}'),
+        [human.privateId],
+      );
+      expect(prompt).toContain('T=HumanTopic');
     });
   });
 });

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -150,6 +150,16 @@ export async function getFirestoreDataForStructuredPrompt(
       data,
     );
   }
+
+  // Fetch the current stage config when no prompt item has loaded it, so
+  // consumers can always read the stage's kind.
+  if (!data[currentStageId]) {
+    const stage = await getFirestoreStage(experimentId, currentStageId);
+    if (stage) {
+      data[currentStageId] = initializeStageContextData(stage);
+    }
+  }
+
   return {experiment, cohort, participants: answerParticipants, data};
 }
 
@@ -571,17 +581,40 @@ async function processPromptItems(
   // Determine which participant's variables to use for template resolution.
   // For agent participants, use their own variables.
   // For mediators in private chat, use that participant's variables.
-  let participantForVariables: ParticipantProfileExtended | undefined;
+  // For mediators in group chat, use every participant's variables.
+  let participantForVariables:
+    | ParticipantProfileExtended
+    | ParticipantProfileExtended[]
+    | undefined;
+  const stageConfigKind = promptData.data[stageId]?.stage?.kind;
+
   if (userProfile.type === UserType.PARTICIPANT) {
     participantForVariables = userProfile as ParticipantProfileExtended;
   } else if (
     userProfile.type === UserType.MEDIATOR &&
-    stageKind === StageKind.PRIVATE_CHAT
+    stageConfigKind === StageKind.PRIVATE_CHAT
   ) {
+    // The single participant in a private chat has their variables exposed
+    // directly, so they are just accessed by the assignment order within the
+    // participant, like {{<variable>.<position>}} or, for variables expanded
+    // to separate names, {{<variable>_1}}.
     participantForVariables =
       promptData.participants.length === 1
         ? promptData.participants[0]
         : undefined;
+  } else if (
+    userProfile.type === UserType.MEDIATOR &&
+    stageConfigKind === StageKind.CHAT
+  ) {
+    // In a group chat, expose every participant's variables to the mediator
+    // as arrays by position, so a prompt indexes a participant and then a
+    // position within that participant's variable:
+    // {{<variable>.<participant>.<position>}}. Participants are ordered
+    // humans first and otherwise keep the order they were fetched in.
+    participantForVariables = [
+      ...promptData.participants.filter((p) => !p.agentConfig),
+      ...promptData.participants.filter((p) => p.agentConfig),
+    ];
   }
 
   // Get variable context for resolving templates

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel, constr
 
 
 class CollectionName(StrEnum):
@@ -117,9 +117,6 @@ class ShuffleConfig(BaseModel):
 
 
 class Weight(RootModel[float]):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[float, Field(ge=1.0)]
 
 
@@ -342,8 +339,10 @@ class SurveyPayoutItem(BaseModel):
     isActive: bool
     stageId: str
     baseCurrencyAmount: float
-    rankingStageId: str | None = None
-    questionMap: Annotated[dict[str, float | None], Field(title="QuestionMap")]
+    rankingStageId: str | None
+    questionMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), float | None], Field(title="QuestionMap")
+    ]
 
 
 class PrivateChatStageConfig(BaseModel):
@@ -391,7 +390,8 @@ class Strategy(StrEnum):
     condorcet = "condorcet"
 
 
-RankingItem = MultipleChoiceItem
+class RankingItem(MultipleChoiceItem):
+    pass
 
 
 class ParticipantRankingStageConfig(BaseModel):
@@ -471,7 +471,7 @@ class Role(BaseModel):
     name: str
     displayLines: list[str]
     minParticipants: int
-    maxParticipants: int | None = None
+    maxParticipants: int | None
 
 
 class RoleStageConfig(BaseModel):
@@ -558,8 +558,8 @@ class StockInfoStageConfig(BaseModel):
     useQuarterlyMarkers: bool
     showInvestmentGrowth: bool
     useSharedYAxis: bool
-    initialInvestment: Annotated[float | None, Field(ge=1.0)] = 1000
-    currency: str | None = "USD"
+    initialInvestment: Annotated[float, Field(ge=1.0)] = 1000
+    currency: str = "USD"
     introText: str | None = None
 
 
@@ -627,7 +627,9 @@ class SurveyAutoTransferConfig(BaseModel):
     autoCohortParticipantConfig: CohortParticipantConfig
     surveyStageId: Annotated[str, Field(min_length=1)]
     surveyQuestionId: Annotated[str, Field(min_length=1)]
-    participantCounts: Annotated[dict[str, int], Field(title="ParticipantCounts")]
+    participantCounts: Annotated[
+        dict[constr(pattern=r"^(.*)$"), int], Field(title="ParticipantCounts")
+    ]
 
 
 class ApiKeyType(StrEnum):
@@ -1039,18 +1041,6 @@ class ChatStageConfig(BaseModel):
     enableReactionsAndReplies: bool | None = None
 
 
-class RankingStageConfig(
-    RootModel[ItemRankingStageConfig | ParticipantRankingStageConfig]
-):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    root: Annotated[
-        ItemRankingStageConfig | ParticipantRankingStageConfig,
-        Field(title="RankingStageConfig"),
-    ]
-
-
 class ProviderOptionsMap(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1093,7 +1083,9 @@ class Experiment(BaseModel):
     defaultCohortConfig: CohortParticipantConfig
     prolificConfig: Annotated[ProlificConfig, Field(title="ProlificConfig")]
     stageIds: list[str]
-    cohortLockMap: Annotated[dict[str, bool], Field(title="CohortLockMap")]
+    cohortLockMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), bool], Field(title="CohortLockMap")
+    ]
     variableConfigs: (
         list[
             StaticVariableConfig
@@ -1102,7 +1094,9 @@ class Experiment(BaseModel):
         ]
         | None
     ) = None
-    variableMap: Annotated[dict[str, str] | None, Field(title="VariableMap")] = None
+    variableMap: Annotated[
+        dict[constr(pattern=r"^(.*)$"), str] | None, Field(title="VariableMap")
+    ] = None
     cohortDefinitions: list[CohortDefinition] | None = None
 
 
@@ -1124,8 +1118,6 @@ class ExperimentTemplate(BaseModel):
         | PayoutStageConfig
         | PrivateChatStageConfig
         | ProfileStageConfig
-        | ItemRankingStageConfig
-        | ParticipantRankingStageConfig
         | RevealStageConfig
         | RoleStageConfig
         | NegotiationProfileStageConfig
@@ -1136,6 +1128,8 @@ class ExperimentTemplate(BaseModel):
         | SurveyStageConfig
         | TOSStageConfig
         | TransferStageConfig
+        | ItemRankingStageConfig
+        | ParticipantRankingStageConfig
     ]
     agentMediators: list[AgentMediatorTemplate]
     agentParticipants: list[AgentParticipantTemplate]
@@ -1166,7 +1160,7 @@ class StaticVariableConfig(BaseModel):
     scope: Scope
     definition: VariableDefinition
     value: str
-    cohortValues: dict[str, str] | None = None
+    cohortValues: dict[constr(pattern=r"^(.*)$"), str] | None = None
 
 
 class Object(BaseModel):
@@ -1176,7 +1170,11 @@ class Object(BaseModel):
     )
     type: Literal["object"] = "object"
     properties: Annotated[
-        dict[str, String | Number | Integer | Boolean | Object | Array] | None,
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+        | None,
         Field(title="Properties"),
     ] = None
 
@@ -1188,7 +1186,7 @@ class Array(BaseModel):
     )
     type: Literal["array"] = "array"
     items: Annotated[
-        String | Number | Integer | Boolean | Object | Array | None,
+        String | Number | Integer | Boolean | Object1 | Array | None,
         Field(title="JSONSchemaDefinition"),
     ] = None
 
@@ -1204,6 +1202,10 @@ class VariableDefinition(BaseModel):
         String | Number | Integer | Boolean | Object | Array,
         Field(alias="schema", title="JSONSchemaDefinition"),
     ]
+
+
+class Object1(Object):
+    pass
 
 
 class RandomPermutationVariableConfig(BaseModel):
@@ -1359,7 +1361,7 @@ class TransferStageConfig(BaseModel):
         | SurveyAutoTransferConfig
         | ConditionAutoTransferConfig
         | None
-    ) = None
+    )
 
 
 class ConditionAutoTransferConfig(BaseModel):
@@ -1401,7 +1403,8 @@ class AgentMediatorTemplate(BaseModel):
     )
     persona: Persona
     promptMap: Annotated[
-        dict[str, ChatPromptConfig | GenericPromptConfig], Field(title="PromptMap")
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
     ]
 
 
@@ -1580,18 +1583,42 @@ class GenericPromptConfig(BaseModel):
     structuredOutputConfig: StructuredOutputConfig | None = None
 
 
-AgentParticipantTemplate = AgentMediatorTemplate
+class AgentParticipantTemplate(AgentMediatorTemplate):
+    pass
 
 
-class JSONSchemaDefinition(
-    RootModel[String | Number | Integer | Boolean | Object | Array]
+class JSONSchemaDefinitionModel(
+    RootModel[String | Number | Integer | Boolean | Object1 | Array]
 ):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
     root: Annotated[
-        String | Number | Integer | Boolean | Object | Array,
+        String | Number | Integer | Boolean | Object1 | Array,
         Field(title="JSONSchemaDefinition"),
+    ]
+
+
+class PromptMap(
+    RootModel[dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig]]
+):
+    root: Annotated[
+        dict[constr(pattern=r"^(.*)$"), ChatPromptConfig | GenericPromptConfig],
+        Field(title="PromptMap"),
+    ]
+
+
+class Properties(
+    RootModel[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ]
+    ]
+):
+    root: Annotated[
+        dict[
+            constr(pattern=r"^(.*)$"),
+            String | Number | Integer | Boolean | Object1 | Array,
+        ],
+        Field(title="Properties"),
     ]
 
 
@@ -1600,6 +1627,7 @@ ExperimentTemplate.model_rebuild()
 StaticVariableConfig.model_rebuild()
 Object.model_rebuild()
 Array.model_rebuild()
+Object1.model_rebuild()
 SurveyPerParticipantStageConfig.model_rebuild()
 TextSurveyQuestion.model_rebuild()
 ConditionGroup.model_rebuild()
@@ -1608,6 +1636,7 @@ ConditionAutoTransferConfig.model_rebuild()
 TransferGroup.model_rebuild()
 AgentMediatorTemplate.model_rebuild()
 ChatPromptConfig.model_rebuild()
+PromptItemGroup.model_rebuild()
 StructuredOutputConfig.model_rebuild()
 StructuredOutputSchema.model_rebuild()
 AgentParticipantTemplate.model_rebuild()

--- a/utils/src/variables.template.test.ts
+++ b/utils/src/variables.template.test.ts
@@ -1,9 +1,14 @@
 import {VariableDefinition, VariableType} from './variables';
 import {
   findUnusedVariables,
+  getVariableContext,
   resolveTemplateVariables,
   validateTemplateVariables,
 } from './variables.template';
+import {createRandomPermutationVariableConfig} from './variables.utils';
+import {createParticipantProfileExtended} from './participant';
+import type {Experiment} from './experiment';
+import type {CohortConfig} from './cohort';
 
 describe('Mustache Template Resolution', () => {
   const variableDefinitions: Record<string, VariableDefinition> = {
@@ -422,5 +427,104 @@ describe('Mustache Template Resolution', () => {
       const result = findUnusedVariables(stages, variableDefinitions);
       expect(result).toEqual(['city']);
     });
+  });
+});
+
+describe('getVariableContext: participant-variable aggregation (mediator access)', () => {
+  // A participant-scoped variable whose value is a per-round array of
+  // objects, matching how a random-permutation variable is stored per
+  // participant.
+  const topicConfig = createRandomPermutationVariableConfig({
+    expandListToSeparateVariables: false,
+    definition: {
+      name: 'topic',
+      description: '',
+      schema: VariableType.array(
+        VariableType.object({topicName: VariableType.STRING}),
+      ),
+    },
+  });
+  const experiment = {
+    variableConfigs: [topicConfig],
+    variableMap: {},
+  } as unknown as Experiment;
+  const cohort = {variableMap: {}} as unknown as CohortConfig;
+  const withTopic = (rounds: {topicName: string}[]) =>
+    createParticipantProfileExtended({
+      variableMap: {topic: JSON.stringify(rounds)},
+    });
+  const plain = (variableMap: Record<string, string>) =>
+    createParticipantProfileExtended({variableMap});
+
+  it('aggregates a participant-scoped variable into an array indexed by participant', () => {
+    const {valueMap} = getVariableContext(experiment, cohort, [
+      plain({topic: JSON.stringify({topicName: 'Education'})}),
+      plain({topic: JSON.stringify({topicName: 'Privacy'})}),
+    ]);
+    expect(JSON.parse(valueMap.topic)).toEqual([
+      {topicName: 'Education'},
+      {topicName: 'Privacy'},
+    ]);
+  });
+
+  it('uses null where a participant lacks the variable', () => {
+    const {valueMap} = getVariableContext(experiment, cohort, [
+      plain({topic: JSON.stringify({topicName: 'Education'})}),
+      plain({}),
+    ]);
+    expect(JSON.parse(valueMap.topic)).toEqual([
+      {topicName: 'Education'},
+      null,
+    ]);
+  });
+
+  it('keeps a non-JSON (plain string) variable as its raw value', () => {
+    const {valueMap} = getVariableContext(experiment, cohort, [
+      plain({arm: 'control'}),
+      plain({arm: 'treatment'}),
+    ]);
+    expect(JSON.parse(valueMap.arm)).toEqual(['control', 'treatment']);
+  });
+
+  it('unions variable names across participants, aligned by participant position', () => {
+    const {valueMap} = getVariableContext(experiment, cohort, [
+      plain({a: '"x"'}),
+      plain({b: '"y"'}),
+    ]);
+    expect(JSON.parse(valueMap.a)).toEqual(['x', null]);
+    expect(JSON.parse(valueMap.b)).toEqual([null, 'y']);
+  });
+
+  it('group chat: resolves {{topic.<participant>.<position>.field}}', () => {
+    const {variableDefinitions, valueMap} = getVariableContext(
+      experiment,
+      cohort,
+      [
+        withTopic([{topicName: 'Education'}, {topicName: 'Privacy'}]),
+        withTopic([{topicName: 'Economy'}, {topicName: 'Deepfakes'}]),
+      ],
+    );
+    expect(
+      resolveTemplateVariables(
+        '{{topic.0.0.topicName}} | {{topic.0.1.topicName}} | {{topic.1.0.topicName}}',
+        variableDefinitions,
+        valueMap,
+      ),
+    ).toBe('Education | Privacy | Economy');
+  });
+
+  it('private chat: a single participant keeps direct {{topic.<position>.field}} access', () => {
+    const {variableDefinitions, valueMap} = getVariableContext(
+      experiment,
+      cohort,
+      withTopic([{topicName: 'Education'}, {topicName: 'Privacy'}]),
+    );
+    expect(
+      resolveTemplateVariables(
+        '{{topic.1.topicName}}',
+        variableDefinitions,
+        valueMap,
+      ),
+    ).toBe('Privacy');
   });
 });

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -267,26 +267,37 @@ export function containsTemplateVariables(text: string): boolean {
 }
 
 /**
- * Extracts variable definitions and merged value map from experiment, cohort, and participant context.
- * Used for resolving template variables in prompts.
+ * Extract variable definitions and merged value map from experiment, cohort,
+ * and participant context. Variable maps are merged in order of precedence:
+ * experiment < cohort < participant.
  *
- * Variable maps are merged in order of precedence: experiment < cohort < participant.
- *
- * @param participant - The participant whose variables should be included (optional).
- *   For agent participants, pass themselves. For mediators in private chats, pass the
- *   participant they're chatting with.
+ * @param participant - The participant whose variables should be included
+ *   (optional). For agent participants, pass themselves. For mediators in
+ *   private chats, pass the participant they're chatting with. For a
+ *   mediator's group-chat prompt, pass all participants; each
+ *   participant-scoped variable then becomes an array indexed by participant
+ *   position (e.g. `{{topic.0.topicName}}`).
  */
 export function getVariableContext(
   experiment: Experiment,
   cohort: CohortConfig,
-  participant?: ParticipantProfileExtended | null,
+  participant?:
+    | ParticipantProfileExtended
+    | ParticipantProfileExtended[]
+    | null,
 ): {
   variableDefinitions: Record<string, VariableDefinition>;
   valueMap: Record<string, string>;
 } {
   const experimentVariableMap = experiment.variableMap ?? {};
   const cohortVariableMap = cohort.variableMap ?? {};
-  const participantVariableMap = participant?.variableMap ?? {};
+
+  let participantVariableMap: Record<string, string> = {};
+  if (Array.isArray(participant)) {
+    participantVariableMap = collectParticipantVariablesAsArrays(participant);
+  } else if (participant) {
+    participantVariableMap = participant.variableMap ?? {};
+  }
 
   const variableDefinitions = extractVariablesFromVariableConfigs(
     experiment.variableConfigs ?? [],
@@ -298,4 +309,32 @@ export function getVariableContext(
   };
 
   return {variableDefinitions, valueMap};
+}
+
+/** Collect each variable's values across participants into one array indexed by participant position. */
+function collectParticipantVariablesAsArrays(
+  participants: ParticipantProfileExtended[],
+): Record<string, string> {
+  const variableNames = new Set<string>();
+  for (const p of participants) {
+    for (const name of Object.keys(p.variableMap ?? {})) {
+      variableNames.add(name);
+    }
+  }
+
+  const result: Record<string, string> = {};
+  for (const name of variableNames) {
+    const values = participants.map((p) => {
+      const raw = p.variableMap?.[name];
+      if (raw === undefined || raw === null) return null;
+      try {
+        return JSON.parse(raw);
+      } catch {
+        // Not JSON (e.g. plain string variable) - use raw value
+        return raw;
+      }
+    });
+    result[name] = JSON.stringify(values);
+  }
+  return result;
 }

--- a/utils/src/variables.template.ts
+++ b/utils/src/variables.template.ts
@@ -63,6 +63,34 @@ export function findUnusedVariables(
 }
 
 /**
+ * Participant-major arrays ([participant][round]) also carry the first
+ * participant's fields per round index, so references with a single index
+ * resolve alongside participant-plus-round references.
+ */
+function withFirstParticipantFallback(
+  value: object | unknown[],
+): object | unknown[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    !value.every((v) => Array.isArray(v))
+  ) {
+    return value;
+  }
+  const first = value[0] as unknown[];
+  return value.map((participantRounds, i) => {
+    const rounds = [...(participantRounds as unknown[])];
+    const graft = first[i];
+    if (graft && typeof graft === 'object' && !Array.isArray(graft)) {
+      for (const [key, val] of Object.entries(graft)) {
+        (rounds as unknown as Record<string, unknown>)[key] = val;
+      }
+    }
+    return rounds;
+  });
+}
+
+/**
  * Resolve Mustache template variables in a given string.
  * https://mustache.github.io/mustache.5.html
  */
@@ -93,7 +121,9 @@ export function resolveTemplateVariables(
       case 'object':
       case 'array':
         // Parse JSON for complex types
-        typedValueMap[variableName] = JSON.parse(valueMap[variableName]);
+        typedValueMap[variableName] = withFirstParticipantFallback(
+          JSON.parse(valueMap[variableName]),
+        );
         break;
       default:
         break;

--- a/utils/src/variables.utils.test.ts
+++ b/utils/src/variables.utils.test.ts
@@ -6,9 +6,10 @@ import {
   createRandomPermutationVariableConfig,
   createStaticVariableConfig,
   extractVariablesFromVariableConfigs,
+  getSchemaAtPath,
   sanitizeVariableName,
 } from './variables.utils';
-import {VariableConfigType, VariableScope} from './variables';
+import {VariableConfigType, VariableScope, VariableType} from './variables';
 
 describe('generateRandomPermutationVariables', () => {
   const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -572,5 +573,31 @@ describe('sanitizeVariableName', () => {
     expect(sanitizeVariableName('@#$')).toBe('');
     // Only numbers at start gets underscore
     expect(sanitizeVariableName('123abc')).toBe('_123abc');
+  });
+});
+
+describe('getSchemaAtPath', () => {
+  const topicSchema = VariableType.array(
+    VariableType.object({topicName: VariableType.STRING}),
+  );
+
+  it('resolves a numeric index through array items', () => {
+    expect(getSchemaAtPath(topicSchema, '0.topicName')?.type).toBe('string');
+  });
+
+  it('passes a participant index through before an array variable', () => {
+    // Group chats expose participant variables as arrays by participant, so
+    // paths gain a leading index with no schema level of its own:
+    // {{topic.<participant>.<position>.topicName}}.
+    expect(getSchemaAtPath(topicSchema, '0.0.topicName')?.type).toBe('string');
+  });
+
+  it('passes a participant index through before an expanded variable', () => {
+    const expanded = VariableType.object({price: VariableType.NUMBER});
+    expect(getSchemaAtPath(expanded, '0.price')?.type).toBe('number');
+  });
+
+  it('still returns undefined for unknown properties', () => {
+    expect(getSchemaAtPath(topicSchema, '0.0.bogus')).toBeUndefined();
   });
 });

--- a/utils/src/variables.utils.ts
+++ b/utils/src/variables.utils.ts
@@ -373,8 +373,11 @@ export function getSchemaAtPath(
         currentSchema = currentSchema.items as TSchema;
         continue;
       }
-      // Numeric index provided but schema is not an array or has no items
-      return undefined;
+      // Numeric index provided but schema is not an array. Group chat prompts
+      // access participant variables as arrays indexed by participant
+      // position, so numeric indexing on a non-array is allowed here (e.g.
+      // `treatmentGroup_1.0.price`).
+      continue;
     }
 
     // 2. Handle Object Properties


### PR DESCRIPTION
Allows mediators to access participant variables. For example, a mediator can know the experimental condition of the participant so that it can write in a different style, or a mediator can know the topic that the participant is assigned to discuss.

In a private chat, the participant's variables are directly exposed (e.g., `treatment`). In a group chat, participant variables are exposed as an array (e.g., `treatment.0` for the first participant). The order is human-first if there are human and AI participants. These can be included in prompts with the standard `{{treatment.0}}` formatting.

For example, in the following example, a mediator in private chat sees the topic variable to which this participant has been randomly assigned. This allows it to ask about the topic in its first message instead of needing the participant to send a message that states the topic.

<img width="1087" height="988" alt="mediator-access-participant-variables-example" src="https://github.com/user-attachments/assets/867416ea-44a1-4455-a389-ca3c729f5cd8" />
