### PR TITLE
feat: the participant is quizzed periodically during a group chat

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -741,6 +741,14 @@
         },
         "additionalParticipantInstructions": {
           "type": "string"
+        },
+        "minNumberOfMessages": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "maxNumberOfMessages": {
+          "minimum": 1,
+          "type": ["integer", "null"]
         }
       }
     },
@@ -3969,6 +3977,14 @@
           "type": "boolean"
         },
         "maxResponses": {
+          "type": ["integer", "null"]
+        },
+        "maxNumberOfMessages": {
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "minNumberOfMessages": {
+          "minimum": 0,
           "type": ["integer", "null"]
         },
         "initialMessage": {

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -738,6 +738,9 @@
         },
         "personaPositionPrompt": {
           "type": "string"
+        },
+        "additionalParticipantInstructions": {
+          "type": "string"
         }
       }
     },

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1366,6 +1366,9 @@
         "isTurnBasedChat": {
           "type": "boolean"
         },
+        "isTurnBasedChatGroupStyle": {
+          "type": "boolean"
+        },
         "minNumberOfTurns": {
           "type": "number"
         },

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -735,6 +735,9 @@
         },
         "isTurnBased": {
           "type": "boolean"
+        },
+        "personaPositionPrompt": {
+          "type": "string"
         }
       }
     },
@@ -2515,6 +2518,10 @@
               "type": "null"
             }
           ]
+        },
+        "treatmentIndex": {
+          "minimum": 0,
+          "type": "integer"
         }
       }
     },
@@ -2838,6 +2845,9 @@
                 "$ref": "#/$defs/ChatParticipantInstructionsPromptItem"
               },
               {
+                "$ref": "#/$defs/OtherProfileContextsPromptItem"
+              },
+              {
                 "$ref": "#/$defs/PromptItemGroup"
               }
             ]
@@ -3089,6 +3099,36 @@
         }
       }
     },
+    "OtherProfileContextsPromptItem": {
+      "title": "OtherProfileContextsPromptItem",
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "OTHER_PROFILE_CONTEXTS",
+          "type": "string"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "title": "Condition",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ComparisonCondition"
+                },
+                {
+                  "$ref": "#/$defs/ConditionGroup"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
     "PromptItemGroup": {
       "title": "PromptItemGroup",
       "additionalProperties": false,
@@ -3123,6 +3163,9 @@
               },
               {
                 "$ref": "#/$defs/ChatParticipantInstructionsPromptItem"
+              },
+              {
+                "$ref": "#/$defs/OtherProfileContextsPromptItem"
               },
               {
                 "$ref": "#/$defs/PromptItemGroup"
@@ -4039,6 +4082,9 @@
               },
               {
                 "$ref": "#/$defs/ChatParticipantInstructionsPromptItem"
+              },
+              {
+                "$ref": "#/$defs/OtherProfileContextsPromptItem"
               },
               {
                 "$ref": "#/$defs/PromptItemGroup"

--- a/frontend/src/components/chat/chat_info_panel.scss
+++ b/frontend/src/components/chat/chat_info_panel.scss
@@ -4,6 +4,7 @@
 :host {
   @include common.flex-column;
   flex-shrink: 0;
+  height: 100%;
 }
 
 .top-layout {
@@ -20,6 +21,74 @@
   overflow-y: auto;
   padding: common.$main-content-padding;
   width: 240px;
+  height: 100%;
+  box-sizing: border-box;
+  position: relative; // anchor for the quiz overlay
+}
+
+// Quiz section: rendered below the stage description
+// in the left panel while the backend has paused the chat for the quiz.
+.quiz-section {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+  padding-top: common.$spacing-large;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+
+// Prominent paused heading.
+.quiz-paused {
+  @include typescale.title-medium;
+  font-weight: 700;
+  color: var(--md-sys-color-primary);
+}
+
+.quiz-question {
+  @include typescale.body-small;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+// 7-point Likert laid out top-to-bottom.
+.quiz-likert {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+}
+
+.likert-option {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-medium;
+  cursor: pointer;
+  text-align: left;
+  padding: common.$spacing-small common.$spacing-medium;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-medium;
+  background: var(--md-sys-color-surface-container);
+  color: inherit;
+
+  &.selected {
+    border-color: var(--md-sys-color-primary);
+    background: var(--md-sys-color-primary-container);
+  }
+}
+
+.likert-value {
+  @include typescale.label-medium;
+  flex-shrink: 0;
+  font-weight: 700;
+  min-width: 16px;
+}
+
+.likert-label {
+  @include typescale.label-medium;
+}
+
+// Larger multi-line answer box (enough for a short paragraph).
+.quiz-textarea::part(textarea) {
+  min-height: 120px;
+}
+
+.quiz-submit-btn {
+  align-self: flex-end;
 }
 
 .panel-item {
@@ -102,4 +171,12 @@
 .chip {
   @include typescale.label-small;
   @include common.chip;
+}
+
+.scrollable-content {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+  overflow-y: auto;
+  max-height: 70%;
+  flex-shrink: 0;
 }

--- a/frontend/src/components/chat/chat_info_panel.scss
+++ b/frontend/src/components/chat/chat_info_panel.scss
@@ -48,6 +48,12 @@
   color: var(--md-sys-color-on-surface);
 }
 
+// The note after the question is part of the same line, in normal weight so
+// the question itself still reads as the bold part.
+.quiz-note {
+  font-weight: 400;
+}
+
 // 7-point Likert laid out top-to-bottom.
 .quiz-likert {
   @include common.flex-column;

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -19,11 +19,16 @@ import {
   ChatStagePublicData,
   MediatorProfile,
   ParticipantProfile,
+  ParticipantProfileExtended,
   convertUnifiedTimestampToTime,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {getChatStartTimestamp} from '../../shared/stage.utils';
-import {getHashBasedColor} from '../../shared/utils';
+import {
+  getHashBasedColor,
+  variableAssignmentsIncludeObserver,
+  MEDIATOR_OBSERVER_COLOR,
+} from '../../shared/utils';
 import {styles} from './chat_info_panel.scss';
 
 /** Chat panel view with stage info, timer, participants. */
@@ -39,6 +44,15 @@ export class ChatPanel extends MobxLitElement {
   @property() stage: ChatStageConfig | null = null;
   @property({type: Boolean}) topLayout = false;
   @state() isStatusLoading = false;
+
+  // Observer-specific avatar coloring (mediators shown blue; that blue
+  // reserved away from other participants) only applies when the experiment
+  // assigns the `_isObserver` treatment variable.
+  private get reserveMediatorColor(): boolean {
+    return variableAssignmentsIncludeObserver(
+      this.cohortService.activeParticipants,
+    );
+  }
 
   override render() {
     if (!this.stage) {
@@ -112,7 +126,16 @@ export class ChatPanel extends MobxLitElement {
   }
 
   private renderParticipantList(topLayout = false) {
-    const activeParticipants = this.cohortService.activeParticipants;
+    const activeParticipants = this.cohortService.activeParticipants.filter(
+      // Inactive personas supply stored content to agents and never appear
+      // in the chat, so exclude them from the roster too. The map is
+      // populated from the full participant docs (see cohort.service), so
+      // agentConfig is present at runtime even though the static type is the
+      // public ParticipantProfile.
+      (p) =>
+        !p.isObserver &&
+        !(p as ParticipantProfileExtended).agentConfig?.isInactivePersona,
+    );
     const mediators = this.cohortService.getMediatorsForStage(
       this.stage?.id ?? '',
     );
@@ -158,7 +181,9 @@ export class ChatPanel extends MobxLitElement {
         <div class="profile">
           <profile-display
             .profile=${profile}
-            .color=${getHashBasedColor(profile.publicId ?? '')}
+            .color=${this.reserveMediatorColor
+              ? MEDIATOR_OBSERVER_COLOR
+              : getHashBasedColor(profile.publicId ?? '')}
             displayType=${small ? 'chatSmall' : 'chat'}
           >
           </profile-display>
@@ -177,6 +202,9 @@ export class ChatPanel extends MobxLitElement {
         <participant-profile-display
           .profile=${profile}
           .showIsSelf=${isCurrent}
+          .excludeColors=${this.reserveMediatorColor
+            ? [MEDIATOR_OBSERVER_COLOR]
+            : []}
           displayType=${small ? 'chatSmall' : 'chat'}
         >
         </participant-profile-display>

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -1,5 +1,7 @@
 import '../../pair-components/icon_button';
 import '../../pair-components/tooltip';
+import '../../pair-components/textarea';
+import '../../pair-components/button';
 import '../participant_profile/avatar_icon';
 import '../participant_profile/profile_display';
 import '../stages/stage_description';
@@ -31,6 +33,19 @@ import {
 } from '../../shared/utils';
 import {styles} from './chat_info_panel.scss';
 
+// 7-point Likert scale (top-to-bottom), most to least positive (so "like" is
+// at the top). The stored value (1-7) is unchanged; only the display order is
+// reversed.
+const QUIZ_LIKERT_OPTIONS: {value: number; label: string}[] = [
+  {value: 7, label: 'Strongly like'},
+  {value: 6, label: 'Like'},
+  {value: 5, label: 'Somewhat like'},
+  {value: 4, label: 'Neutral'},
+  {value: 3, label: 'Somewhat dislike'},
+  {value: 2, label: 'Dislike'},
+  {value: 1, label: 'Strongly dislike'},
+];
+
 /** Chat panel view with stage info, timer, participants. */
 @customElement('chat-info-panel')
 export class ChatPanel extends MobxLitElement {
@@ -54,21 +69,63 @@ export class ChatPanel extends MobxLitElement {
     );
   }
 
+  // Quiz state.
+  // Selected 7-point Likert value (1-7), or null if unselected.
+  @state() private quizRating: number | null = null;
+  // Highest quiz checkpoint the participant has already answered. The backend
+  // publishes the authoritative pause checkpoint (quizPauseCheckpoint); the
+  // popup shows whenever it leads this local answered count.
+  @state() private quizAnsweredCheckpoint = 0;
+
+  // Backend-authoritative pause checkpoint for this stage (0 = not paused).
+  private get quizPauseCheckpoint(): number {
+    if (!this.stage) return 0;
+    const publicData = this.cohortService.stagePublicDataMap[this.stage.id] as
+      | ChatStagePublicData
+      | undefined;
+    return publicData?.quizPauseCheckpoint ?? 0;
+  }
+
+  // The quiz shows whenever the backend has paused the chat at a checkpoint
+  // the participant has not yet answered. The backend pause is authoritative,
+  // so the popup can never outrun the participant (the "2nd submit does
+  // nothing" bug): each pause raises quizPauseCheckpoint by exactly one.
+  private get showQuiz(): boolean {
+    return (
+      this.participantService.profile?.isQuizzed === true &&
+      this.quizPauseCheckpoint > this.quizAnsweredCheckpoint
+    );
+  }
+
   override render() {
     if (!this.stage) {
       return nothing;
     }
 
     if (this.topLayout) {
+      // The narrow layout has no side panel, so the quiz renders here, above
+      // the roster. Otherwise a paused chat would have no answerable quiz.
       return html`
-        <div class="top-layout">${this.renderParticipantList(true)}</div>
+        <div class="top-layout">
+          ${this.showQuiz ? this.renderQuiz() : nothing}
+          ${this.renderParticipantList(true)}
+        </div>
       `;
     }
+
+    const showQuiz = this.showQuiz;
+    // When an observer is present in the cohort, participant labels gain a
+    // "(yours)" suffix and representative agent names get long, so widen the
+    // panel to accommodate them.
+    const observerPresent = this.cohortService.activeParticipants.some(
+      (p) => p.isObserver,
+    );
 
     return html`
       <div class="side-layout">
         <stage-description .stage=${this.stage} noPadding> </stage-description>
-        ${this.renderTimer()} ${this.renderParticipantList()}
+        ${showQuiz ? this.renderQuiz() : nothing} ${this.renderTimer()}
+        ${this.renderParticipantList()}
       </div>
     `;
   }
@@ -210,6 +267,117 @@ export class ChatPanel extends MobxLitElement {
         </participant-profile-display>
       </div>
     `;
+  }
+
+  private setQuizRating(rating: number) {
+    this.quizRating = rating;
+  }
+
+  private async submitQuiz() {
+    if (this.quizRating === null) return;
+    const rating = this.quizRating;
+    const checkpoint = this.quizPauseCheckpoint;
+    const text = this.participantService.quizText.trim();
+    // Pass the backend's current pause checkpoint so the endpoint clears it and
+    // resumes the stalled turn; the Likert value is saved as a structured field.
+    await this.participantService.submitParticipantThought(
+      text,
+      checkpoint,
+      rating,
+    );
+    // Advance exactly one checkpoint so no quiz is ever skipped; the form resets
+    // (submitParticipantThought clears quizText).
+    this.quizAnsweredCheckpoint = this.quizAnsweredCheckpoint + 1;
+    this.quizRating = null;
+  }
+
+  // Submit the quiz on Enter (Shift+Enter still inserts a newline) once the
+  // Likert rating and a non-empty answer are both present, matching the submit
+  // button's enabled state. keydown is composed, so it reaches this host
+  // listener from the inner <textarea>; quizText is already current
+  // because pr-textarea fires change on every input.
+  private onQuizKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Enter' || e.shiftKey) return;
+    const text = this.participantService.quizText.trim();
+    const canSubmit =
+      this.quizRating !== null &&
+      text !== '' &&
+      !this.participantService.isSubmittingThought;
+    if (!canSubmit) return;
+    e.preventDefault();
+    this.submitQuiz();
+  }
+
+  // Tracks the pause checkpoint the form was last reset for, so a new pause
+  // clears any stale rating/text from the previous quiz.
+  private lastResetPauseCheckpoint = 0;
+
+  override willUpdate() {
+    const pause = this.quizPauseCheckpoint;
+    if (pause > this.lastResetPauseCheckpoint) {
+      this.lastResetPauseCheckpoint = pause;
+      this.quizRating = null;
+      this.participantService.setQuizText('');
+    }
+  }
+
+  private renderQuiz() {
+    const text = this.participantService.quizText;
+    const isSubmitting = this.participantService.isSubmittingThought;
+    const canSubmit =
+      this.quizRating !== null && text.trim() !== '' && !isSubmitting;
+    const quizQuestion = 'Do you like the process so far?';
+    return html`
+      <div class="quiz-section">
+        <div class="quiz-question">${quizQuestion}</div>
+        <div class="quiz-likert">
+          ${QUIZ_LIKERT_OPTIONS.map(
+            (option) => html`
+              <button
+                type="button"
+                class="likert-option ${this.quizRating === option.value
+                  ? 'selected'
+                  : ''}"
+                aria-label=${option.label}
+                @click=${() => this.setQuizRating(option.value)}
+              >
+                <span class="likert-label">${option.label}</span>
+              </button>
+            `,
+          )}
+        </div>
+        <div class="quiz-question">
+          In one sentence, describe what you like or dislike.
+        </div>
+        <pr-textarea
+          size="small"
+          variant="outlined"
+          .rows=${6}
+          placeholder="Type your answer here..."
+          .value=${text}
+          ?disabled=${isSubmitting}
+          ?focused=${true}
+          @change=${this.onQuizTextChange}
+          @keydown=${this.onQuizKeydown}
+          class="quiz-textarea"
+        >
+        </pr-textarea>
+        <pr-button
+          size="small"
+          variant="tonal"
+          ?disabled=${!canSubmit}
+          ?loading=${isSubmitting}
+          @click=${() => this.submitQuiz()}
+          class="quiz-submit-btn"
+        >
+          Submit
+        </pr-button>
+      </div>
+    `;
+  }
+
+  private onQuizTextChange(e: CustomEvent) {
+    this.participantService.setQuizText(e.detail.value);
   }
 }
 

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -282,11 +282,15 @@ export class ChatPanel extends MobxLitElement {
     const text = this.participantService.quizText.trim();
     // Pass the backend's current pause checkpoint so the endpoint clears it and
     // resumes the stalled turn; the Likert value is saved as a structured field.
-    await this.participantService.submitParticipantThought(
+    const response = await this.participantService.submitParticipantThought(
       text,
       checkpoint,
       rating,
     );
+    // A submission that did not reach the backend leaves the chat paused, so
+    // the quiz has to stay on screen: counting it as answered would hide the
+    // form with nothing to resume the discussion.
+    if (!response?.success) return;
     // Advance exactly one checkpoint so no quiz is ever skipped; the form resets
     // (submitParticipantThought clears quizText).
     this.quizAnsweredCheckpoint = this.quizAnsweredCheckpoint + 1;

--- a/frontend/src/components/chat/chat_info_panel.ts
+++ b/frontend/src/components/chat/chat_info_panel.ts
@@ -332,10 +332,14 @@ export class ChatPanel extends MobxLitElement {
     const isSubmitting = this.participantService.isSubmittingThought;
     const canSubmit =
       this.quizRating !== null && text.trim() !== '' && !isSubmitting;
-    const quizQuestion = 'Do you like the process so far?';
     return html`
       <div class="quiz-section">
-        <div class="quiz-question">${quizQuestion}</div>
+        <div class="quiz-question">
+          Do you like the process so far?
+          <span class="quiz-note"
+            >Your responses will not be a part of this discussion.</span
+          >
+        </div>
         <div class="quiz-likert">
           ${QUIZ_LIKERT_OPTIONS.map(
             (option) => html`

--- a/frontend/src/components/chat/chat_input.ts
+++ b/frontend/src/components/chat/chat_input.ts
@@ -8,6 +8,8 @@ import {ParticipantAnswerService} from '../../services/participant.answer';
 import {ParticipantService} from '../../services/participant.service';
 import {ExperimentService} from '../../services/experiment.service';
 
+import {StageKind} from '@deliberation-lab/utils';
+
 import {styles} from './chat_input.scss';
 
 /** Chat input component */
@@ -38,6 +40,7 @@ export class ChatInputComponent extends MobxLitElement {
   };
   @property() isDisabled = false;
   @property() isLoading = false;
+  @property() isTurnBased = false;
   @state() hasFocusedOnce = false;
 
   override render() {
@@ -80,11 +83,19 @@ export class ChatInputComponent extends MobxLitElement {
       return true;
     };
 
+    const stage = this.experimentService.getStage(this.stageId);
+    const isPrivateChat = stage?.kind === StageKind.PRIVATE_CHAT;
+    const isObserver =
+      !isPrivateChat && this.participantService.profile?.isObserver === true;
+    const placeholderText = isObserver
+      ? 'You are observing this discussion and cannot send messages.'
+      : 'Send message';
+
     return html`
       <div class="input ${this.isDisabled ? 'disabled' : ''}">
         <pr-textarea
           size="small"
-          placeholder="Send message"
+          placeholder=${placeholderText}
           .value=${this.getUserInput()}
           ?focused=${shouldFocus()}
           ?disabled=${this.isDisabled}
@@ -94,7 +105,7 @@ export class ChatInputComponent extends MobxLitElement {
         >
         </pr-textarea>
         <pr-tooltip
-          text="Send message"
+          text=${placeholderText}
           color="tertiary"
           variant="outlined"
           position="TOP_END"

--- a/frontend/src/components/chat/chat_input.ts
+++ b/frontend/src/components/chat/chat_input.ts
@@ -1,6 +1,6 @@
 import {MobxLitElement} from '@adobe/lit-mobx';
 
-import {CSSResultGroup, html} from 'lit';
+import {CSSResultGroup, html, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
@@ -42,6 +42,37 @@ export class ChatInputComponent extends MobxLitElement {
   @property() isLoading = false;
   @property() isTurnBased = false;
   @state() hasFocusedOnce = false;
+
+  // In turn-based chat the input is disabled between turns. When it becomes
+  // enabled again (this participant's turn), move the cursor into the box so
+  // they can type immediately. Skip touch devices, where focusing would force
+  // the on-screen keyboard up every turn, and use preventScroll so re-focusing
+  // does not jump the chat layout if the participant has scrolled up.
+  override updated(changedProperties: PropertyValues) {
+    if (
+      this.isTurnBased &&
+      changedProperties.has('isDisabled') &&
+      !this.isDisabled &&
+      navigator.maxTouchPoints === 0
+    ) {
+      const prTextarea = this.renderRoot.querySelector('pr-textarea') as
+        | (Element & {
+            renderRoot?: ParentNode;
+            updateComplete?: Promise<unknown>;
+          })
+        | null;
+      // The child pr-textarea re-renders asynchronously, so at this point its
+      // inner <textarea> still has the disabled attribute and focus() would be
+      // a no-op. Wait for the child's update to commit (disabled cleared)
+      // before focusing.
+      void prTextarea?.updateComplete?.then(() => {
+        const textarea = prTextarea?.renderRoot?.querySelector(
+          '#textarea',
+        ) as HTMLElement | null;
+        textarea?.focus({preventScroll: true});
+      });
+    }
+  }
 
   override render() {
     const sendInput = async () => {

--- a/frontend/src/components/chat/chat_interface.scss
+++ b/frontend/src/components/chat/chat_interface.scss
@@ -138,6 +138,15 @@ chat-input {
   }
 }
 
+// Mediator typing indicator matches the mediator's blue bubble + dots.
+.typing-bubble.mediator {
+  background: var(--md-sys-color-mediator-container);
+}
+
+.typing-bubble.mediator .typing-dots span {
+  background-color: var(--md-sys-color-on-mediator-container);
+}
+
 @keyframes typingBlink {
   0% {
     opacity: 0.4;

--- a/frontend/src/components/chat/chat_interface.scss
+++ b/frontend/src/components/chat/chat_interface.scss
@@ -63,8 +63,16 @@ chat-input {
 
 .banner {
   @include typescale.label-large;
+  // All variants share a 1px border so the box's outer height is identical
+  // across success/warning/placeholder; only the border colour changes. This
+  // keeps the chat content above from shifting when the variant swaps (e.g.
+  // success → placeholder → warning during a turn transition).
+  border: 1px solid transparent;
   border-radius: 8px;
-  margin: common.$spacing-medium common.$spacing-xl;
+  // The banner always spans the full width of the text entry box: its
+  // horizontal insets match the chat input's padding ($main-content-padding) so
+  // the two align in any window size, rather than reading as a centered chip.
+  margin: common.$spacing-medium common.$main-content-padding;
   padding: common.$spacing-medium common.$spacing-large;
   text-align: center;
 
@@ -76,9 +84,16 @@ chat-input {
 
   &.warning {
     background: #fef9e7;
-    border: 1px solid #f7dc6f;
+    border-color: #f7dc6f;
     color: #7d6608; // High-contrast dark yellow readable on pale yellow
     font-weight: 500;
+  }
+
+  // Reserves the banner's vertical space during transient turn transitions
+  // so the chat content above does not shift up or down between turns.
+  &.banner-placeholder {
+    background: transparent;
+    color: transparent;
   }
 }
 

--- a/frontend/src/components/chat/chat_interface.scss
+++ b/frontend/src/components/chat/chat_interface.scss
@@ -95,6 +95,31 @@ chat-input {
     background: transparent;
     color: transparent;
   }
+
+  // Setup banner: spinner + text on one centered row, so it's visually clear
+  // that work is in progress while the group chat is being set up.
+  &.setup-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: common.$spacing-small;
+  }
+}
+
+.setup-spinner {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border: 2px solid rgba(125, 102, 8, 0.25); // faded warning text color
+  border-top-color: #7d6608; // matches the warning text color
+  border-radius: 50%;
+  animation: setupSpin 0.8s linear infinite;
+}
+
+@keyframes setupSpin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .typing-msg {

--- a/frontend/src/components/chat/chat_interface.scss
+++ b/frontend/src/components/chat/chat_interface.scss
@@ -89,6 +89,16 @@ chat-input {
     font-weight: 500;
   }
 
+  // Quiz pause: a hard stop, shown in a dark blue banner (a deeper shade of the
+  // mediator blue) so the participant notices the chat is held and answers the
+  // questions on the left.
+  &.paused {
+    background: var(--md-sys-color-on-mediator-container, #00174c);
+    border-color: var(--md-sys-color-on-mediator-container, #00174c);
+    color: #ffffff;
+    font-weight: 600;
+  }
+
   // Reserves the banner's vertical space during transient turn transitions
   // so the chat content above does not shift up or down between turns.
   &.banner-placeholder {

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -68,6 +68,14 @@ export class ChatInterface extends MobxLitElement {
   // Tracks inner width of window
   @state() mobileView = false;
 
+  // "Setting up the group chat..." banner shown while agent participants /
+  // personas are still being generated (before the first turn or message),
+  // held for at least 1 second once it appears. While it shows it takes the
+  // place of the turn banner and suppresses the typing dots.
+  @state() private sawSetup = false;
+  @state() private minSetupTimePassed = false;
+  private setupTimer: number | undefined;
+
   private updateResponsiveState = () => {
     this.mobileView = window.innerWidth <= 1024;
   };
@@ -81,6 +89,58 @@ export class ChatInterface extends MobxLitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('resize', this.updateResponsiveState);
+    if (this.setupTimer !== undefined) {
+      clearTimeout(this.setupTimer);
+      this.setupTimer = undefined;
+    }
+  }
+
+  override updated() {
+    // Once the chat data has loaded but the chat isn't ready yet (agents /
+    // personas still generating), start the minimum-display timer so the
+    // banner stays up for at least 1s even if setup finishes sooner.
+    if (
+      !this.sawSetup &&
+      this.isGroupChat &&
+      !this.cohortService.isChatLoading &&
+      !this.isChatReady
+    ) {
+      this.sawSetup = true;
+      this.setupTimer = window.setTimeout(() => {
+        this.minSetupTimePassed = true;
+      }, 1000);
+    }
+  }
+
+  private get isGroupChat(): boolean {
+    return this.stage?.kind === StageKind.CHAT;
+  }
+
+  /** Whether the group chat has started: a turn is assigned or a message
+   *  exists. Before this, agent participants/personas may still be generating. */
+  private get isChatReady(): boolean {
+    const stageId = this.stage?.id ?? '';
+    if (!stageId) return false;
+    const data = this.cohortService.stagePublicDataMap[stageId] as
+      | ChatStagePublicData
+      | undefined;
+    if (data?.currentTurnParticipantId) return true;
+    if ((this.cohortService.chatMap[stageId] ?? []).length > 0) return true;
+    const discussionMap = this.cohortService.chatDiscussionMap[stageId];
+    return Boolean(
+      discussionMap &&
+      Object.values(discussionMap).some((messages) => messages.length > 0),
+    );
+  }
+
+  /** Show the yellow setup banner while a group chat is being set up, holding
+   *  it for at least 1s once it appears. While shown it replaces the turn
+   *  banner and the typing dots are suppressed. */
+  private get showSetupBanner(): boolean {
+    if (!this.isGroupChat) return false;
+    if (this.cohortService.isChatLoading) return false;
+    if (!this.isChatReady) return true;
+    return this.sawSetup && !this.minSetupTimePassed;
   }
 
   private renderPanel() {
@@ -321,6 +381,9 @@ export class ChatInterface extends MobxLitElement {
   private renderTypingIndicator() {
     if (this.externalConversationOver || this.isConversationOver)
       return nothing;
+    // While the setup banner is showing, suppress the typing dots even if a
+    // turn has just been assigned.
+    if (this.showSetupBanner) return nothing;
     const turnState = this.turnIndicatorState;
     if (!turnState) return nothing;
 
@@ -414,6 +477,17 @@ export class ChatInterface extends MobxLitElement {
       }
       return nothing;
     }
+    // The setup banner occupies the same slot as the turn banner and takes
+    // precedence: while it shows, the "Waiting for ..." banner does not.
+    if (this.showSetupBanner) {
+      return html`
+        <div class="banner warning setup-banner">
+          <span class="setup-spinner" aria-hidden="true"></span>
+          <span>Setting up the group chat...</span>
+        </div>
+      `;
+    }
+
     const turnState = this.turnIndicatorState;
     if (!turnState) {
       // Keep an empty banner element in the DOM during transient turn-

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -184,13 +184,15 @@ export class ChatInterface extends MobxLitElement {
     const data = this.stagePublicData;
     if (!data || !data.currentTurnParticipantId) return null;
 
-    // If the latest message is already from the current turn holder, the
-    // backend has not advanced the turn yet. Hide the turn indicator so the
-    // holder's input stays disabled (the placeholder banner keeps the layout
-    // steady) until the turn switches to the next holder all at once.
-    const messages = this.cohortService.chatMap[this.stage.id] ?? [];
+    // The backend stamps turnProcessedMessageId once its turn logic has
+    // handled a message. Until the newest participant or mediator message is
+    // stamped, the holder in the public data is stale, so hide the indicator
+    // and disable input.
+    const messages = (this.cohortService.chatMap[this.stage.id] ?? []).filter(
+      (m) => m.type !== UserType.SYSTEM && m.type !== UserType.EXPERIMENTER,
+    );
     const latest = messages[messages.length - 1];
-    if (latest?.senderId === data.currentTurnParticipantId) return null;
+    if (latest && latest.id !== data.turnProcessedMessageId) return null;
 
     return this.buildGroupChatTurnState(data.currentTurnParticipantId);
   }

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -143,6 +143,18 @@ export class ChatInterface extends MobxLitElement {
     return this.sawSetup && !this.minSetupTimePassed;
   }
 
+  /** Whether the group chat is paused for a quiz checkpoint. While paused, a
+   *  banner replaces the turn banner and the typing dots are suppressed, since
+   *  the turn is held and no agent is typing. */
+  private get isPausedForQuiz(): boolean {
+    const stageId = this.stage?.id ?? '';
+    if (!stageId) return false;
+    const data = this.cohortService.stagePublicDataMap[stageId] as
+      | ChatStagePublicData
+      | undefined;
+    return (data?.quizPauseCheckpoint ?? 0) > 0;
+  }
+
   private renderPanel() {
     if (!this.stage) return nothing;
     return html`
@@ -386,6 +398,9 @@ export class ChatInterface extends MobxLitElement {
     // While the setup banner is showing, suppress the typing dots even if a
     // turn has just been assigned.
     if (this.showSetupBanner) return nothing;
+    // While paused for a quiz, the turn is held by the backend
+    // and no agent is typing, so suppress the typing dots.
+    if (this.isPausedForQuiz) return nothing;
     const turnState = this.turnIndicatorState;
     if (!turnState) return nothing;
 
@@ -465,6 +480,23 @@ export class ChatInterface extends MobxLitElement {
   }
 
   private renderTurnBanner() {
+    // A quiz pause takes precedence over every other banner, including the
+    // conversation-over case below, so a final quiz still pending after the
+    // last message keeps showing its banner instead of the "ended" prompt.
+    // quizPauseCheckpoint is only ever set for a quiz, so non-quiz chats are
+    // unaffected. When the discussion has also ended, the banner says "ended"
+    // (not "paused"); both direct the participant to the questions on the left.
+    if (this.isPausedForQuiz) {
+      const ended = this.externalConversationOver || this.isConversationOver;
+      const where = this.mobileView ? 'above' : 'on the left';
+      return html`
+        <div class="banner paused">
+          ${ended
+            ? `The discussion has ended. Please answer the questions ${where}.`
+            : `The conversation is paused. Please answer the questions ${where}.`}
+        </div>
+      `;
+    }
     if (this.externalConversationOver || this.isConversationOver) {
       // Every turn-based chat (group or private) shows the ended banner as its
       // single end-of-discussion indicator; the duplicate in-chat system message

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -10,8 +10,10 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {
   ChatStageConfig,
   ChatStagePublicData,
+  PrivateChatStageConfig,
   StageConfig,
   StageKind,
+  UserType,
 } from '@deliberation-lab/utils';
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
@@ -48,6 +50,14 @@ export class ChatInterface extends MobxLitElement {
   @property({type: Boolean}) showPanel = false;
   @property({type: Boolean}) showInput = true;
   @property({type: Boolean}) disableInput = false;
+  // For a representative-conducted private chat: the rep's display identity
+  // (name, avatar, the observer's color) so the representative shows
+  // consistently before/after its first message and matches the group chat.
+  @property({type: Object}) repPrivateChatProfile: {
+    name: string;
+    avatar: string;
+    color: string;
+  } | null = null;
 
   // Tracks inner width of window
   @state() mobileView = false;
@@ -83,7 +93,13 @@ export class ChatInterface extends MobxLitElement {
   }
 
   @computed get isMyTurn() {
-    if (!this.stage || this.stage.kind !== StageKind.CHAT) return true;
+    if (!this.stage) return true;
+    if (this.stage.kind === StageKind.PRIVATE_CHAT) {
+      const config = this.stage as PrivateChatStageConfig;
+      if (!config.isTurnBasedChatGroupStyle) return true;
+      return this.turnIndicatorState?.isMyTurn ?? false;
+    }
+    if (this.stage.kind !== StageKind.CHAT) return true;
     const config = this.stage as ChatStageConfig;
     if (!config.isTurnBased) return true;
 
@@ -91,7 +107,11 @@ export class ChatInterface extends MobxLitElement {
   }
 
   @computed get turnIndicatorState() {
-    if (!this.stage || this.stage.kind !== StageKind.CHAT) return null;
+    if (!this.stage) return null;
+    if (this.stage.kind === StageKind.PRIVATE_CHAT) {
+      return this.privateChatTurnIndicatorState;
+    }
+    if (this.stage.kind !== StageKind.CHAT) return null;
     const config = this.stage as ChatStageConfig;
     if (!config.isTurnBased) return null;
 
@@ -148,10 +168,75 @@ export class ChatInterface extends MobxLitElement {
   /** Whether the current stage is configured for turn-based interaction. */
   @computed get isTurnBasedMode() {
     if (!this.stage) return false;
+    if (this.stage.kind === StageKind.PRIVATE_CHAT) {
+      return (
+        (this.stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle ??
+        false
+      );
+    }
     if (this.stage.kind === StageKind.CHAT) {
       return (this.stage as ChatStageConfig).isTurnBased ?? false;
     }
     return false;
+  }
+
+  @computed private get privateChatTurnIndicatorState() {
+    if (!this.stage || this.stage.kind !== StageKind.PRIVATE_CHAT) return null;
+    const config = this.stage as PrivateChatStageConfig;
+    if (!config.isTurnBasedChatGroupStyle) return null;
+
+    // Private chats have no public turn state, so the turn holder is
+    // inferred from the latest message: the mediator speaks first and turns
+    // alternate. An error message from the mediator counts as its turn so
+    // the participant can retry.
+    const messages =
+      this.participantService.privateChatMap[this.stage.id] ?? [];
+    const publicId = this.participantService.profile?.publicId ?? '';
+    const latest = messages[messages.length - 1];
+    // Match the group-chat path: agent participants never see "Your turn",
+    // since the agent doesn't drive the participant UI's chat input.
+    const isMyTurn =
+      !this.participantService.profile?.agentConfig &&
+      !!latest &&
+      latest.senderId !== publicId;
+
+    if (isMyTurn) {
+      const profile = this.participantService.profile;
+      return {
+        name: profile?.name ?? '',
+        avatar: profile?.avatar ?? '',
+        isMediator: false,
+        id: publicId,
+        isMyTurn: true,
+      };
+    }
+
+    const lastMediatorMsg = [...messages]
+      .reverse()
+      .find((m) => m.type === UserType.MEDIATOR);
+    const assignedMediator = this.cohortService.getMediatorsForStage(
+      this.stage.id,
+    )[0];
+
+    // In a representative-conducted private chat, show the represented
+    // participant's identity (and color) consistently, matching the group chat.
+    const rep = this.repPrivateChatProfile;
+    return {
+      name:
+        rep?.name ??
+        lastMediatorMsg?.profile?.name ??
+        assignedMediator?.name ??
+        'Mediator',
+      avatar:
+        rep?.avatar ??
+        lastMediatorMsg?.profile?.avatar ??
+        assignedMediator?.avatar ??
+        '🤖',
+      color: rep?.color,
+      isMediator: true,
+      id: lastMediatorMsg?.senderId ?? assignedMediator?.publicId ?? 'mediator',
+      isMyTurn: false,
+    };
   }
 
   // True when the given turn-holder id is the viewing participant or their
@@ -171,19 +256,22 @@ export class ChatInterface extends MobxLitElement {
     if (turnState.isMyTurn) return nothing;
 
     const reserve = this.reserveMediatorColor;
+    const repColor = (turnState as {color?: string}).color;
     // The mediator's typing indicator uses the same reserved blue as its
-    // avatar/bubble; other speakers keep their own color (with blue reserved
-    // away).
-    const useMediatorColor = reserve && turnState.isMediator;
-    const color = turnState.isMediator
-      ? useMediatorColor
-        ? MEDIATOR_OBSERVER_COLOR
-        : getHashBasedColor(turnState.id)
-      : getProfileBasedColor(
-          turnState.id,
-          turnState.avatar ?? '',
-          reserve ? [MEDIATOR_OBSERVER_COLOR] : [],
-        );
+    // avatar/bubble; a representative keeps its assigned color, and other
+    // speakers keep their own color (with blue reserved away).
+    const useMediatorColor = !repColor && reserve && turnState.isMediator;
+    const color =
+      repColor ??
+      (turnState.isMediator
+        ? useMediatorColor
+          ? MEDIATOR_OBSERVER_COLOR
+          : getHashBasedColor(turnState.id)
+        : getProfileBasedColor(
+            turnState.id,
+            turnState.avatar ?? '',
+            reserve ? [MEDIATOR_OBSERVER_COLOR] : [],
+          ));
 
     const ownSide = this.isOwnSideTurn(turnState.id);
 

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -19,7 +19,12 @@ import {CohortService} from '../../services/cohort.service';
 import {ParticipantService} from '../../services/participant.service';
 
 import {styles} from './chat_interface.scss';
-import {getHashBasedColor, getProfileBasedColor} from '../../shared/utils';
+import {
+  getHashBasedColor,
+  getProfileBasedColor,
+  variableAssignmentsIncludeObserver,
+  MEDIATOR_OBSERVER_COLOR,
+} from '../../shared/utils';
 
 /** Chat interface component */
 @customElement('chat-interface')
@@ -29,6 +34,15 @@ export class ChatInterface extends MobxLitElement {
   private readonly cohortService = core.getService(CohortService);
   private readonly participantService = core.getService(ParticipantService);
   private readonly authService = core.getService(AuthService);
+
+  // When the experiment assigns the `_isObserver` treatment variable, the
+  // mediator is shown in blue (avatar, bubble, and typing indicator) and blue
+  // is reserved away from other speakers.
+  private get reserveMediatorColor(): boolean {
+    return variableAssignmentsIncludeObserver(
+      this.cohortService.activeParticipants,
+    );
+  }
 
   @property({type: Object}) stage: StageConfig | undefined = undefined;
   @property({type: Boolean}) showPanel = false;
@@ -130,6 +144,15 @@ export class ChatInterface extends MobxLitElement {
     };
   }
 
+  // True when the given turn-holder id is the viewing participant or their
+  // representative (publicId `${publicId}-agent`), so their typing indicator
+  // and name label sit on their own side of the chat, like their messages.
+  private isOwnSideTurn(id: string | undefined): boolean {
+    const myId = this.participantService.profile?.publicId;
+    if (!myId || !id) return false;
+    return id === myId || id === `${myId}-agent`;
+  }
+
   private renderTypingIndicator() {
     const turnState = this.turnIndicatorState;
     if (!turnState) return nothing;
@@ -137,16 +160,33 @@ export class ChatInterface extends MobxLitElement {
     // Do not show typing indicator if it is the current user's turn (they type in the textarea instead!)
     if (turnState.isMyTurn) return nothing;
 
+    const reserve = this.reserveMediatorColor;
+    // The mediator's typing indicator uses the same reserved blue as its
+    // avatar/bubble; other speakers keep their own color (with blue reserved
+    // away).
+    const useMediatorColor = reserve && turnState.isMediator;
     const color = turnState.isMediator
-      ? getHashBasedColor(turnState.id)
-      : getProfileBasedColor(turnState.id, turnState.avatar ?? '');
+      ? useMediatorColor
+        ? MEDIATOR_OBSERVER_COLOR
+        : getHashBasedColor(turnState.id)
+      : getProfileBasedColor(
+          turnState.id,
+          turnState.avatar ?? '',
+          reserve ? [MEDIATOR_OBSERVER_COLOR] : [],
+        );
+
+    const ownSide = this.isOwnSideTurn(turnState.id);
 
     return html`
-      <div class="chat-message typing-msg">
+      <div class="chat-message typing-msg ${ownSide ? 'current-user' : ''}">
         <avatar-icon .emoji=${turnState.avatar} .color=${color}> </avatar-icon>
         <div class="content">
           <div class="label">${turnState.name}</div>
-          <div class="chat-bubble typing-bubble">
+          <div
+            class="chat-bubble typing-bubble ${useMediatorColor
+              ? 'mediator'
+              : ''}"
+          >
             <div class="typing-dots">
               <span></span>
               <span></span>
@@ -182,6 +222,7 @@ export class ChatInterface extends MobxLitElement {
             : html`<chat-input
                 .stageId=${this.stage?.id ?? ''}
                 .isDisabled=${this.disableInput || !this.isMyTurn}
+                .isTurnBased=${this.isTurnBasedMode}
               ></chat-input>`}
         </div>
       </div>

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -14,6 +14,7 @@ import {
   StageConfig,
   StageKind,
   UserType,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
@@ -58,6 +59,11 @@ export class ChatInterface extends MobxLitElement {
     avatar: string;
     color: string;
   } | null = null;
+  // Set by a parent view (e.g. the private chat) that has its own notion of
+  // when the conversation is over, such as a response timeout the turn
+  // indicator here cannot see. When true, the turn banner and typing
+  // indicator hide so they do not contradict a conversation-ended message.
+  @property({type: Boolean}) externalConversationOver = false;
 
   // Tracks inner width of window
   @state() mobileView = false;
@@ -248,7 +254,73 @@ export class ChatInterface extends MobxLitElement {
     return id === myId || id === `${myId}-agent`;
   }
 
+  @computed get isConversationOver() {
+    if (!this.stage) return false;
+    if (this.stage.kind === StageKind.PRIVATE_CHAT) {
+      const chatMessages =
+        this.participantService.privateChatMap[this.stage.id] ?? [];
+      const publicId = this.participantService.profile?.publicId ?? '';
+      const participantMessageCount = chatMessages.filter(
+        (msg) => msg.senderId === publicId && !msg.isError,
+      ).length;
+
+      const maxTurns = (this.stage as PrivateChatStageConfig).maxNumberOfTurns;
+      const maxTurnsReached =
+        maxTurns !== null && participantMessageCount >= maxTurns;
+
+      const isWaitingForResponse =
+        chatMessages.length > 0 &&
+        chatMessages[chatMessages.length - 1].senderId === publicId;
+
+      const discussionStartTimestamp =
+        chatMessages.length > 0 ? chatMessages[0].timestamp : null;
+      const elapsedMinutes = discussionStartTimestamp
+        ? getTimeElapsed(discussionStartTimestamp, 'm')
+        : 0;
+      const maxTimeReached =
+        this.stage.timeLimitInMinutes !== null &&
+        this.stage.timeLimitInMinutes > 0 &&
+        elapsedMinutes >= this.stage.timeLimitInMinutes;
+
+      const minTurnsMet =
+        participantMessageCount >=
+        (this.stage as PrivateChatStageConfig).minNumberOfTurns;
+
+      return (
+        (maxTurnsReached && !isWaitingForResponse) ||
+        (maxTimeReached && minTurnsMet)
+      );
+    }
+
+    if (this.stage.kind === StageKind.CHAT) {
+      const stageData = this.cohortService.stagePublicDataMap[
+        this.stage.id
+      ] as ChatStagePublicData;
+      if (!stageData) return false;
+      if (stageData.discussionEndTimestamp) return true;
+      // Use the cap the backend actually enforces (a per-mediator override
+      // replaces the stage value), falling back to the stage value. Using the
+      // stage value directly would trip early when an override is higher,
+      // hiding the banner before the mediator's final message.
+      const max =
+        stageData.effectiveMaxNumberOfMessages ??
+        (this.stage as ChatStageConfig).maxNumberOfMessages;
+      if (max != null) {
+        const messages = this.cohortService.chatMap[this.stage.id] ?? [];
+        const count = messages.filter(
+          (m) => m.type !== UserType.SYSTEM && !m.isError,
+        ).length;
+        if (count >= max) return true;
+      }
+      return false;
+    }
+
+    return false;
+  }
+
   private renderTypingIndicator() {
+    if (this.externalConversationOver || this.isConversationOver)
+      return nothing;
     const turnState = this.turnIndicatorState;
     if (!turnState) return nothing;
 
@@ -328,6 +400,20 @@ export class ChatInterface extends MobxLitElement {
   }
 
   private renderTurnBanner() {
+    if (this.externalConversationOver || this.isConversationOver) {
+      // Every turn-based chat (group or private) shows the ended banner as its
+      // single end-of-discussion indicator; the duplicate in-chat system message
+      // is suppressed for turn-based chats (see group_chat_participant_view).
+      // Non-turn-based chats show no banner and keep the system message instead.
+      if (this.isTurnBasedMode) {
+        return html`
+          <div class="banner success">
+            The discussion has ended. Please proceed to the next stage.
+          </div>
+        `;
+      }
+      return nothing;
+    }
     const turnState = this.turnIndicatorState;
     if (!turnState) {
       // Keep an empty banner element in the DOM during transient turn-

--- a/frontend/src/components/chat/chat_interface.ts
+++ b/frontend/src/components/chat/chat_interface.ts
@@ -98,21 +98,23 @@ export class ChatInterface extends MobxLitElement {
     const data = this.stagePublicData;
     if (!data || !data.currentTurnParticipantId) return null;
 
-    const id = data.currentTurnParticipantId;
-
     // If the latest message is already from the current turn holder, the
-    // backend trigger hasn't advanced the turn yet — hide the indicator to
-    // avoid a stale "Waiting for X" flash immediately after X just spoke.
+    // backend has not advanced the turn yet. Hide the turn indicator so the
+    // holder's input stays disabled (the placeholder banner keeps the layout
+    // steady) until the turn switches to the next holder all at once.
     const messages = this.cohortService.chatMap[this.stage.id] ?? [];
     const latest = messages[messages.length - 1];
-    if (latest?.senderId === id) return null;
+    if (latest?.senderId === data.currentTurnParticipantId) return null;
 
+    return this.buildGroupChatTurnState(data.currentTurnParticipantId);
+  }
+
+  private buildGroupChatTurnState(id: string) {
     const isMyTurn =
       !this.participantService.profile?.agentConfig &&
       id === this.participantService.profile?.publicId;
 
-    const participantProfile =
-      this.cohortService.participantMap[data.currentTurnParticipantId];
+    const participantProfile = this.cohortService.participantMap[id];
     if (participantProfile && participantProfile.name) {
       return {
         name: participantProfile.name,
@@ -123,8 +125,7 @@ export class ChatInterface extends MobxLitElement {
       };
     }
 
-    const mediatorProfile =
-      this.cohortService.mediatorMap[data.currentTurnParticipantId];
+    const mediatorProfile = this.cohortService.mediatorMap[id];
     if (mediatorProfile && mediatorProfile.name) {
       return {
         name: mediatorProfile.name,
@@ -142,6 +143,15 @@ export class ChatInterface extends MobxLitElement {
       id,
       isMyTurn,
     };
+  }
+
+  /** Whether the current stage is configured for turn-based interaction. */
+  @computed get isTurnBasedMode() {
+    if (!this.stage) return false;
+    if (this.stage.kind === StageKind.CHAT) {
+      return (this.stage as ChatStageConfig).isTurnBased ?? false;
+    }
+    return false;
   }
 
   // True when the given turn-holder id is the viewing participant or their
@@ -231,7 +241,16 @@ export class ChatInterface extends MobxLitElement {
 
   private renderTurnBanner() {
     const turnState = this.turnIndicatorState;
-    if (!turnState) return nothing;
+    if (!turnState) {
+      // Keep an empty banner element in the DOM during transient turn-
+      // transitions (e.g., end-of-cycle wraps) so the chat content above
+      // does not shift up or down. The placeholder banner reserves the
+      // same vertical space as a real banner but renders no visible text.
+      if (this.isTurnBasedMode) {
+        return html`<div class="banner banner-placeholder">&nbsp;</div>`;
+      }
+      return nothing;
+    }
 
     if (turnState.isMyTurn) {
       return html` <div class="banner success">It's your turn to speak!</div> `;

--- a/frontend/src/components/chat/chat_message.scss
+++ b/frontend/src/components/chat/chat_message.scss
@@ -89,6 +89,14 @@ $bubble-width: 400px;
   }
 }
 
+// Mediator messages use a distinct (blue) bubble to set them apart from the
+// grey (secondary-container) participant bubbles. Declared after .chat-bubble
+// so it overrides the background/color at equal specificity.
+.mediator-bubble {
+  background: var(--md-sys-color-mediator-container);
+  color: var(--md-sys-color-on-mediator-container);
+}
+
 .current-user {
   flex-direction: row-reverse;
 

--- a/frontend/src/components/chat/chat_message.ts
+++ b/frontend/src/components/chat/chat_message.ts
@@ -12,6 +12,7 @@ import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
+import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
 import {ParticipantService} from '../../services/participant.service';
 
@@ -21,6 +22,8 @@ import {
   convertUnifiedTimestampToDate,
   getHashBasedColor,
   getProfileBasedColor,
+  variableAssignmentsIncludeObserver,
+  MEDIATOR_OBSERVER_COLOR,
 } from '../../shared/utils';
 
 import {styles} from './chat_message.scss';
@@ -31,11 +34,25 @@ export class ChatMessageComponent extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly authService = core.getService(AuthService);
+  private readonly cohortService = core.getService(CohortService);
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
   @property() chat: ChatMessage | undefined = undefined;
+  // Optional explicit avatar color. Used e.g. for the private chat
+  // representative, whose color must match the observer (and the group-chat
+  // representative) rather than being derived from the mediator's name/id.
+  @property() colorOverride = '';
   private fullscreenElement: HTMLElement | null = null;
+
+  // Observer-specific chat coloring (mediators shown blue; that blue reserved
+  // away from other speakers) only applies when the experiment assigns the
+  // `_isObserver` treatment variable.
+  private get reserveMediatorColor(): boolean {
+    return variableAssignmentsIncludeObserver(
+      this.cohortService.activeParticipants,
+    );
+  }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
@@ -82,11 +99,20 @@ export class ChatMessageComponent extends MobxLitElement {
     }
   }
 
+  // A message belongs on the viewing participant's own side of the chat if
+  // they sent it directly or their representative (publicId
+  // `${publicId}-agent`) sent it, so the participant's own voice stays on
+  // one side of the chat.
+  private isOwnSideMessage(senderId: string | undefined): boolean {
+    const myId = this.participantService.profile?.publicId;
+    if (!myId || !senderId) return false;
+    return senderId === myId || senderId === `${myId}-agent`;
+  }
+
   renderParticipantMessage(chatMessage: ChatMessage) {
     const classes = classMap({
       'chat-message': true,
-      'current-user':
-        chatMessage.senderId === this.participantService.profile?.publicId,
+      'current-user': this.isOwnSideMessage(chatMessage.senderId),
     });
 
     const profile = chatMessage.profile;
@@ -96,10 +122,12 @@ export class ChatMessageComponent extends MobxLitElement {
       if (!chatMessage.profile?.name) {
         return '';
       }
-      // Otherwise, use profile ID/avatar to determine color
+      // Otherwise, use profile ID/avatar to determine color, reserving the
+      // mediator color (blue) away from participants when applicable.
       return getProfileBasedColor(
         chatMessage.senderId ?? '',
         profile.avatar ?? '',
+        this.reserveMediatorColor ? [MEDIATOR_OBSERVER_COLOR] : [],
       );
     };
 
@@ -132,13 +160,19 @@ export class ChatMessageComponent extends MobxLitElement {
 
   renderMediatorMessage(chatMessage: ChatMessage) {
     const profile = chatMessage.profile;
+    const reserveColor = this.reserveMediatorColor;
+    // An explicit override (e.g. a representative whose color must match its
+    // participant) wins; otherwise mediators are blue in observer experiments,
+    // falling back to an id hash color.
+    const avatarColor =
+      this.colorOverride ||
+      (reserveColor
+        ? MEDIATOR_OBSERVER_COLOR
+        : getHashBasedColor(chatMessage.senderId ?? ''));
 
     return html`
       <div class="chat-message">
-        <avatar-icon
-          .emoji=${profile.avatar}
-          .color=${getHashBasedColor(chatMessage.senderId ?? '')}
-        >
+        <avatar-icon .emoji=${profile.avatar} .color=${avatarColor}>
         </avatar-icon>
         <div class="content">
           <div class="label">
@@ -151,7 +185,11 @@ export class ChatMessageComponent extends MobxLitElement {
             >
           </div>
           ${chatMessage.message
-            ? html`<div class="chat-bubble">
+            ? html`<div
+                class="chat-bubble ${reserveColor && !this.colorOverride
+                  ? 'mediator-bubble'
+                  : ''}"
+              >
                 ${unsafeHTML(convertMarkdownToHTML(chatMessage.message))}
               </div>`
             : nothing}

--- a/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/agent_chat_prompt_editor.ts
@@ -307,6 +307,9 @@ export class EditorComponent extends MobxLitElement {
     agentPromptConfig: ChatPromptConfig,
   ) {
     const chatSettings = agentPromptConfig.chatSettings;
+    // Per-mediator message-count overrides govern group chats only.
+    const isGroupChat =
+      this.experimentEditor.getStage(this.stageId)?.kind === StageKind.CHAT;
 
     const updateInitialMessage = (e: InputEvent) => {
       const initialMessage = (e.target as HTMLTextAreaElement).value;
@@ -360,6 +363,28 @@ export class EditorComponent extends MobxLitElement {
         chatSettings: {
           ...agentPromptConfig.chatSettings,
           maxResponses,
+        },
+      });
+    };
+
+    const updateMaxNumberOfMessages = (e: InputEvent) => {
+      const value = (e.target as HTMLInputElement).value;
+      const maxNumberOfMessages = value === '' ? null : Number(value);
+      this.updatePrompt({
+        chatSettings: {
+          ...agentPromptConfig.chatSettings,
+          maxNumberOfMessages,
+        },
+      });
+    };
+
+    const updateMinNumberOfMessages = (e: InputEvent) => {
+      const value = (e.target as HTMLInputElement).value;
+      const minNumberOfMessages = value === '' ? null : Number(value);
+      this.updatePrompt({
+        chatSettings: {
+          ...agentPromptConfig.chatSettings,
+          minNumberOfMessages,
         },
       });
     };
@@ -460,6 +485,50 @@ export class EditorComponent extends MobxLitElement {
             />
           </div>
         </div>
+        ${isGroupChat
+          ? html`
+              <div class="field">
+                <label for="maxNumberOfMessages"
+                  >Per-mediator message cap</label
+                >
+                <div class="description">
+                  Overrides the stage-level "Max total messages" cap for group
+                  chats where this mediator is active. Leave empty to defer to
+                  the stage-level cap.
+                </div>
+                <div class="number-input">
+                  <input
+                    .disabled=${!this.experimentEditor.isCreator}
+                    type="number"
+                    min="1"
+                    .value=${chatSettings.maxNumberOfMessages ?? ''}
+                    placeholder="Defer to stage cap"
+                    @input=${updateMaxNumberOfMessages}
+                  />
+                </div>
+              </div>
+              <div class="field">
+                <label for="minNumberOfMessages"
+                  >Per-mediator message minimum</label
+                >
+                <div class="description">
+                  Overrides the stage-level "Min total messages" gate for group
+                  chats where this mediator is active. Leave empty to defer to
+                  the stage-level minimum.
+                </div>
+                <div class="number-input">
+                  <input
+                    .disabled=${!this.experimentEditor.isCreator}
+                    type="number"
+                    min="0"
+                    .value=${chatSettings.minNumberOfMessages ?? ''}
+                    placeholder="Defer to stage minimum"
+                    @input=${updateMinNumberOfMessages}
+                  />
+                </div>
+              </div>
+            `
+          : nothing}
         <div class="field">
           <label for="numRetries">API retry attempts</label>
           <div class="description">

--- a/frontend/src/components/experiment_builder/structured_prompt_editor.ts
+++ b/frontend/src/components/experiment_builder/structured_prompt_editor.ts
@@ -118,6 +118,12 @@ export class EditorComponent extends MobxLitElement {
       this.addPromptItem(targetArray, {type: PromptItemType.PROFILE_CONTEXT});
     };
 
+    const addOtherProfileContexts = () => {
+      this.addPromptItem(targetArray, {
+        type: PromptItemType.OTHER_PROFILE_CONTEXTS,
+      });
+    };
+
     const addProfileInfo = () => {
       this.addPromptItem(targetArray, {type: PromptItemType.PROFILE_INFO});
     };
@@ -158,6 +164,13 @@ export class EditorComponent extends MobxLitElement {
           <div class="menu-item" role="button" @click=${addProfileContext}>
             Custom agent context
           </div>
+          <div
+            class="menu-item"
+            role="button"
+            @click=${addOtherProfileContexts}
+          >
+            Automatically generated or retrieved personas
+          </div>
           <div class="menu-item" role="button" @click=${addProfileInfo}>
             Profile info (avatar, name, pronouns)
           </div>
@@ -193,6 +206,18 @@ export class EditorComponent extends MobxLitElement {
             <div class="chip-collapsible">
               Context string provided when specific agent is created (or empty
               string if none)
+            </div>
+          </details>
+        `;
+      case PromptItemType.OTHER_PROFILE_CONTEXTS:
+        return html`
+          <details>
+            <summary class="chip tertiary">
+              Automatically generated or retrieved personas
+            </summary>
+            <div class="chip-collapsible">
+              Inserts automatically generated or retrieved personas. Empty if
+              the cohort has no other agents with personas.
             </div>
           </details>
         `;

--- a/frontend/src/components/experiment_builder/variable_editor.ts
+++ b/frontend/src/components/experiment_builder/variable_editor.ts
@@ -26,6 +26,8 @@ import {
   type VariableConfig,
   BalanceAcross,
   BalanceStrategy,
+  RESERVED_TREATMENT_VARIABLE_KEYS,
+  RESERVED_TREATMENT_VARIABLE_GITHUB_URL,
   VariableConfigType,
   VariableScope,
   createBalancedAssignmentVariableConfig,
@@ -142,6 +144,30 @@ export class VariableEditor extends MobxLitElement {
   }
 
   // ===== Variable Config =====
+
+  /**
+   * Inline warning shown directly under a property (or variable) name input
+   * when that name is a reserved treatment key
+   * (RESERVED_TREATMENT_VARIABLE_KEYS), since those are hoisted onto
+   * participants and modify behavior. Matches the field-level
+   * validation-error style.
+   */
+  private renderReservedKeyWarning(name: string) {
+    const reserved: readonly string[] = RESERVED_TREATMENT_VARIABLE_KEYS;
+    if (!reserved.includes(name)) return nothing;
+    return html`
+      <div class="validation-error">
+        ⚠️ Warning: "${name}" is a special variable that changes system
+        behavior.
+        <a
+          href=${RESERVED_TREATMENT_VARIABLE_GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          >See GitHub</a
+        >.
+      </div>
+    `;
+  }
 
   private renderVariableConfig(config: VariableConfig, index: number) {
     return html`
@@ -1069,6 +1095,7 @@ export class VariableEditor extends MobxLitElement {
           <option value="array">Array</option>
         </select>
       </div>
+      ${this.renderReservedKeyWarning(name)}
     `;
 
     if (!isComplex) {

--- a/frontend/src/components/experiment_builder/variable_editor.ts
+++ b/frontend/src/components/experiment_builder/variable_editor.ts
@@ -21,6 +21,7 @@ import {ExperimentEditor} from '../../services/experiment.editor';
 
 import {
   type BalancedAssignmentVariableConfig,
+  type ChatStageConfig,
   type MultiValueVariableConfigType,
   type StaticVariableConfig,
   type VariableConfig,
@@ -28,6 +29,7 @@ import {
   BalanceStrategy,
   RESERVED_TREATMENT_VARIABLE_KEYS,
   RESERVED_TREATMENT_VARIABLE_GITHUB_URL,
+  StageKind,
   VariableConfigType,
   VariableScope,
   createBalancedAssignmentVariableConfig,
@@ -155,6 +157,14 @@ export class VariableEditor extends MobxLitElement {
   private renderReservedKeyWarning(name: string) {
     const reserved: readonly string[] = RESERVED_TREATMENT_VARIABLE_KEYS;
     if (!reserved.includes(name)) return nothing;
+    // _isQuizzed only takes effect in turn-based group chats.
+    const quizIgnored =
+      name === '_isQuizzed' &&
+      !this.experimentEditor.stages.some(
+        (stage) =>
+          stage.kind === StageKind.CHAT &&
+          (stage as ChatStageConfig).isTurnBased,
+      );
     return html`
       <div class="validation-error">
         ⚠️ Warning: "${name}" is a special variable that changes system
@@ -165,6 +175,12 @@ export class VariableEditor extends MobxLitElement {
           rel="noopener noreferrer"
           >See GitHub</a
         >.
+        ${quizIgnored
+          ? html`<div>
+              "_isQuizzed" is currently ignored because no group chat stage is
+              turn-based.
+            </div>`
+          : nothing}
       </div>
     `;
   }

--- a/frontend/src/components/participant_profile/profile_display.ts
+++ b/frontend/src/components/participant_profile/profile_display.ts
@@ -57,6 +57,10 @@ export class ParticipantProfileDisplay extends MobxLitElement {
   // Display (you) indicator that the profile is the current user
   @property() showIsSelf = false;
 
+  // Avatar colors to exclude from id/hash-based selection (e.g. blue when it
+  // is reserved for mediators).
+  @property({type: Array}) excludeColors: string[] = [];
+
   override render() {
     if (!this.profile) return nothing;
 
@@ -68,13 +72,14 @@ export class ParticipantProfileDisplay extends MobxLitElement {
 
     // Use profile ID to determine color
     const color = () => {
-      // If publicId is in format animal-color-number, extract color
+      // If publicId is in format animal-color-number, extract color (unless it
+      // is excluded, e.g. blue reserved for mediators)
       const splitId = (this.profile?.publicId ?? '').split('-');
-      if (splitId.length >= 3) {
+      if (splitId.length >= 3 && !this.excludeColors.includes(splitId[1])) {
         return splitId[1];
       }
       // Otherwise, use publicId as hash
-      return getHashBasedColor(this.profile?.publicId);
+      return getHashBasedColor(this.profile?.publicId, this.excludeColors);
     };
 
     // If alternate profile ID in stage ID, use anonymous profile

--- a/frontend/src/components/participant_profile/profile_display.ts
+++ b/frontend/src/components/participant_profile/profile_display.ts
@@ -16,7 +16,13 @@ import {
 } from '@deliberation-lab/utils';
 
 import {styles} from './profile_display.scss';
-import {getHashBasedColor} from '../../shared/utils';
+import {core} from '../../core/core';
+import {CohortService} from '../../services/cohort.service';
+import {
+  getHashBasedColor,
+  MEDIATOR_OBSERVER_COLOR,
+  variableAssignmentsIncludeObserver,
+} from '../../shared/utils';
 import {MAN_EMOJIS, WOMAN_EMOJIS, PERSON_EMOJIS} from '../../shared/constants';
 
 enum ProfileDisplayType {
@@ -61,6 +67,19 @@ export class ParticipantProfileDisplay extends MobxLitElement {
   // is reserved for mediators).
   @property({type: Array}) excludeColors: string[] = [];
 
+  private readonly cohortService = core.getService(CohortService);
+
+  // In an observer study the mediator color is reserved, so participants must
+  // not derive it. Callers can still pass their own exclusions.
+  private get effectiveExcludeColors(): string[] {
+    if (this.excludeColors.length > 0) return this.excludeColors;
+    return variableAssignmentsIncludeObserver(
+      this.cohortService.activeParticipants,
+    )
+      ? [MEDIATOR_OBSERVER_COLOR]
+      : [];
+  }
+
   override render() {
     if (!this.profile) return nothing;
 
@@ -74,12 +93,13 @@ export class ParticipantProfileDisplay extends MobxLitElement {
     const color = () => {
       // If publicId is in format animal-color-number, extract color (unless it
       // is excluded, e.g. blue reserved for mediators)
+      const excludeColors = this.effectiveExcludeColors;
       const splitId = (this.profile?.publicId ?? '').split('-');
-      if (splitId.length >= 3 && !this.excludeColors.includes(splitId[1])) {
+      if (splitId.length >= 3 && !excludeColors.includes(splitId[1])) {
         return splitId[1];
       }
       // Otherwise, use publicId as hash
-      return getHashBasedColor(this.profile?.publicId, this.excludeColors);
+      return getHashBasedColor(this.profile?.publicId, excludeColors);
     };
 
     // If alternate profile ID in stage ID, use anonymous profile

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -32,11 +32,96 @@ export class ChatEditor extends MobxLitElement {
       <div class="title">Conversation settings</div>
       ${this.renderTimeLimit()} ${this.renderTurnBasedSetting()}
       <div class="divider"></div>
+      <div class="title">Message limits</div>
+      ${this.renderMinNumberOfMessages()} ${this.renderMaxNumberOfMessages()}
+      <div class="divider"></div>
       <div class="title">Agent mediators</div>
       <div class="description">
         Navigate to "Agent mediators" tab to add or edit mediators
       </div>
       ${this.renderMediators()}
+    `;
+  }
+
+  private renderMinNumberOfMessages() {
+    const minNumberOfMessages = this.stage?.minNumberOfMessages ?? 0;
+    const maxNumberOfMessages = this.stage?.maxNumberOfMessages ?? null;
+
+    const updateNum = (e: InputEvent) => {
+      if (!this.stage) return;
+      let value = Math.max(0, Number((e.target as HTMLInputElement).value));
+      if (maxNumberOfMessages !== null) {
+        value = Math.min(value, maxNumberOfMessages);
+      }
+      this.experimentEditor.updateStage({
+        ...this.stage,
+        minNumberOfMessages: value,
+      });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="number-input">
+          <label for="minTotalMessages">
+            Minimum total messages across all participants and mediators
+            combined (0 = no minimum). Takes precedence over maximum time limit.
+          </label>
+          <input
+            type="number"
+            id="minTotalMessages"
+            name="minTotalMessages"
+            min="0"
+            .max=${maxNumberOfMessages ?? ''}
+            .value=${minNumberOfMessages}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateNum}
+          />
+        </div>
+      </div>
+    `;
+  }
+
+  private renderMaxNumberOfMessages() {
+    const maxNumberOfMessages = this.stage?.maxNumberOfMessages ?? null;
+    const minNumberOfMessages = this.stage?.minNumberOfMessages ?? 0;
+
+    const updateNum = (e: InputEvent) => {
+      if (!this.stage) return;
+      const value = (e.target as HTMLInputElement).value;
+      if (value === '') {
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          maxNumberOfMessages: null,
+        });
+      } else {
+        const num = Math.max(minNumberOfMessages, Math.max(1, Number(value)));
+        this.experimentEditor.updateStage({
+          ...this.stage,
+          maxNumberOfMessages: num,
+        });
+      }
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="number-input">
+          <label for="maxTotalMessages">
+            Maximum total messages across all participants and mediators
+            combined (empty = no limit). The discussion ends for the whole
+            cohort once this is reached.
+          </label>
+          <input
+            type="number"
+            id="maxTotalMessages"
+            name="maxTotalMessages"
+            min="1"
+            .value=${maxNumberOfMessages ?? ''}
+            placeholder="No limit"
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateNum}
+          />
+        </div>
+      </div>
     `;
   }
 

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -77,6 +77,31 @@ export class ChatEditor extends MobxLitElement {
             @input=${updateNum}
           />
         </div>
+        ${this.renderQuizCadenceNote()}
+      </div>
+    `;
+  }
+
+  private renderQuizCadenceNote() {
+    const hasQuizzedTreatment = (
+      this.experimentEditor.experiment.variableConfigs ?? []
+    ).some(
+      (config) =>
+        'values' in config &&
+        ((config as {values?: string[]}).values ?? []).some((value) => {
+          try {
+            return JSON.parse(value)?.['_isQuizzed'] === true;
+          } catch {
+            return false;
+          }
+        }),
+    );
+    if (!hasQuizzedTreatment) return nothing;
+    return html`
+      <div class="description">
+        ⚠️ A treatment sets <code>_isQuizzed</code>: the chat pauses for a quiz
+        at each third of the minimum message count (up to 3 quizzes; fewer if
+        the minimum is under 3).
       </div>
     `;
   }

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -277,6 +277,10 @@ export class GroupChatView extends MobxLitElement {
       <chat-interface
         .stage=${this.stage}
         .disableInput=${this.disableInput ||
+        // Observers are strictly read-only inside chat rooms (cannot type/send messages)
+        // but must retain interactive capabilities to complete surveys in other stages,
+        // so this gating is applied component-specifically rather than globally.
+        this.participantService.profile?.isObserver ||
         this.participantService.disableStage ||
         this.isConversationOver()}
         showPanel

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -300,8 +300,13 @@ export class GroupChatView extends MobxLitElement {
       this.stage.id,
     );
 
-    // Determine if Next Stage button should be disabled
-    const disableNext = !this.isMinimumTimeMet || !this.isMinimumMessagesMet();
+    // Determine if Next Stage button should be disabled. Also block advance
+    // while a quiz is pending (incl. the final quiz after the last message) so
+    // the participant cannot skip past it.
+    const disableNext =
+      !this.isMinimumTimeMet ||
+      !this.isMinimumMessagesMet() ||
+      this.isQuizPending;
 
     const renderProgress = () => {
       if (!this.stage?.progress.showParticipantProgress) {
@@ -328,6 +333,10 @@ export class GroupChatView extends MobxLitElement {
         // so this gating is applied component-specifically rather than globally.
         this.participantService.profile?.isObserver ||
         this.participantService.disableStage ||
+        // Block the direct-participation human from typing while their quiz is
+        // pending (observers are already read-only) so they answer before the
+        // discussion resumes.
+        this.isQuizPending ||
         this.isConversationOver()}
         showPanel
       >
@@ -362,6 +371,20 @@ export class GroupChatView extends MobxLitElement {
       getTimeElapsed(publicStageData.discussionStartTimestamp, 'm') >=
       this.stage.timeMinimumInMinutes
     );
+  }
+
+  /** True while the participant has an unanswered quiz pending. The backend
+   *  keeps quizPauseCheckpoint > 0 until they submit (and zeroes it on
+   *  submit), so this single public-data flag is the authoritative "quiz
+   *  unanswered" signal, including the final quiz that follows the last
+   *  message. It is only ever set for a quiz, so ordinary chats are
+   *  unaffected. Used to block stage advance until the quiz is submitted. */
+  private get isQuizPending(): boolean {
+    if (!this.stage) return false;
+    const data = this.cohortService.stagePublicDataMap[this.stage.id] as
+      | ChatStagePublicData
+      | undefined;
+    return (data?.quizPauseCheckpoint ?? 0) > 0;
   }
 
   get minutesRemainingUntilMinimum(): number {

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -27,6 +27,7 @@ import {
   ChatStageConfig,
   DiscussionItem,
   StageKind,
+  UserType,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
 
@@ -49,6 +50,19 @@ export class GroupChatView extends MobxLitElement {
   @state() readyToEndDiscussionLoading = false;
 
   private renderChatMessage(chatMessage: ChatMessage) {
+    // Turn-based chats show a "discussion has ended" banner (rendered by
+    // chat-interface), so suppress the duplicate system message carrying that
+    // exact text. Non-turn-based chats get no banner and keep the system
+    // message as their end-of-discussion cue.
+    if (
+      chatMessage.type === UserType.SYSTEM &&
+      chatMessage.message ===
+        'The discussion has ended. Please proceed to the next stage.' &&
+      this.stage?.isTurnBased &&
+      this.isConversationOver()
+    ) {
+      return nothing;
+    }
     return html` <chat-message .chat=${chatMessage}></chat-message> `;
   }
 
@@ -61,7 +75,39 @@ export class GroupChatView extends MobxLitElement {
       stage.id
     ] as ChatStagePublicData;
     if (!stageData) return;
-    return Boolean(stageData.discussionEndTimestamp);
+    if (stageData.discussionEndTimestamp) return true;
+    // Honor the backend's effective cap (a per-mediator override replaces the
+    // stage value), falling back to the stage value when none is published.
+    const max =
+      stageData.effectiveMaxNumberOfMessages ??
+      (stage as ChatStageConfig).maxNumberOfMessages;
+    if (max != null && this.cohortMessageCount() >= max) return true;
+    return false;
+  }
+
+  /**
+   * Total non-system, non-error messages sent in the cohort's public chat.
+   * Used to enforce cohort-wide min/max message limits.
+   */
+  private cohortMessageCount(): number {
+    const stageId = this.participantService.currentStageViewId ?? '';
+    const messages = this.cohortService.chatMap[stageId] ?? [];
+    return messages.filter((m) => m.type !== UserType.SYSTEM && !m.isError)
+      .length;
+  }
+
+  private isMinimumMessagesMet() {
+    if (!this.stage) return true;
+    // Honor a per-mediator min override published by the backend, falling back
+    // to the stage-level minimum when none is set.
+    const stageData = this.cohortService.stagePublicDataMap[this.stage.id] as
+      | ChatStagePublicData
+      | undefined;
+    const min =
+      stageData?.effectiveMinNumberOfMessages ??
+      this.stage.minNumberOfMessages ??
+      0;
+    return this.cohortMessageCount() >= min;
   }
 
   private renderChatHistory(currentDiscussionId: string | null) {
@@ -255,7 +301,7 @@ export class GroupChatView extends MobxLitElement {
     );
 
     // Determine if Next Stage button should be disabled
-    const disableNext = !this.isMinimumTimeMet;
+    const disableNext = !this.isMinimumTimeMet || !this.isMinimumMessagesMet();
 
     const renderProgress = () => {
       if (!this.stage?.progress.showParticipantProgress) {

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -25,6 +25,7 @@ import {
   ChatStagePublicData,
   ChatMessage,
   ChatStageConfig,
+  getQuizPauseCheckpointForCount,
   DiscussionItem,
   StageKind,
   UserType,
@@ -314,6 +315,7 @@ export class GroupChatView extends MobxLitElement {
     const disableNext =
       !this.isMinimumTimeMet ||
       !this.isMinimumMessagesMet() ||
+      this.isQuizOwed ||
       this.isQuizPending;
 
     const renderProgress = () => {
@@ -393,6 +395,30 @@ export class GroupChatView extends MobxLitElement {
       | ChatStagePublicData
       | undefined;
     return (data?.quizPauseCheckpoint ?? 0) > 0;
+  }
+
+  /** True while this participant still owes a quiz for the current message
+   *  count. The backend raises quizPauseCheckpoint a beat after a message
+   *  lands, so at the moment the minimum-messages condition flips true the
+   *  pause flag has not arrived yet, briefly enabling "Next stage" in the gap
+   *  before the quiz appears. This derives the same answer the pause is about
+   *  to encode, from the message count and the answered checkpoint the client
+   *  already holds, so there is no gap. Scoped to quiz participants in
+   *  turn-based chats, so other chats are unaffected. */
+  private get isQuizOwed(): boolean {
+    if (!this.stage) return false;
+    if ((this.stage as ChatStageConfig).isTurnBased !== true) return false;
+    if (!this.participantService.profile?.isQuizzed) return false;
+    const data = this.cohortService.stagePublicDataMap[this.stage.id] as
+      | ChatStagePublicData
+      | undefined;
+    const min =
+      data?.effectiveMinNumberOfMessages ?? this.stage.minNumberOfMessages ?? 0;
+    const expected = getQuizPauseCheckpointForCount(
+      this.cohortMessageCount(),
+      min,
+    );
+    return expected > (data?.quizAnsweredCheckpoint ?? 0);
   }
 
   get minutesRemainingUntilMinimum(): number {

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -160,6 +160,8 @@ export class ChatEditor extends MobxLitElement {
 
   private renderTurnBasedChat() {
     const isTurnBasedChat = this.stage?.isTurnBasedChat ?? true;
+    const isTurnBasedChatGroupStyle =
+      this.stage?.isTurnBasedChatGroupStyle ?? false;
 
     const updateCheck = () => {
       if (!this.stage) return;
@@ -169,18 +171,39 @@ export class ChatEditor extends MobxLitElement {
       });
     };
 
+    const updateGroupStyleCheck = () => {
+      if (!this.stage) return;
+      this.experimentEditor.updateStage({
+        ...this.stage,
+        isTurnBasedChatGroupStyle: !isTurnBasedChatGroupStyle,
+      });
+    };
+
     return html`
       <div class="config-item">
         <div class="checkbox-wrapper">
           <md-checkbox
             touch-target="wrapper"
             ?checked=${isTurnBasedChat}
-            ?disabled=${!this.experimentEditor.canEditStages}
+            ?disabled=${!this.experimentEditor.canEditStages ||
+            isTurnBasedChatGroupStyle}
             @click=${updateCheck}
           >
           </md-checkbox>
           <div>
             Turn-based chat (participant and mediator alternate messages)
+          </div>
+        </div>
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${isTurnBasedChatGroupStyle}
+            ?disabled=${!this.experimentEditor.canEditStages || isTurnBasedChat}
+            @click=${updateGroupStyleCheck}
+          >
+          </md-checkbox>
+          <div>
+            Turn-based chat (group-chat style, e.g., banner while waiting)
           </div>
         </div>
       </div>

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -87,11 +87,10 @@ export class PrivateChatView extends MobxLitElement {
       chatMessages[chatMessages.length - 1].senderId === publicId &&
       !this.responseTimeout.timedOut;
 
-    // Check if max number of turns reached (but only after response received)
+    // Check if max number of turns reached
     const maxTurnsReached =
       this.stage.maxNumberOfTurns !== null &&
-      participantMessageCount >= this.stage.maxNumberOfTurns &&
-      !isWaitingForResponse;
+      participantMessageCount >= this.stage.maxNumberOfTurns;
 
     const discussionStartTimestamp =
       chatMessages.length > 0 ? chatMessages[0].timestamp : null;
@@ -120,7 +119,8 @@ export class PrivateChatView extends MobxLitElement {
     // Min turns takes precedence: conversation stays open until min turns is met,
     // even if max time has elapsed.
     const isConversationOver =
-      maxTurnsReached || (maxTimeReached && minTurnsMet);
+      (maxTurnsReached && !isWaitingForResponse) ||
+      (maxTimeReached && minTurnsMet);
 
     // Disable input if turn-taking is set and latest message
     // is from participant OR if conversation is over
@@ -151,6 +151,7 @@ export class PrivateChatView extends MobxLitElement {
         .stage=${this.stage}
         .disableInput=${isDisabledInput()}
         .repPrivateChatProfile=${this.repPrivateChatProfile}
+        .externalConversationOver=${isConversationOver}
       >
         ${chatMessages.map((message) => this.renderChatMessage(message))}
         ${isWaitingForResponse &&

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -104,9 +104,14 @@ export class PrivateChatView extends MobxLitElement {
       this.stage.timeLimitInMinutes > 0 &&
       elapsedMinutes >= this.stage.timeLimitInMinutes;
 
-    // Check if minimum number of turns met for progression
-    // For turn-based chats, only count completed turns (where agent has responded)
-    const minTurnsMet = this.stage.isTurnBasedChat
+    // Check if minimum number of turns met for progression.
+    // Both turn-based variants (text turn-taking and banner-style turn-taking)
+    // alternate participant and mediator, so the participant's last turn isn't
+    // complete until the mediator has responded. Otherwise the "Next stage"
+    // button can appear while the mediator is still composing its final message.
+    const isTurnBased =
+      this.stage.isTurnBasedChat || this.stage.isTurnBasedChatGroupStyle;
+    const minTurnsMet = isTurnBased
       ? participantMessageCount >= this.stage.minNumberOfTurns &&
         !isWaitingForResponse
       : participantMessageCount >= this.stage.minNumberOfTurns;
@@ -142,12 +147,20 @@ export class PrivateChatView extends MobxLitElement {
     const isNextDisabled = !minTurnsMet || !minTimeMet;
 
     return html`
-      <chat-interface .stage=${this.stage} .disableInput=${isDisabledInput()}>
+      <chat-interface
+        .stage=${this.stage}
+        .disableInput=${isDisabledInput()}
+        .repPrivateChatProfile=${this.repPrivateChatProfile}
+      >
         ${chatMessages.map((message) => this.renderChatMessage(message))}
-        ${isWaitingForResponse && !isConversationOver
+        ${isWaitingForResponse &&
+        !isConversationOver &&
+        !this.stage.isTurnBasedChatGroupStyle
           ? this.renderAgentIndicator(chatMessages)
           : nothing}
-        ${isConversationOver && minTimeMet
+        ${isConversationOver &&
+        minTimeMet &&
+        !this.stage.isTurnBasedChatGroupStyle
           ? this.renderConversationEndedMessage()
           : nothing}
         ${isConversationOver && !minTimeMet

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -20,7 +20,12 @@ import {
   UserType,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
-import {getHashBasedColor, getProfileBasedColor} from '../../shared/utils';
+import {
+  getHashBasedColor,
+  getProfileBasedColor,
+  MEDIATOR_OBSERVER_COLOR,
+  variableAssignmentsIncludeObserver,
+} from '../../shared/utils';
 import {ResponseTimeoutTracker} from '../../shared/response_timeout';
 
 import {styles} from './group_chat_participant_view.scss';
@@ -220,7 +225,15 @@ export class PrivateChatView extends MobxLitElement {
       // Colour the representative from its own robot avatar, not the observer's
       // (possibly gendered) avatar, so it matches the group-chat representative
       // and is never given a mediator/gendered colour.
-      color: getProfileBasedColor(profile.publicId ?? '', '🤖'),
+      color: getProfileBasedColor(
+        profile.publicId ?? '',
+        '🤖',
+        variableAssignmentsIncludeObserver(
+          this.cohortService.activeParticipants,
+        )
+          ? [MEDIATOR_OBSERVER_COLOR]
+          : [],
+      ),
     };
   }
 

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -8,15 +8,19 @@ import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
+import {ExperimentService} from '../../services/experiment.service';
 import {ParticipantService} from '../../services/participant.service';
+import {CohortService} from '../../services/cohort.service';
 
 import {
   ChatMessage,
   PrivateChatStageConfig,
+  StageKind,
+  TransferStageConfig,
   UserType,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
-import {getHashBasedColor} from '../../shared/utils';
+import {getHashBasedColor, getProfileBasedColor} from '../../shared/utils';
 import {ResponseTimeoutTracker} from '../../shared/response_timeout';
 
 import {styles} from './group_chat_participant_view.scss';
@@ -27,6 +31,8 @@ export class PrivateChatView extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
+  private readonly cohortService = core.getService(CohortService);
+  private readonly experimentService = core.getService(ExperimentService);
 
   @property() stage: PrivateChatStageConfig | undefined = undefined;
 
@@ -162,15 +168,99 @@ export class PrivateChatView extends MobxLitElement {
     `;
   }
 
+  /**
+   * If this private chat is conducted by the participant's
+   * representative (a `_hasRepresentative` round), returns the
+   * representative's display name, avatar, and color, so it shows consistently
+   * before and after its first message and matches the group chat. Returns
+   * null otherwise.
+   */
+  private get repPrivateChatProfile(): {
+    name: string;
+    avatar: string;
+    color: string;
+  } | null {
+    const profile = this.participantService.profile;
+    if (!profile || !this.stage) return null;
+    const stages = this.experimentService.stages;
+    const idx = stages.findIndex((s) => s.id === this.stage?.id);
+    if (idx < 0) return null;
+    // The round is identified by the next transfer's treatmentIndex.
+    let treatmentIndex: number | null = null;
+    for (let i = idx + 1; i < stages.length; i++) {
+      const s = stages[i];
+      if (s.kind === StageKind.TRANSFER) {
+        const ti = (s as TransferStageConfig).treatmentIndex;
+        treatmentIndex = typeof ti === 'number' ? ti : null;
+        break;
+      }
+      if (s.kind === StageKind.PRIVATE_CHAT) return null;
+    }
+    if (treatmentIndex === null) return null;
+    if (!this.roundHasRepresentative(profile.variableMap, treatmentIndex)) {
+      return null;
+    }
+    return {
+      name: `${profile.name ?? profile.publicId}'s Agent (yours)`,
+      avatar: '🤖',
+      // Colour the representative from its own robot avatar, not the observer's
+      // (possibly gendered) avatar, so it matches the group-chat representative
+      // and is never given a mediator/gendered colour.
+      color: getProfileBasedColor(profile.publicId ?? '', '🤖'),
+    };
+  }
+
+  /** True if the treatment selected for `index` sets `_hasRepresentative`. */
+  private roundHasRepresentative(
+    variableMap: Record<string, string> | undefined,
+    index: number,
+  ): boolean {
+    if (!variableMap) return false;
+    for (const [name, value] of Object.entries(variableMap)) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(value);
+      } catch {
+        continue;
+      }
+      let treatment: unknown;
+      if (Array.isArray(parsed)) {
+        treatment = parsed[index];
+      } else if (parsed && typeof parsed === 'object') {
+        const suffix = name.match(/_(\d+)$/);
+        if (suffix && Number(suffix[1]) !== index + 1) continue;
+        treatment = parsed;
+      } else {
+        continue;
+      }
+      if (
+        treatment &&
+        typeof treatment === 'object' &&
+        (treatment as Record<string, unknown>)._hasRepresentative === true
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private renderAgentIndicator(chatMessages: ChatMessage[]) {
-    // Get avatar/color from last mediator message
-    const lastMediator = [...chatMessages]
+    const lastMediatorMsg = [...chatMessages]
       .reverse()
       .find((msg) => msg.type === UserType.MEDIATOR);
-    const avatar = lastMediator?.profile?.avatar;
-    const color = lastMediator
-      ? getHashBasedColor(lastMediator.senderId ?? '')
-      : undefined;
+    const assignedMediator = this.cohortService.getMediatorsForStage(
+      this.stage?.id ?? '',
+    )[0];
+
+    const rep = this.repPrivateChatProfile;
+    const avatar =
+      rep?.avatar ??
+      lastMediatorMsg?.profile?.avatar ??
+      assignedMediator?.avatar;
+    const colorKey =
+      lastMediatorMsg?.senderId ?? assignedMediator?.publicId ?? '';
+    const color =
+      rep?.color ?? (colorKey ? getHashBasedColor(colorKey) : undefined);
 
     const renderCancelButton = () => {
       if (this.stage?.preventCancellation) {
@@ -209,7 +299,10 @@ export class PrivateChatView extends MobxLitElement {
     if (chatMessage.isError) {
       return html`<div class="description error">${chatMessage.message}</div>`;
     }
-    return html`<chat-message .chat=${chatMessage}></chat-message>`;
+    return html`<chat-message
+      .chat=${chatMessage}
+      .colorOverride=${this.repPrivateChatProfile?.color ?? ''}
+    ></chat-message>`;
   }
 
   private renderConversationEndedMessage() {

--- a/frontend/src/components/stages/transfer_editor.ts
+++ b/frontend/src/components/stages/transfer_editor.ts
@@ -75,8 +75,46 @@ export class TransferEditorComponent extends MobxLitElement {
     return html`
       ${this.renderTimeout()}
       ${this.authService.showAlphaFeatures
-        ? this.renderAutoTransfer()
+        ? html`${this.renderTreatmentIndex()}${this.renderAutoTransfer()}`
         : nothing}
+    `;
+  }
+
+  private renderTreatmentIndex() {
+    if (!this.stage) return nothing;
+
+    const current = this.stage.treatmentIndex;
+
+    const updateTreatmentIndex = (e: InputEvent) => {
+      if (!this.stage) return;
+      const raw = (e.target as HTMLInputElement).value.trim();
+      const treatmentIndex = raw === '' ? undefined : Number(raw);
+      this.experimentEditor.updateStage({...this.stage, treatmentIndex});
+    };
+
+    return html`
+      <div class="section">
+        <div class="title">
+          Treatment index
+          <span class="alpha">alpha</span>
+        </div>
+        <div class="description">
+          For within-subjects experiments: transfers based on the Nth item from
+          a multi-item <code>treatment</code> array. Leave blank to disable.
+        </div>
+        <div class="number-input">
+          <input
+            type="number"
+            id="treatmentIndex"
+            min="0"
+            placeholder="(none)"
+            name="treatmentIndex"
+            .value=${current === undefined ? '' : String(current)}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @input=${updateTreatmentIndex}
+          />
+        </div>
+      </div>
     `;
   }
 

--- a/frontend/src/pair-components/textarea.ts
+++ b/frontend/src/pair-components/textarea.ts
@@ -119,9 +119,10 @@ export class TextArea extends LitElement {
 
     return html`
       ${this.renderLabel()}
-      <div class="textarea-wrapper">
+      <div class="textarea-wrapper" part="wrapper">
         <textarea
           id="textarea"
+          part="textarea"
           ${ref(this.textareaRef)}
           class=${classes}
           ?disabled=${this.disabled}

--- a/frontend/src/sass/_colors.scss
+++ b/frontend/src/sass/_colors.scss
@@ -231,6 +231,12 @@
   --md-sys-color-outline-variant-high: var(--md-ref-palette-neutral-variant90);
   --md-sys-color-box-shadow-3:
     0px 1px 3px 0px rgba(0, 0, 0, 0.3), 0px 4px 8px 3px rgba(0, 0, 0, 0.15);
+
+  // Mediator chat bubble/typing indicator: blue, matching the mediator's blue
+  // avatar, so it stands out from the grey (secondary-container) bubbles other
+  // participants use.
+  --md-sys-color-mediator-container: var(--md-sys-color-avatar-blue);
+  --md-sys-color-on-mediator-container: #00174c;
 }
 
 /* Dark theme. */
@@ -277,6 +283,12 @@
   --md-sys-color-outline-variant-high: var(--md-ref-palette-neutral-variant25);
   --md-sys-color-box-shadow-3:
     0px 1px 3px 0px rgba(0, 0, 0, 0.3), 0px 4px 8px 3px rgba(0, 0, 0, 0.15);
+
+  // Mediator chat bubble/typing indicator: blue, matching the mediator's blue
+  // avatar, so it stands out from the grey (secondary-container) bubbles other
+  // participants use.
+  --md-sys-color-mediator-container: var(--md-sys-color-avatar-blue);
+  --md-sys-color-on-mediator-container: #00174c;
 
   // scrollbar
   scrollbar-color: #777 #333;

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -458,14 +458,13 @@ export class CohortService extends Service {
           or(where('currentCohortId', '==', this.cohortId)),
         ),
         (snapshot) => {
-          let changedDocs = snapshot.docChanges().map((change) => change.doc);
-          if (changedDocs.length === 0) {
-            changedDocs = snapshot.docs;
-          }
-
-          changedDocs.forEach((doc) => {
-            const profile = doc.data() as MediatorProfile;
-            this.mediatorMap[profile.publicId] = profile;
+          snapshot.docChanges().forEach((change) => {
+            const profile = change.doc.data() as MediatorProfile;
+            if (change.type === 'removed') {
+              delete this.mediatorMap[profile.publicId];
+            } else {
+              this.mediatorMap[profile.publicId] = profile;
+            }
           });
           this.isMediatorsLoading = false;
         },

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -202,8 +202,24 @@ export class CohortService extends Service {
 
   // If stage is in a waiting phase
   isStageInWaitingPhase(stageId: string) {
-    // Return false if stage is unlocked for cohort, else true
-    return !this.cohortConfig?.stageUnlockMap[stageId];
+    // Group-style turn-based private chats are per-participant and
+    // mediator-goes-first: the mediator posts on stage entry without a
+    // cohort-wide unlock, which can never be satisfied in a within-subjects
+    // design where other participants occupy different stages. So they are
+    // never in a waiting phase. Otherwise the participant is stuck on the
+    // yellow "waiting for others" screen and the chat never initializes.
+    const stageConfig = this.sp.experimentService.getStage(stageId);
+    if (
+      stageConfig?.kind === StageKind.PRIVATE_CHAT &&
+      (stageConfig as {isTurnBasedChatGroupStyle?: boolean})
+        .isTurnBasedChatGroupStyle
+    ) {
+      return false;
+    }
+    // The unlock map only ever records unlocked stages (value true); a stage
+    // still gated by "waiting" is simply absent. Absent or falsy both mean the
+    // stage is still in its waiting phase.
+    return !this.cohortConfig?.stageUnlockMap?.[stageId];
   }
 
   // Get number of participants needed to pass waiting phase

--- a/frontend/src/services/experiment.editor.ts
+++ b/frontend/src/services/experiment.editor.ts
@@ -4,6 +4,7 @@ import {
   AgentParticipantPersonaConfig,
   AgentParticipantTemplate,
   ApiKeyType,
+  ChatStageConfig,
   CohortParticipantConfig,
   Experiment,
   ExperimentTemplate,
@@ -186,6 +187,20 @@ export class ExperimentEditor extends Service {
     renderApiErrorMessage(ApiKeyType.OLLAMA_CUSTOM_URL);
 
     for (const stage of this.stages) {
+      // Group chat: validate only that the stage's own message-count bounds are
+      // self-consistent. Per-mediator overrides replace these at runtime, and
+      // the effective minimum is clamped to the effective maximum, so a
+      // mediator cap below the stage minimum cannot lock progression.
+      if (stage.kind === StageKind.CHAT) {
+        const chatStage = stage as ChatStageConfig;
+        const stageMin = chatStage.minNumberOfMessages ?? 0;
+        const stageMax = chatStage.maxNumberOfMessages;
+        if (stageMax != null && stageMin > stageMax) {
+          errors.push(
+            `${stage.name}: minimum total messages (${stageMin}) exceeds the stage's maximum (${stageMax})`,
+          );
+        }
+      }
       if (
         stage.kind === StageKind.SURVEY ||
         stage.kind === StageKind.SURVEY_PER_PARTICIPANT

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -68,6 +68,7 @@ import {
   updateSurveyStageParticipantAnswerCallable,
   updateRankingStageParticipantAnswerCallable,
   ackExperimenterAlertCallable,
+  submitParticipantThoughtCallable,
 } from '../shared/callables';
 import {PROLIFIC_COMPLETION_URL_PREFIX} from '../shared/constants';
 import {
@@ -102,6 +103,7 @@ export class ParticipantService extends Service {
     {};
   @observable privateChatMap: Record<string, ChatMessage[]> = {};
   @observable alertMap: Record<string, AlertMessage> = {};
+  @observable quizText = '';
 
   // Loading
   @observable unsubscribe: Unsubscribe[] = [];
@@ -115,6 +117,7 @@ export class ParticipantService extends Service {
 
   // Chat creation loading
   @observable isSendingChat = false;
+  @observable isSubmittingThought = false;
 
   @computed get isLoading() {
     return this.isProfileLoading || this.areAnswersLoading;
@@ -225,6 +228,10 @@ export class ParticipantService extends Service {
 
   @action setCurrentStageView(stageId: string | undefined) {
     this.currentStageViewId = stageId;
+  }
+
+  @action setQuizText(text: string) {
+    this.quizText = text;
   }
 
   updateForRoute(
@@ -432,6 +439,7 @@ export class ParticipantService extends Service {
     this.answerMap = {};
     this.privateChatMap = {};
     this.alertMap = {};
+    this.quizText = '';
     this.sp.participantAnswerService.reset();
   }
 
@@ -748,6 +756,52 @@ export class ParticipantService extends Service {
         },
       );
     }
+    return response;
+  }
+
+  /** Submit the participant's private thoughts on the discussion. */
+  async submitParticipantThought(
+    text: string,
+    checkpoint?: number,
+    rating?: number,
+  ) {
+    if (!this.experimentId || !this.profile || !text || text.trim() === '') {
+      return {success: false};
+    }
+
+    if (this.isSubmittingThought) {
+      return {success: false};
+    }
+
+    this.isSubmittingThought = true;
+    let response = {success: false};
+
+    try {
+      response = await submitParticipantThoughtCallable(
+        this.sp.firebaseService.functions,
+        {
+          experimentId: this.experimentId,
+          participantId: this.profile.privateId,
+          stageId: this.profile.currentStageId,
+          text: text.trim(),
+          ...(checkpoint != null ? {checkpoint} : {}),
+          ...(rating != null ? {rating} : {}),
+        },
+      );
+
+      if (response.success) {
+        runInAction(() => {
+          this.quizText = '';
+        });
+      }
+    } catch (error) {
+      console.error('Error submitting thought:', error);
+    } finally {
+      runInAction(() => {
+        this.isSubmittingThought = false;
+      });
+    }
+
     return response;
   }
 

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -48,6 +48,7 @@ import {
   UpdateRankingStageParticipantAnswerData,
   UpdateSurveyPerParticipantStageParticipantAnswerData,
   UpdateSurveyStageParticipantAnswerData,
+  SubmitParticipantThoughtData,
   PersonaGenerationMode,
 } from '@deliberation-lab/utils';
 
@@ -797,6 +798,21 @@ export const ackExperimenterAlertCallable = async (
   >(
     functions,
     'ackExperimenterAlert',
+  )(config);
+  return data;
+};
+
+/** Generic endpoint to submit participant observation thoughts. */
+export const submitParticipantThoughtCallable = async (
+  functions: Functions,
+  config: SubmitParticipantThoughtData,
+) => {
+  const {data} = await httpsCallable<
+    SubmitParticipantThoughtData,
+    SuccessResponse
+  >(
+    functions,
+    'submitParticipantThought',
   )(config);
   return data;
 };

--- a/frontend/src/shared/utils.ts
+++ b/frontend/src/shared/utils.ts
@@ -77,32 +77,78 @@ export function convertUnifiedTimestampToISO(timestamp: UnifiedTimestamp) {
 /** Get color based on profile ID and avatar
  *  (e.g., use pronoun colors if avatar matches
  */
-export function getProfileBasedColor(publicId: string, avatar: string) {
-  if (MAN_EMOJIS.indexOf(avatar) > -1) {
+export function getProfileBasedColor(
+  publicId: string,
+  avatar: string,
+  exclude: string[] = [],
+) {
+  // Pronoun-based colors, unless that color is excluded (e.g. blue reserved
+  // for mediators), in which case fall through to an id/hash color.
+  if (MAN_EMOJIS.indexOf(avatar) > -1 && !exclude.includes('blue')) {
     return 'blue';
-  } else if (WOMAN_EMOJIS.indexOf(avatar) > -1) {
+  } else if (WOMAN_EMOJIS.indexOf(avatar) > -1 && !exclude.includes('pink')) {
     return 'pink';
-  } else if (PERSON_EMOJIS.indexOf(avatar) > -1) {
+  } else if (
+    PERSON_EMOJIS.indexOf(avatar) > -1 &&
+    !exclude.includes('purple')
+  ) {
     return 'purple';
   }
 
-  // If publicId is in format animal-color-number, extract color
+  // If publicId is in format animal-color-number, extract color (unless that
+  // color is excluded, e.g. blue reserved for mediators).
   const splitId = (publicId ?? '').split('-');
-  if (splitId.length >= 3) {
+  if (splitId.length >= 3 && !exclude.includes(splitId[1])) {
     return splitId[1];
   }
 
   // Else, return hash-based color
-  return getHashBasedColor(publicId);
+  return getHashBasedColor(publicId, exclude);
 }
 
-/** Get random or hash-based color (e.g., for avatar backgroud). */
-export function getHashBasedColor(hashString = ''): string {
-  const COLORS = ['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink'];
+/** Get random or hash-based color (e.g., for avatar backgroud).
+ *  Colors in `exclude` are removed from the pool (e.g. to reserve blue for
+ *  mediators).
+ */
+export function getHashBasedColor(
+  hashString = '',
+  exclude: string[] = [],
+): string {
+  const allColors = [
+    'red',
+    'orange',
+    'yellow',
+    'green',
+    'blue',
+    'purple',
+    'pink',
+  ];
+  const COLORS = exclude.length
+    ? allColors.filter((color) => !exclude.includes(color))
+    : allColors;
   const index =
     hashString.length > 0
       ? getHashIntegerFromString(hashString) % COLORS.length
       : Math.floor(Math.random() * COLORS.length);
 
   return COLORS[index];
+}
+
+/** The color reserved for mediators when an experiment uses observers. */
+export const MEDIATOR_OBSERVER_COLOR = 'blue';
+
+/**
+ * Whether any of the given participants' variable assignments reference the
+ * `_isObserver` treatment variable. Used to gate the observer-specific chat
+ * colors (mediators shown in blue, that blue reserved away from other
+ * speakers) to experiments that actually assign observers.
+ */
+export function variableAssignmentsIncludeObserver(
+  participants: {variableMap?: Record<string, string>}[],
+): boolean {
+  return participants.some((participant) =>
+    Object.values(participant.variableMap ?? {}).some((value) =>
+      value.includes('_isObserver'),
+    ),
+  );
 }

--- a/frontend/src/shared/utils.ts
+++ b/frontend/src/shared/utils.ts
@@ -135,7 +135,7 @@ export function getHashBasedColor(
 }
 
 /** The color reserved for mediators when an experiment uses observers. */
-export const MEDIATOR_OBSERVER_COLOR = 'blue';
+export {MEDIATOR_OBSERVER_COLOR} from '@deliberation-lab/utils';
 
 /**
  * Whether any of the given participants' variable assignments reference the

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -440,6 +440,12 @@ export async function getAgentChatMessage(
     ) {
       return {message: null, success: true, retryTimedOut: false};
     }
+    // Quiz pause: if the chat is paused for a quiz, an agent that began its
+    // turn before the pause must not post. The turn resumes when the
+    // participant submits.
+    if (chatPublicData && (chatPublicData.quizPauseCheckpoint ?? 0) > 0) {
+      return {message: null, success: true, retryTimedOut: false};
+    }
   }
 
   // Confirm that agent can send chat messages based on prompt config

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -8,7 +8,10 @@ import {
   PrivateChatStageConfig,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
+  getTurnCycleInfo,
+  getTurnCycleStatusForPrompt,
   MediatorProfileExtended,
+  ModelResponse,
   ModelResponseStatus,
   ParticipantProfileExtended,
   StageConfig,
@@ -101,6 +104,41 @@ async function getPrivateChatRepProfileOverride(
     return null;
   }
   return getRepresentativeProfile(String(human.name || human.publicId));
+}
+
+// Fast-failing transient gRPC status codes for which a Firestore write is worth
+// retrying: UNKNOWN(2), DEADLINE_EXCEEDED(4), ABORTED(10), INTERNAL(13),
+// UNAVAILABLE(14). Under load the local emulator intermittently fails a commit
+// with "2 UNKNOWN" or blows the ~60s client deadline ("4 DEADLINE_EXCEEDED");
+// without a retry that surfaces as an unhandled error that kills the function
+// and stalls the turn-based chat (the message is never written, the turn never
+// advances). A fresh commit on retry typically succeeds once the load clears,
+// so retrying beats letting the chat go silent.
+const TRANSIENT_FIRESTORE_CODES = new Set([2, 4, 10, 13, 14]);
+async function firestoreWriteWithRetry<T>(
+  op: () => Promise<T>,
+  attempts = 4,
+): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await op();
+    } catch (error) {
+      lastError = error;
+      const code = (error as {code?: number})?.code;
+      if (
+        !TRANSIENT_FIRESTORE_CODES.has(code as number) ||
+        i === attempts - 1
+      ) {
+        throw error;
+      }
+      console.warn(
+        `[chat.agent] Transient Firestore write error (code ${code}); retry ${i + 1}/${attempts - 1}`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 250 * (i + 1)));
+    }
+  }
+  throw lastError;
 }
 
 /** Use persona chat prompt to create and send agent chat message. */
@@ -389,13 +427,13 @@ export async function getAgentChatMessage(
   const isTurnBasedPrivateChat =
     stage.kind === StageKind.PRIVATE_CHAT &&
     (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle;
+  let chatPublicData: ChatStagePublicData | undefined;
   if (isTurnBasedGroupChat) {
-    const publicStageData = await getFirestoreStagePublicData(
+    chatPublicData = (await getFirestoreStagePublicData(
       experimentId,
       cohortId,
       stageId,
-    );
-    const chatPublicData = publicStageData as ChatStagePublicData;
+    )) as ChatStagePublicData;
     if (
       chatPublicData &&
       chatPublicData.currentTurnParticipantId !== user.publicId
@@ -417,7 +455,7 @@ export async function getAgentChatMessage(
 
   // Use provided participant IDs for prompt context
   // Get structured prompt
-  const structuredPrompt = await getPromptFromConfig(
+  let structuredPrompt = await getPromptFromConfig(
     experimentId,
     cohortId,
     stageId,
@@ -425,6 +463,22 @@ export async function getAgentChatMessage(
     promptConfig,
     participantIds, // Pass participant IDs to limit context scope (e.g., for private chats)
   );
+
+  // For a turn-based group chat with a fixed message cap, tell the agent
+  // (participant or mediator) which cycle it is in and how many remain, so it
+  // can pace its contribution. No-op when not turn-based or there is no cap.
+  if (isTurnBasedGroupChat) {
+    const cycleInfo = getTurnCycleInfo(
+      chatPublicData,
+      stage as ChatStageConfig,
+    );
+    if (cycleInfo) {
+      structuredPrompt += `\n\n${getTurnCycleStatusForPrompt(
+        cycleInfo.currentCycle,
+        cycleInfo.totalCycles,
+      )}`;
+    }
+  }
 
   // Check if we should use message-based format
   // Only for private chat with exactly one participant AND one mediator
@@ -849,6 +903,10 @@ export async function skipTimedOutTurnBasedAgentTurn(
 
   const skipMessage = createSystemChatMessage({
     message: `${user.name ?? user.publicId} was skipped due to ${skipReason}.`,
+    // Use the firebase-admin Timestamp for this backend write: the util's
+    // default timestamp is a client-SDK (firebase/firestore) Timestamp, which
+    // firebase-admin cannot serialize (crashes the write, stalling the chat).
+    timestamp: Timestamp.now(),
   });
   await app
     .firestore()
@@ -889,21 +947,78 @@ export async function sendAgentGroupChatMessage(
   chatMessage: ChatMessage,
   chatSettings: AgentChatSettings,
 ) {
+  const capStage = await getFirestoreStage(experimentId, stageId);
+  const isTurnBasedGroup =
+    capStage?.kind === StageKind.CHAT &&
+    (capStage as ChatStageConfig).isTurnBased === true;
+
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
   if (chatSettings.wordsPerMinute) {
-    await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
+    // A turn-based chat's first message posts immediately.
+    const isFirstMessage =
+      isTurnBasedGroup &&
+      triggerChatId === '' &&
+      (
+        await getFirestorePublicStageChatMessages(
+          experimentId,
+          cohortId,
+          stageId,
+        )
+      ).every((m) => m.type === UserType.SYSTEM);
+    if (!isFirstMessage) {
+      await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
+    }
+  }
+
+  // Read the live cohort state once for both the cap guard and the
+  // conversation-moved-on check (avoids reading the chat history twice).
+  const [capPublicData, chatHistory] = await Promise.all([
+    getFirestoreStagePublicData(experimentId, cohortId, stageId) as Promise<
+      ChatStagePublicData | undefined
+    >,
+    getFirestorePublicStageChatMessages(experimentId, cohortId, stageId),
+  ]);
+
+  // Hard cap: never append a message past the effective message limit. The
+  // turn trigger ends the chat once the cap is reached, but an agent that began
+  // generating beforehand (or a slow/duplicate call) must not post its now-stale
+  // message past the limit. Drop it if the discussion already ended or the
+  // cohort is already at the cap. The count excludes the message we are
+  // about to write, so a message that itself reaches the cap is allowed.
+  if (capPublicData?.discussionEndTimestamp) {
+    console.log(
+      'Discussion already ended; dropping message to respect the cap',
+    );
+    return true;
+  }
+  const effectiveCap =
+    capPublicData?.effectiveMaxNumberOfMessages ??
+    (capStage?.kind === StageKind.CHAT
+      ? (capStage as ChatStageConfig).maxNumberOfMessages
+      : null);
+  if (effectiveCap != null) {
+    const capCount = chatHistory.filter(
+      (m) =>
+        m.type !== UserType.SYSTEM &&
+        !m.isError &&
+        !(m as {isReasoningOnly?: boolean}).isReasoningOnly,
+    ).length;
+    if (capCount >= effectiveCap) {
+      console.log(
+        'Cohort at message cap; dropping message to respect the limit',
+      );
+      return true;
+    }
   }
 
   // Check if the conversation has moved on,
-  // i.e., trigger chat ID is no longer that latest message
-  // Skip this check for initial messages (empty triggerChatId)
-  if (triggerChatId !== '') {
-    const chatHistory = await getFirestorePublicStageChatMessages(
-      experimentId,
-      cohortId,
-      stageId,
-    );
+  // i.e., trigger chat ID is no longer that latest message.
+  // Skip this check for initial messages (empty triggerChatId).
+  // Also skip it entirely for turn-based group chats: the turn order is
+  // deterministic, so a newer message never means this agent's turn was
+  // superseded. Dropping here would stall the whole turn-based chat.
+  if (triggerChatId !== '' && !isTurnBasedGroup) {
     const nonSystemHistory = chatHistory.filter(
       (m) => m.type !== UserType.SYSTEM,
     );
@@ -934,7 +1049,7 @@ export async function sendAgentGroupChatMessage(
     }
 
     // Otherwise, log response ID as trigger message
-    await triggerResponseDoc.set({});
+    await firestoreWriteWithRetry(() => triggerResponseDoc.set({}));
   }
 
   // Send chat message
@@ -950,7 +1065,7 @@ export async function sendAgentGroupChatMessage(
     .doc(chatMessage.id);
 
   chatMessage.timestamp = Timestamp.now();
-  await agentDocument.set(chatMessage);
+  await firestoreWriteWithRetry(() => agentDocument.set(chatMessage));
 
   return true;
 }
@@ -1030,7 +1145,7 @@ export async function sendAgentPrivateChatMessage(
     }
 
     // Otherwise, log response ID as trigger message
-    await triggerResponseDoc.set({});
+    await firestoreWriteWithRetry(() => triggerResponseDoc.set({}));
   }
 
   // Send chat message
@@ -1046,7 +1161,7 @@ export async function sendAgentPrivateChatMessage(
     .doc(chatMessage.id);
 
   chatMessage.timestamp = Timestamp.now();
-  await agentDocument.set(chatMessage);
+  await firestoreWriteWithRetry(() => agentDocument.set(chatMessage));
 
   return true;
 }

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -17,6 +17,7 @@ import {
   createChatMessage,
   createParticipantProfileBase,
   createSystemChatMessage,
+  getRepresentativeProfile,
   sanitizeRawResponseForLogging,
   shuffleWithSeed,
 } from '@deliberation-lab/utils';
@@ -36,6 +37,8 @@ import {
 import {updateParticipantReadyToEndChat} from '../chat/chat.utils';
 import {
   getExperimenterDataFromExperiment,
+  getFirestoreExperiment,
+  getFirestoreParticipant,
   getFirestorePublicStageChatMessages,
   getFirestorePrivateChatMessages,
   getFirestoreStage,
@@ -46,6 +49,10 @@ import {
   getPrivateChatTriggerLogRef,
   getFirestoreParticipantAnswerRef,
 } from '../utils/firestore';
+import {
+  getRoundTreatmentIndex,
+  treatmentAtIndexHasRepresentative,
+} from '../treatment.utils';
 import {app} from '../app';
 import {
   getChatMessageStoragePath,
@@ -59,6 +66,41 @@ import {updateModelLogFiles} from '../log.utils';
 
 // 300s cloud function timeout minus 10s buffer for skip handler.
 const TURN_BASED_AGENT_RETRY_TIMEOUT_MS = 290000;
+
+/**
+ * For a private chat in a `_hasRepresentative` round, the mediator is shown
+ * as the participant's representative. Returns that display profile, or null
+ * when it doesn't apply (not a private chat, not a mediator, or the round's
+ * treatment lacks `_hasRepresentative`). Read from the round's treatment
+ * because hoisting only happens later, at the transfer.
+ */
+async function getPrivateChatRepProfileOverride(
+  experimentId: string,
+  stage: StageConfig,
+  participantIds: string[],
+  user: ParticipantProfileExtended | MediatorProfileExtended,
+): Promise<{name: string; avatar: string} | null> {
+  if (stage.kind !== StageKind.PRIVATE_CHAT) return null;
+  if (user.type !== UserType.MEDIATOR) return null;
+  const humanId = participantIds[0];
+  if (!humanId) return null;
+  const human = await getFirestoreParticipant(experimentId, humanId);
+  if (!human?.variableMap) return null;
+  const experiment = await getFirestoreExperiment(experimentId);
+  const stageIds = experiment?.stageIds ?? [];
+  const stageIndex = stageIds.indexOf(stage.id);
+  if (stageIndex < 0) return null;
+  const roundIndex = await getRoundTreatmentIndex(
+    experimentId,
+    stageIds,
+    stageIndex,
+  );
+  if (roundIndex === null) return null;
+  if (!treatmentAtIndexHasRepresentative(human.variableMap, roundIndex)) {
+    return null;
+  }
+  return getRepresentativeProfile(String(human.name || human.publicId));
+}
 
 /** Use persona chat prompt to create and send agent chat message. */
 export async function createAgentChatMessageFromPrompt(
@@ -76,12 +118,31 @@ export async function createAgentChatMessageFromPrompt(
     return false;
   }
 
+  // Inactive personas supply persona context to other agents'
+  // prompts but never post chat messages themselves.
+  if (
+    user.type === UserType.PARTICIPANT &&
+    user.agentConfig.isInactivePersona
+  ) {
+    return false;
+  }
+
   // Stage (in order to determine stage kind)
   const stage = await getFirestoreStage(experimentId, stageId);
   if (!stage) {
     console.log(`[chat.agent] Stage ${stageId} not found`);
     return false;
   }
+
+  // Cosmetic: in `_hasRepresentative` conditions the private chat is
+  // presented as conducted by the participant's representative. Computed once;
+  // null unless this is a private-chat mediator message in such a condition.
+  const repProfileOverride = await getPrivateChatRepProfileOverride(
+    experimentId,
+    stage,
+    participantIds,
+    user,
+  );
 
   // Fetches stored (else default) prompt config for given stage
   const promptConfig = (await getStructuredPromptConfig(
@@ -247,6 +308,14 @@ export async function createAgentChatMessageFromPrompt(
       );
       return false;
     }
+    if (repProfileOverride && message) {
+      // Present the mediator as the participant's representative.
+      message.profile = {
+        ...message.profile,
+        name: repProfileOverride.name,
+        avatar: repProfileOverride.avatar,
+      };
+    }
     await sendAgentPrivateChatMessage(
       experimentId,
       privateChatParticipantId,
@@ -358,6 +427,7 @@ export async function getAgentChatMessage(
       cohortId,
       stageId,
       false, // checkIsAgent = false to get all mediators
+      stage,
     );
     mediatorCount = mediators.length;
   }
@@ -702,7 +772,13 @@ export async function skipTimedOutTurnBasedAgentTurn(
         ChatStagePublicData | undefined
       >,
       getFirestoreActiveParticipants(experimentId, cohortId, stage.id, false),
-      getFirestoreActiveMediators(experimentId, cohortId, stage.id, true),
+      getFirestoreActiveMediators(
+        experimentId,
+        cohortId,
+        stage.id,
+        true,
+        stage,
+      ),
       getFirestorePublicStageChatMessages(experimentId, cohortId, stage.id),
     ]);
 
@@ -1030,16 +1106,17 @@ async function sendInitialGroupChatMessages(
 
   const allParticipantIds = allParticipants.map((p) => p.privateId);
 
+  const stage = await getFirestoreStage(experimentId, stageId);
+  const chatStage = stage as ChatStageConfig;
+
   // Send initial messages from agent mediators
   const agentMediators = await getFirestoreActiveMediators(
     experimentId,
     cohortId,
     stageId,
     true, // checkIsAgent = true
+    stage ?? null,
   );
-
-  const stage = await getFirestoreStage(experimentId, stageId);
-  const chatStage = stage as ChatStageConfig;
 
   if (chatStage.isTurnBased) {
     const publicStageData = await getFirestoreStagePublicData(
@@ -1077,6 +1154,7 @@ async function sendInitialGroupChatMessages(
           .map((m) => m.publicId)
           .filter((id) => !existingIds.has(id));
         const newParticipantIds = allParticipants
+          .filter((p) => !p.isObserver && !p.agentConfig?.isInactivePersona)
           .map((p) => p.publicId)
           .filter((id) => !existingIds.has(id));
 
@@ -1110,7 +1188,9 @@ async function sendInitialGroupChatMessages(
 
     // If uninitialized
     if (!chatPublicData || !chatPublicData.currentTurnParticipantId) {
-      const allPublicParticipantIds = allParticipants.map((p) => p.publicId);
+      const allPublicParticipantIds = allParticipants
+        .filter((p) => !p.isObserver && !p.agentConfig?.isInactivePersona)
+        .map((p) => p.publicId);
       const allMediatorIds = agentMediators.map((m) => m.publicId);
 
       // Shuffle participants with seed
@@ -1221,7 +1301,9 @@ async function sendInitialGroupChatMessages(
   }
 
   // Send initial messages from agent participants
-  const agentParticipants = allParticipants.filter((p) => p.agentConfig);
+  const agentParticipants = allParticipants.filter(
+    (p) => p.agentConfig && !p.agentConfig.isInactivePersona,
+  );
 
   for (const participant of agentParticipants) {
     await createAgentChatMessageFromPrompt(
@@ -1251,7 +1333,10 @@ async function sendInitialPrivateChatMessages(
     cohortId,
     stageId,
     false, // checkIsAgent = false to get all participants
+    true, // includeObservers = true
   );
+
+  const stage = await getFirestoreStage(experimentId, stageId);
 
   // Get agent mediators
   const agentMediators = await getFirestoreActiveMediators(
@@ -1259,6 +1344,7 @@ async function sendInitialPrivateChatMessages(
     cohortId,
     stageId,
     true, // checkIsAgent = true
+    stage ?? null,
   );
 
   // For each participant (human or agent), send initial messages from agent mediators
@@ -1276,7 +1362,9 @@ async function sendInitialPrivateChatMessages(
   }
 
   // Also send initial messages from agent participants if they exist
-  const agentParticipants = allParticipants.filter((p) => p.agentConfig);
+  const agentParticipants = allParticipants.filter(
+    (p) => p.agentConfig && !p.agentConfig.isInactivePersona,
+  );
 
   for (const agentParticipant of agentParticipants) {
     await createAgentChatMessageFromPrompt(

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -5,6 +5,7 @@ import {
   ChatPromptConfig,
   ChatStageConfig,
   ChatStagePublicData,
+  PrivateChatStageConfig,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
   MediatorProfileExtended,
@@ -161,9 +162,15 @@ export async function createAgentChatMessageFromPrompt(
   const isPrivateChat = stage.kind === StageKind.PRIVATE_CHAT;
   const isTurnBasedGroupChat =
     stage.kind === StageKind.CHAT && (stage as ChatStageConfig).isTurnBased;
+  // Group-style turn-based private chats retry transient model errors until
+  // the deadline too: the participant is blocked waiting on the mediator, so
+  // we mirror the group-chat turn-based behavior rather than erroring out.
+  const isTurnBasedPrivateChat =
+    stage.kind === StageKind.PRIVATE_CHAT &&
+    (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle;
   const retryDeadlineMs =
     turnBasedRetryDeadlineMs ??
-    (isTurnBasedGroupChat
+    (isTurnBasedGroupChat || isTurnBasedPrivateChat
       ? Date.now() + TURN_BASED_AGENT_RETRY_TIMEOUT_MS
       : undefined);
 
@@ -379,6 +386,9 @@ export async function getAgentChatMessage(
   // For turn-based conversation, ensure it is the agent's turn
   const isTurnBasedGroupChat =
     stage.kind === StageKind.CHAT && (stage as ChatStageConfig).isTurnBased;
+  const isTurnBasedPrivateChat =
+    stage.kind === StageKind.PRIVATE_CHAT &&
+    (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle;
   if (isTurnBasedGroupChat) {
     const publicStageData = await getFirestoreStagePublicData(
       experimentId,
@@ -454,7 +464,8 @@ export async function getAgentChatMessage(
   }
 
   const retryDurationMs =
-    isTurnBasedGroupChat && turnBasedRetryDeadlineMs !== undefined
+    (isTurnBasedGroupChat || isTurnBasedPrivateChat) &&
+    turnBasedRetryDeadlineMs !== undefined
       ? Math.max(0, turnBasedRetryDeadlineMs - Date.now())
       : null;
 
@@ -494,7 +505,9 @@ export async function getAgentChatMessage(
     user.agentConfig.modelSettings,
     promptConfig.generationConfig,
     effectiveStructuredOutputConfig,
-    isTurnBasedGroupChat ? null : (promptConfig.numRetries ?? 0),
+    isTurnBasedGroupChat || isTurnBasedPrivateChat
+      ? null
+      : (promptConfig.numRetries ?? 0),
     retryDurationMs,
   );
 
@@ -951,16 +964,37 @@ export async function sendAgentPrivateChatMessage(
   chatMessage: ChatMessage,
   chatSettings: AgentChatSettings,
 ) {
+  const privateStage = await getFirestoreStage(experimentId, stageId);
+  const isTurnBasedPrivate =
+    privateStage?.kind === StageKind.PRIVATE_CHAT &&
+    (privateStage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true;
+
   // TODO: Decrease typing delay to account for LLM API call latencies?
   // TODO: Don't send message if conversation continues while agent is typing?
   if (chatSettings.wordsPerMinute) {
-    await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
+    // A turn-based chat's first message posts immediately.
+    const isFirstMessage =
+      isTurnBasedPrivate &&
+      triggerChatId === '' &&
+      (
+        await getFirestorePrivateChatMessages(
+          experimentId,
+          participantId,
+          stageId,
+        )
+      ).every((m) => m.type === UserType.SYSTEM);
+    if (!isFirstMessage) {
+      await awaitTypingDelay(chatMessage.message, chatSettings.wordsPerMinute);
+    }
   }
 
   // Check if the conversation has moved on,
-  // i.e., trigger chat ID is no longer that latest message
-  // Skip this check for initial messages (empty triggerChatId)
-  if (triggerChatId !== '') {
+  // i.e., trigger chat ID is no longer that latest message.
+  // Skip this check for initial messages (empty triggerChatId).
+  // Also skip it entirely for group-style turn-based private chats: the turn
+  // order is deterministic, so a newer message never means this agent's turn
+  // was superseded. Dropping here would stall the whole turn-based chat.
+  if (triggerChatId !== '' && !isTurnBasedPrivate) {
     const chatHistory = await getFirestorePrivateChatMessages(
       experimentId,
       participantId,

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -459,7 +459,7 @@ export async function getAgentChatMessage(
 
   // Use provided participant IDs for prompt context
   // Get structured prompt
-  let structuredPrompt = await getPromptFromConfig(
+  const structuredPrompt = await getPromptFromConfig(
     experimentId,
     cohortId,
     stageId,

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -8,8 +8,6 @@ import {
   PrivateChatStageConfig,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
-  getTurnCycleInfo,
-  getTurnCycleStatusForPrompt,
   MediatorProfileExtended,
   ModelResponse,
   ModelResponseStatus,
@@ -469,22 +467,6 @@ export async function getAgentChatMessage(
     promptConfig,
     participantIds, // Pass participant IDs to limit context scope (e.g., for private chats)
   );
-
-  // For a turn-based group chat with a fixed message cap, tell the agent
-  // (participant or mediator) which cycle it is in and how many remain, so it
-  // can pace its contribution. No-op when not turn-based or there is no cap.
-  if (isTurnBasedGroupChat) {
-    const cycleInfo = getTurnCycleInfo(
-      chatPublicData,
-      stage as ChatStageConfig,
-    );
-    if (cycleInfo) {
-      structuredPrompt += `\n\n${getTurnCycleStatusForPrompt(
-        cycleInfo.currentCycle,
-        cycleInfo.totalCycles,
-      )}`;
-    }
-  }
 
   // Check if we should use message-based format
   // Only for private chat with exactly one participant AND one mediator

--- a/functions/src/data.ts
+++ b/functions/src/data.ts
@@ -21,6 +21,7 @@ import {
   MediatorPromptConfig,
   ParticipantProfileExtended,
   ParticipantPromptConfig,
+  ParticipantThought,
   StageConfig,
   StageKind,
   StageParticipantAnswer,
@@ -160,6 +161,33 @@ export async function getExperimentDownload(
       for (const stage of stageAnswers) {
         participantDownload.answerMap[stage.id] = stage;
       }
+
+      // Fetch thoughts for all stages of this participant in parallel
+      const stageIdsWithThoughts = experimentConfig.stageIds || [];
+      const thoughtsQueries = stageIdsWithThoughts.map(async (stageId) => {
+        const thoughtsList = (
+          await firestore
+            .collection('experiments')
+            .doc(experimentId)
+            .collection('participants')
+            .doc(profile.privateId)
+            .collection('stageData')
+            .doc(stageId)
+            .collection('thoughts')
+            .orderBy('timestamp', 'asc')
+            .get()
+        ).docs.map((thoughtDoc) => thoughtDoc.data() as ParticipantThought);
+
+        return {stageId, thoughtsList};
+      });
+
+      const thoughtsResults = await Promise.all(thoughtsQueries);
+      for (const {stageId, thoughtsList} of thoughtsResults) {
+        if (thoughtsList.length > 0) {
+          participantDownload.thoughtMap[stageId] = thoughtsList;
+        }
+      }
+
       // Add ParticipantDownload to ExperimentDownload
       experimentDownload.participantMap[profile.publicId] = participantDownload;
     }

--- a/functions/src/data.ts
+++ b/functions/src/data.ts
@@ -188,6 +188,32 @@ export async function getExperimentDownload(
         }
       }
 
+      // Fetch private-chat (e.g. interview) messages for all stages in
+      // parallel. Private chats live in a per-participant subcollection and
+      // were previously excluded from the download, so interviews could not be
+      // recovered from the export.
+      const privateChatQueries = stageIdsWithThoughts.map(async (stageId) => {
+        const messages = (
+          await firestore
+            .collection('experiments')
+            .doc(experimentId)
+            .collection('participants')
+            .doc(profile.privateId)
+            .collection('stageData')
+            .doc(stageId)
+            .collection('privateChats')
+            .orderBy('timestamp', 'asc')
+            .get()
+        ).docs.map((chatDoc) => chatDoc.data() as ChatMessage);
+        return {stageId, messages};
+      });
+      const privateChatResults = await Promise.all(privateChatQueries);
+      for (const {stageId, messages} of privateChatResults) {
+        if (messages.length > 0) {
+          participantDownload.privateChatMap[stageId] = messages;
+        }
+      }
+
       // Add ParticipantDownload to ExperimentDownload
       experimentDownload.participantMap[profile.publicId] = participantDownload;
     }

--- a/functions/src/participant.endpoints.test.ts
+++ b/functions/src/participant.endpoints.test.ts
@@ -1,0 +1,240 @@
+import firebaseFunctionsTest from 'firebase-functions-test';
+import {HttpsError} from 'firebase-functions/v2/https';
+
+// Mock App and Firestore
+const mockGet = jest.fn();
+const mockSet = jest.fn().mockResolvedValue(undefined);
+
+// A deep fluent mock helper for Firestore
+const mockDocFn = jest.fn();
+const mockCollectionFn = jest.fn();
+
+mockDocFn.mockImplementation((path: string) => {
+  return {
+    get: async () => mockGet(path),
+    set: mockSet,
+    collection: mockCollectionFn,
+  };
+});
+
+mockCollectionFn.mockImplementation((_name: string) => {
+  return {
+    doc: mockDocFn,
+    collection: mockCollectionFn,
+  };
+});
+
+jest.mock('./app', () => ({
+  app: {
+    firestore: () => ({
+      collection: mockCollectionFn,
+      doc: mockDocFn,
+    }),
+  },
+}));
+
+// Provide stable thought ID
+jest.mock('@deliberation-lab/utils', () => {
+  const original = jest.requireActual('@deliberation-lab/utils');
+  return {
+    ...original,
+    generateId: () => 'mocked-thought-id',
+  };
+});
+
+import {submitParticipantThought} from './participant.endpoints';
+
+const testEnv = firebaseFunctionsTest({projectId: 'deliberate-lab-test'});
+
+describe('submitParticipantThought endpoint', () => {
+  let wrapped: (req: {data: unknown}) => Promise<unknown>;
+
+  beforeAll(() => {
+    wrapped = testEnv.wrap(submitParticipantThought) as (req: {
+      data: unknown;
+    }) => Promise<unknown>;
+  });
+
+  beforeEach(() => {
+    // Default valid scenario mocks
+    mockGet.mockImplementation((id) => {
+      if (id === 'exp-123') {
+        return {exists: true, data: () => ({})};
+      }
+      if (id === 'part-456') {
+        return {
+          exists: true,
+          data: () => ({isObserver: true, isQuizzed: true}),
+        };
+      }
+      if (id === 'stage-789') {
+        return {exists: true, data: () => ({})};
+      }
+      return {exists: false};
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('successfully saves a trimmed thought to the database', async () => {
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: '   My private observation thought!   ',
+    };
+
+    const response = await wrapped({data});
+
+    expect(response).toEqual({success: true});
+
+    // Verify correct collection/doc calls
+    expect(mockCollectionFn).toHaveBeenCalledWith('experiments');
+    expect(mockDocFn).toHaveBeenCalledWith('exp-123');
+    expect(mockCollectionFn).toHaveBeenCalledWith('participants');
+    expect(mockDocFn).toHaveBeenCalledWith('part-456');
+    expect(mockCollectionFn).toHaveBeenCalledWith('stageData');
+    expect(mockDocFn).toHaveBeenCalledWith('stage-789');
+    expect(mockCollectionFn).toHaveBeenCalledWith('thoughts');
+    expect(mockDocFn).toHaveBeenCalledWith('mocked-thought-id');
+
+    // Verify exact saved payload: trimmed text and auto timestamp
+    expect(mockSet).toHaveBeenCalledWith({
+      id: 'mocked-thought-id',
+      text: 'My private observation thought!',
+      timestamp: expect.any(Object), // Timestamp.now()
+    });
+  });
+
+  it('fails if the experiment does not exist', async () => {
+    mockGet.mockImplementation((id) => {
+      if (id === 'exp-123') {
+        return {exists: false}; // Experiment not found
+      }
+      return {
+        exists: true,
+        data: () => ({isObserver: true, isQuizzed: true}),
+      };
+    });
+
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: 'Valid text',
+    };
+
+    await expect(wrapped({data})).rejects.toThrow(
+      new HttpsError('not-found', 'Experiment not found'),
+    );
+  });
+
+  it('fails if the participant does not exist', async () => {
+    mockGet.mockImplementation((id) => {
+      if (id === 'exp-123') {
+        return {exists: true, data: () => ({})};
+      }
+      if (id === 'part-456') {
+        return {exists: false}; // Participant not found
+      }
+      return {exists: true, data: () => ({})};
+    });
+
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: 'Valid text',
+    };
+
+    await expect(wrapped({data})).rejects.toThrow(
+      new HttpsError('not-found', 'Participant not found'),
+    );
+  });
+
+  it('fails if the stage does not exist', async () => {
+    mockGet.mockImplementation((id) => {
+      if (id === 'exp-123') {
+        return {exists: true, data: () => ({})};
+      }
+      if (id === 'part-456') {
+        return {
+          exists: true,
+          data: () => ({isObserver: true, isQuizzed: true}),
+        };
+      }
+      if (id === 'stage-789') {
+        return {exists: false}; // Stage not found
+      }
+      return {exists: false};
+    });
+
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: 'Valid text',
+    };
+
+    await expect(wrapped({data})).rejects.toThrow(
+      new HttpsError('not-found', 'Stage not found'),
+    );
+  });
+
+  it("fails if the participant's treatment does not include the quiz", async () => {
+    mockGet.mockImplementation((id) => {
+      if (id === 'exp-123') {
+        return {exists: true, data: () => ({})};
+      }
+      if (id === 'part-456') {
+        return {exists: true, data: () => ({isObserver: false})}; // Treatment without the quiz
+      }
+      if (id === 'stage-789') {
+        return {exists: true, data: () => ({})};
+      }
+      return {exists: false};
+    });
+
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: 'Valid text',
+    };
+
+    await expect(wrapped({data})).rejects.toThrow(
+      new HttpsError(
+        'permission-denied',
+        "Participant's treatment does not include the quiz",
+      ),
+    );
+  });
+
+  it('fails when input is invalid or missing required fields', async () => {
+    const invalidData = {
+      experimentId: 'exp-123',
+      participantId: '', // Invalid empty string
+      stageId: 'stage-789',
+      text: 'Valid text',
+    };
+
+    await expect(wrapped({data: invalidData})).rejects.toThrow(
+      new HttpsError('invalid-argument', 'Invalid data'),
+    );
+  });
+
+  it('fails when text is empty or all whitespaces', async () => {
+    const data = {
+      experimentId: 'exp-123',
+      participantId: 'part-456',
+      stageId: 'stage-789',
+      text: '    ', // Only whitespaces
+    };
+
+    await expect(wrapped({data})).rejects.toThrow(
+      new HttpsError('invalid-argument', 'Text cannot be empty'),
+    );
+  });
+});

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -18,14 +18,21 @@ import {
   ChatStageConfig,
   MEDIATOR_OBSERVER_COLOR,
   variableConfigsIncludeObserver,
+  generateId,
+  SubmitParticipantThoughtData,
 } from '@deliberation-lab/utils';
 import {
+  getFirestoreActiveMediators,
+  getFirestoreActiveParticipants,
   getFirestoreCohort,
   getFirestoreStage,
   getFirestoreStagePublicData,
+  getFirestoreStagePublicDataRef,
   getFirestorePrivateChatMessages,
+  getFirestorePublicStageChatMessages,
 } from './utils/firestore';
 import {sendInitialChatMessages} from './chat/chat.agent';
+import {triggerNextTurnHolder} from './triggers/chat.triggers';
 import {
   updateCohortStageUnlocked,
   updateParticipantNextStage,
@@ -852,6 +859,150 @@ export const updateParticipantStatus = onCall(async (request) => {
     participant.currentStatus = data.status;
     transaction.set(document, participant);
   });
+
+  return {success: true};
+});
+
+// ************************************************************************* //
+// submitParticipantThought endpoint                                         //
+//                                                                           //
+// Input structure: { experimentId, participantId, stageId, text,            //
+//   checkpoint, rating }                                                    //
+// Validation: utils/src/participant.validation.ts                           //
+// ************************************************************************* //
+export const submitParticipantThought = onCall(async (request) => {
+  const {data} = request;
+
+  const validInput = Value.Check(SubmitParticipantThoughtData, data);
+  if (!validInput) {
+    throw new HttpsError('invalid-argument', 'Invalid data');
+  }
+
+  const {experimentId, participantId, stageId, text, checkpoint, rating} = data;
+
+  const trimmedText = text.trim();
+  if (trimmedText.length === 0) {
+    throw new HttpsError('invalid-argument', 'Text cannot be empty');
+  }
+
+  // Fetch parent entities in parallel to ensure their existence and check access permissions
+  const [experimentDoc, participantDoc, stageDoc] = await Promise.all([
+    app.firestore().collection('experiments').doc(experimentId).get(),
+    app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('participants')
+      .doc(participantId)
+      .get(),
+    app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('stages')
+      .doc(stageId)
+      .get(),
+  ]);
+
+  if (!experimentDoc.exists) {
+    throw new HttpsError('not-found', 'Experiment not found');
+  }
+
+  if (!participantDoc.exists) {
+    throw new HttpsError('not-found', 'Participant not found');
+  }
+
+  const participant = participantDoc.data() as ParticipantProfileExtended;
+  if (!participant.isQuizzed) {
+    throw new HttpsError(
+      'permission-denied',
+      "Participant's treatment does not include the quiz",
+    );
+  }
+
+  if (!stageDoc.exists) {
+    throw new HttpsError('not-found', 'Stage not found');
+  }
+
+  const thoughtId = generateId();
+  const timestamp = Timestamp.now();
+
+  const thoughtRef = app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('participants')
+    .doc(participantId)
+    .collection('stageData')
+    .doc(stageId)
+    .collection('thoughts')
+    .doc(thoughtId);
+
+  await thoughtRef.set({
+    id: thoughtId,
+    text: trimmedText,
+    ...(rating != null ? {rating} : {}),
+    timestamp,
+  });
+
+  // Quiz pause: submitting the quiz records the
+  // answered checkpoint, clears the chat's pause, and resumes the stalled turn.
+  // No new chat message arrives to re-fire onPublicChatMessageCreated, so the
+  // resume must be explicit here. quizAnsweredCheckpoint is recorded so the
+  // trigger does not immediately re-pause for the checkpoint just answered.
+  if (checkpoint != null && participant.isQuizzed) {
+    const cohortId = participant.currentCohortId;
+    await getFirestoreStagePublicDataRef(
+      experimentId,
+      cohortId,
+      stageId,
+    ).update({quizPauseCheckpoint: 0, quizAnsweredCheckpoint: checkpoint});
+
+    // Resume the turn that was paused: re-dispatch the current turn holder.
+    const publicStageData = (await getFirestoreStagePublicData(
+      experimentId,
+      cohortId,
+      stageId,
+    )) as ChatStagePublicData | undefined;
+    const currentTurnId = publicStageData?.currentTurnParticipantId;
+    if (currentTurnId) {
+      const [mediators, participants, chatMessages] = await Promise.all([
+        getFirestoreActiveMediators(experimentId, cohortId, stageId, true),
+        getFirestoreActiveParticipants(
+          experimentId,
+          cohortId,
+          stageId,
+          false,
+          true, // include observers (for non-observer participant ID context)
+        ),
+        getFirestorePublicStageChatMessages(experimentId, cohortId, stageId),
+      ]);
+      const nextMediatorHolder = mediators.find(
+        (m) => m.publicId === currentTurnId,
+      );
+      const nextTurnHolder = participants.find(
+        (p) => p.publicId === currentTurnId,
+      );
+      const allParticipantIds = participants
+        .filter((p) => !p.isObserver)
+        .map((p) => p.privateId);
+      // Use the latest message ID as the trigger so the resumed agent responds
+      // to the conversation as it stands, and so the empty-triggerChatId
+      // "initial message" lock (already taken when the chat began) does not
+      // silently swallow the resume.
+      const latestMessageId =
+        chatMessages.length > 0 ? chatMessages[chatMessages.length - 1].id : '';
+      await triggerNextTurnHolder(
+        experimentId,
+        cohortId,
+        allParticipantIds,
+        stageId,
+        latestMessageId,
+        nextMediatorHolder,
+        nextTurnHolder,
+      );
+    }
+  }
 
   return {success: true};
 });

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -16,6 +16,8 @@ import {
   getTimeElapsed,
   ChatStagePublicData,
   ChatStageConfig,
+  MEDIATOR_OBSERVER_COLOR,
+  variableConfigsIncludeObserver,
 } from '@deliberation-lab/utils';
 import {
   getFirestoreCohort,
@@ -142,6 +144,14 @@ export const createParticipant = onCall(async (request) => {
         .get()
     ).data().count;
 
+    // When any treatment can assign observers, the mediator color is reserved
+    // and participant profiles must not be generated with it.
+    const reservedProfileColor = variableConfigsIncludeObserver(
+      experiment.variableConfigs ?? [],
+    )
+      ? MEDIATOR_OBSERVER_COLOR
+      : undefined;
+
     // Set participant profile fields
     if (data.isAnonymous) {
       // Find the profile stage to determine which anonymous profile type to use
@@ -158,9 +168,21 @@ export const createParticipant = onCall(async (request) => {
       const profileType =
         profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
 
-      setProfile(numParticipants, participantConfig, true, profileType);
+      setProfile(
+        numParticipants,
+        participantConfig,
+        true,
+        profileType,
+        reservedProfileColor,
+      );
     } else {
-      setProfile(numParticipants, participantConfig, false);
+      setProfile(
+        numParticipants,
+        participantConfig,
+        false,
+        undefined,
+        reservedProfileColor,
+      );
     }
 
     // Set current stage ID in participant config

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -31,7 +31,9 @@ import {
   completeParticipantTransfer,
   executeDirectTransfers,
   DirectTransferInstructions,
+  applyHoistedTreatment,
 } from './participant.utils';
+
 import {generateVariablesForScope} from './variables.utils';
 
 import {onCall, HttpsError} from 'firebase-functions/v2/https';
@@ -45,7 +47,9 @@ import {
   prettyPrintErrors,
 } from './utils/validation';
 
-/** Create, update, and delete participants. */
+const formatAgentName = (nameOrPublicId: string) => {
+  return String(nameOrPublicId || 'Agent') + "'s Agent";
+};
 
 // ************************************************************************* //
 // createParticipant endpoint                                                //
@@ -83,6 +87,9 @@ export const createParticipant = onCall(async (request) => {
   const participantConfig = createParticipantProfileExtended({
     currentCohortId: data.cohortId,
     prolificId: data.prolificId,
+    isObserver: data.isObserver ?? false,
+    hasRepresentative: data.hasRepresentative ?? false,
+    otherAgentGeneration: data.otherAgentGeneration,
   });
 
   // Temporarily always mark participants as connected (PR #537)
@@ -170,7 +177,52 @@ export const createParticipant = onCall(async (request) => {
       },
     );
 
-    // Write new participant document
+    // Hoist treatment fields from the participant's assigned variables onto the
+    // participant (round 0). Shared with the per-transfer re-hoist so both the
+    // array and expanded (_1/_2/...) multi-value formats behave identically.
+    if (!participantConfig.agentConfig && participantConfig.variableMap) {
+      applyHoistedTreatment(
+        participantConfig as unknown as Record<string, unknown>,
+        participantConfig.variableMap,
+        0,
+      );
+    }
+
+    // Fetch existing cohort participants for checking observer status and renaming (Reads first!)
+    const cohortParticipants = (
+      await app
+        .firestore()
+        .collection(`experiments/${data.experimentId}/participants`)
+        .where('currentCohortId', '==', data.cohortId)
+        .get()
+    ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
+
+    const hasObserver = cohortParticipants.some(
+      (p) =>
+        !p.agentConfig &&
+        p.isObserver &&
+        p.currentStatus !== ParticipantStatus.DELETED,
+    );
+
+    // If the new participant is an agent and there's an observer in the cohort, rename them
+    if (participantConfig.agentConfig && hasObserver) {
+      participantConfig.name = formatAgentName(
+        participantConfig.name || participantConfig.publicId,
+      );
+      // Also update anonymous profiles
+      for (const profileSetId of Object.keys(
+        participantConfig.anonymousProfiles,
+      )) {
+        if (participantConfig.anonymousProfiles[profileSetId].name) {
+          participantConfig.anonymousProfiles[profileSetId].name =
+            formatAgentName(
+              participantConfig.anonymousProfiles[profileSetId].name,
+            );
+        }
+      }
+    }
+
+    // Write new participant document (All writes happen at the end!)
     transaction.set(document, participantConfig);
   });
 
@@ -258,6 +310,7 @@ export const updateParticipantWaiting = onCall(async (request) => {
       participant.currentCohortId,
       participant.currentStageId,
       participant.privateId,
+      transaction,
     );
 
     transaction.set(document, participant);
@@ -514,6 +567,7 @@ export const acceptParticipantExperimentStart = onCall(
         participant.currentCohortId,
         participant.currentStageId,
         participant.privateId,
+        transaction,
       );
 
       transaction.set(document, participant);

--- a/functions/src/participant.endpoints.ts
+++ b/functions/src/participant.endpoints.ts
@@ -950,13 +950,34 @@ export const submitParticipantThought = onCall(async (request) => {
   // No new chat message arrives to re-fire onPublicChatMessageCreated, so the
   // resume must be explicit here. quizAnsweredCheckpoint is recorded so the
   // trigger does not immediately re-pause for the checkpoint just answered.
+  // The submitted checkpoint is not trusted blindly: when a reply is lost in
+  // transit the participant submits the same answer again, and by then a newer
+  // quiz may have been raised. Writing the resend's number as-is would clear
+  // that newer quiz while recording progress below it, leaving nothing on
+  // screen and the stage impossible to pass. So the answered counter never
+  // moves backwards, and the pause is only cleared by an answer to the quiz
+  // it is currently showing (or later).
   if (checkpoint != null && participant.isQuizzed) {
     const cohortId = participant.currentCohortId;
-    await getFirestoreStagePublicDataRef(
+    const publicDataRef = getFirestoreStagePublicDataRef(
       experimentId,
       cohortId,
       stageId,
-    ).update({quizPauseCheckpoint: 0, quizAnsweredCheckpoint: checkpoint});
+    );
+    await app.firestore().runTransaction(async (transaction) => {
+      const current = (await transaction.get(publicDataRef)).data() as
+        | ChatStagePublicData
+        | undefined;
+      const answered = Math.max(
+        current?.quizAnsweredCheckpoint ?? 0,
+        checkpoint,
+      );
+      const pause = current?.quizPauseCheckpoint ?? 0;
+      transaction.update(publicDataRef, {
+        quizAnsweredCheckpoint: answered,
+        ...(pause <= checkpoint ? {quizPauseCheckpoint: 0} : {}),
+      });
+    });
 
     // Resume the turn that was paused: re-dispatch the current turn holder.
     const publicStageData = (await getFirestoreStagePublicData(

--- a/functions/src/participant.utils.test.ts
+++ b/functions/src/participant.utils.test.ts
@@ -1,5 +1,12 @@
 import {STAGE_KIND_REQUIRES_TRANSFER_MIGRATION} from '@deliberation-lab/utils';
-import {TRANSFER_MIGRATION_HANDLERS} from './participant.utils';
+import {
+  TRANSFER_MIGRATION_HANDLERS,
+  applyHoistedTreatment,
+} from './participant.utils';
+import {
+  treatmentAtIndexSkipsPrivateChats,
+  treatmentSkipsPrivateChats,
+} from './treatment.utils';
 
 describe('TRANSFER_MIGRATION_HANDLERS', () => {
   it('should have a handler for every stage kind that requires transfer migration', () => {
@@ -13,5 +20,128 @@ describe('TRANSFER_MIGRATION_HANDLERS', () => {
     const kindsWithHandlers = Object.keys(TRANSFER_MIGRATION_HANDLERS).sort();
 
     expect(kindsWithHandlers).toEqual(kindsRequiringMigration);
+  });
+});
+
+describe('treatmentSkipsPrivateChats', () => {
+  // Array form (expandListToSeparateVariables: false): a single `treatment`
+  // variable holding the list of condition objects.
+  const arrayTreatment = (order: Array<'skip' | 'keep'>) => ({
+    treatment: JSON.stringify(
+      order.map((kind, i) => ({
+        treatmentName: `cond${i}`,
+        _skipPrivateChats: kind === 'skip',
+      })),
+    ),
+  });
+
+  it('returns true when any treatment condition sets _skipPrivateChats', () => {
+    expect(
+      treatmentSkipsPrivateChats(arrayTreatment(['keep', 'skip', 'keep'])),
+    ).toBe(true);
+    expect(treatmentSkipsPrivateChats(arrayTreatment(['skip']))).toBe(true);
+  });
+
+  it('supports the expanded name_N form (treatment_1, treatment_2, ...)', () => {
+    const vm = {
+      treatment_1: JSON.stringify({
+        treatmentName: 'a',
+        _skipPrivateChats: false,
+      }),
+      treatment_2: JSON.stringify({
+        treatmentName: 'b',
+        _skipPrivateChats: true,
+      }),
+    };
+    expect(treatmentSkipsPrivateChats(vm)).toBe(true);
+  });
+
+  it('returns false when absent, missing, false, or non-JSON', () => {
+    expect(treatmentSkipsPrivateChats(undefined)).toBe(false);
+    expect(treatmentSkipsPrivateChats({})).toBe(false);
+    expect(treatmentSkipsPrivateChats({treatment: 'not json'})).toBe(false);
+    expect(treatmentSkipsPrivateChats(arrayTreatment(['keep']))).toBe(false);
+  });
+});
+
+describe('treatmentAtIndexSkipsPrivateChats', () => {
+  const arrayTreatment = (order: Array<'skip' | 'keep'>) => ({
+    treatment: JSON.stringify(
+      order.map((kind, i) => ({
+        treatmentName: `cond${i}`,
+        _skipPrivateChats: kind === 'skip',
+      })),
+    ),
+  });
+
+  it('reports only the flag of the requested round (within-subjects)', () => {
+    const vm = arrayTreatment(['skip', 'keep', 'skip']);
+    expect(treatmentAtIndexSkipsPrivateChats(vm, 0)).toBe(true);
+    // Each round's skip flag is independent: one round's skip must not skip
+    // another round's private chat.
+    expect(treatmentAtIndexSkipsPrivateChats(vm, 1)).toBe(false);
+    expect(treatmentAtIndexSkipsPrivateChats(vm, 2)).toBe(true);
+  });
+
+  it('supports the expanded name_N form per round', () => {
+    const vm = {
+      treatment_1: JSON.stringify({
+        treatmentName: 'a',
+        _skipPrivateChats: true,
+      }),
+      treatment_2: JSON.stringify({
+        treatmentName: 'b',
+        _skipPrivateChats: false,
+      }),
+    };
+    expect(treatmentAtIndexSkipsPrivateChats(vm, 0)).toBe(true); // treatment_1
+    expect(treatmentAtIndexSkipsPrivateChats(vm, 1)).toBe(false); // treatment_2
+  });
+
+  it('returns false when absent, missing, or out of range', () => {
+    expect(treatmentAtIndexSkipsPrivateChats(undefined, 0)).toBe(false);
+    expect(treatmentAtIndexSkipsPrivateChats({}, 0)).toBe(false);
+    expect(treatmentAtIndexSkipsPrivateChats(arrayTreatment(['skip']), 5)).toBe(
+      false,
+    );
+  });
+});
+
+describe('applyHoistedTreatment', () => {
+  it('resets omitted hoist fields across rounds (within-subjects rotation)', () => {
+    const variableMap = {
+      treatment: JSON.stringify([
+        {_isObserver: true, _swapMediator: 'mediatorB', _numOtherAgents: 4},
+        {_numOtherAgents: 0}, // round 1 omits _isObserver and _swapMediator
+      ]),
+    };
+    const target: Record<string, unknown> = {};
+
+    applyHoistedTreatment(target, variableMap, 0);
+    expect(target.isObserver).toBe(true);
+    expect(target.swapMediator).toBe('mediatorB');
+
+    // Re-hoist round 1 on the SAME target (simulates a transfer re-hoist).
+    applyHoistedTreatment(target, variableMap, 1);
+    // Omitted keys must reset to "off", not leak round 0's values.
+    expect(target.isObserver).toBe(false);
+    expect(target.swapMediator).toBe('');
+    expect(
+      (target.otherAgentGeneration as {numOtherAgents: number}).numOtherAgents,
+    ).toBe(0);
+  });
+
+  it('leaves fields untouched when the variable scheme has no treatment keys', () => {
+    const target: Record<string, unknown> = {
+      isObserver: true,
+      swapMediator: 'manual',
+    };
+    applyHoistedTreatment(
+      target,
+      {topic: JSON.stringify([{topicName: 'T'}])},
+      0,
+    );
+    expect(target.isObserver).toBe(true);
+    expect(target.swapMediator).toBe('manual');
   });
 });

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -67,6 +67,7 @@ import {
   treatmentSkipsPrivateChats,
 } from './treatment.utils';
 import {createMediatorProfileForPersona} from './mediator.utils';
+import {computeRoundVariableMap, personaMatchHash} from './persona_bank.utils';
 
 import {app} from './app';
 
@@ -1476,6 +1477,23 @@ export async function completeParticipantTransfer(
     );
   }
 
+  // Persona bank match key for this round, applied below to the spawned
+  // other-agents and inactive personas (not the representative, which
+  // draws on its principal's own persona content). Undefined when the transfer names
+  // no treatment index (those agents then fall back to standard generation).
+  let personaHash: string | undefined;
+  if (
+    currentStage?.kind === StageKind.TRANSFER &&
+    typeof (currentStage as TransferStageConfig).treatmentIndex === 'number' &&
+    participant.variableMap
+  ) {
+    const roundVariables = computeRoundVariableMap(
+      participant.variableMap,
+      (currentStage as TransferStageConfig).treatmentIndex as number,
+    );
+    personaHash = personaMatchHash(roundVariables);
+  }
+
   const otherAgentGeneration = participant.otherAgentGeneration;
   const numOtherAgents = otherAgentGeneration?.numOtherAgents ?? 0;
   const numInactivePersonas = otherAgentGeneration?.numInactivePersonas ?? 0;
@@ -1663,10 +1681,30 @@ export async function completeParticipantTransfer(
           // observer's representative above so every representative operates
           // from the same prompt input: the represented person's own
           // responses, not a persona to embody.
-          agentProfile.agentConfig.promptContext = `You are ${representedName}'s representative in this discussion. You are a separate agent, not ${representedName} yourself. Speak and advocate on ${representedName}'s behalf, representing their perspective from their persona description below, rather than expressing your own independent opinions or adopting their persona as your own identity. Ensure you properly separate every paragraph with one empty line.\n\n${representedName}'s persona:`;
+          agentProfile.agentConfig.promptContext = `You are ${representedName}'s representative in this discussion. You are a separate agent, not ${representedName} yourself. Speak and advocate on ${representedName}'s behalf, representing their perspective from their responses below, rather than expressing your own independent opinions or adopting their persona as your own identity. Ensure you properly separate every paragraph with one empty line.\n\n${representedName}'s responses:`;
+          // Representatives draw a persona from the bank (keyed by the
+          // round's variables), not a slot-based one.
+          delete agentProfile.agentConfig.personaSlotKey;
+          if (personaHash) {
+            agentProfile.agentConfig.personaHash = personaHash;
+          }
         }
       } else if (!agentProfile.name) {
         agentProfile.name = `Agent ${agentProfile.publicId.substring(0, 8)}`;
+      }
+
+      // Direct-participation (no-observer) agents draw a PLAIN persona (a
+      // character sketch) from the bank instead of generating one live at
+      // spawn, so group-chat setup is fast. Sketches are topic/treatment-
+      // agnostic, so any bank persona's sketch works ("personas are personas").
+      // The persona-generation trigger claims one keyed to the HUMAN, so a
+      // participant never gets the same persona twice across their rounds, and
+      // sets it as the agent's own persona. Falls
+      // back to live generation if the bank has no unused sketch.
+      if (!cohortHasObserver && agentProfile.agentConfig) {
+        agentProfile.agentConfig.personaSketchForHumanId =
+          participant.privateId;
+        delete agentProfile.agentConfig.personaSlotKey;
       }
 
       // Share the transferring participant's content variables (e.g. the
@@ -1719,6 +1757,11 @@ export async function completeParticipantTransfer(
 
       if (!agentProfile.name) {
         agentProfile.name = `Agent ${agentProfile.publicId.substring(0, 8)}`;
+      }
+
+      // Inactive personas draw a persona from the bank.
+      if (personaHash && agentProfile.agentConfig) {
+        agentProfile.agentConfig.personaHash = personaHash;
       }
 
       agentProfile.variableMap = inheritSpawnedAgentVariables(

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -1206,6 +1206,8 @@ const TREATMENT_HOIST_FIELDS: Record<
     type: 'number',
   },
   _swapMediator: {field: 'swapMediator', type: 'string'},
+  // Whether this round's treatment includes the periodic group-chat quiz.
+  _isQuizzed: {field: 'isQuizzed', type: 'boolean'},
 };
 
 /**

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -38,6 +38,16 @@ import {
   SurveyStagePublicData,
   TransferGroup,
   TransferStageConfig,
+  createParticipantProfileExtended,
+  getRepresentativeProfile,
+  createProgressTimestamps,
+  setProfile,
+  ProfileType,
+  ProfileStageConfig,
+  AgentPersonaConfig,
+  MediatorProfileExtended,
+  DEFAULT_AGENT_MODEL_SETTINGS,
+  RESERVED_TREATMENT_VARIABLE_KEYS,
 } from '@deliberation-lab/utils';
 import {completeStageAsAgentParticipant} from './agent_participant.utils';
 import {
@@ -51,6 +61,12 @@ import {
 import {generateId, UnifiedTimestamp} from '@deliberation-lab/utils';
 import {createCohortInternal} from './cohort.utils';
 import {sendSystemChatMessage} from './chat/chat.utils';
+import {
+  getRoundTreatmentIndex,
+  treatmentAtIndexSkipsPrivateChats,
+  treatmentSkipsPrivateChats,
+} from './treatment.utils';
+import {createMediatorProfileForPersona} from './mediator.utils';
 
 import {app} from './app';
 
@@ -210,22 +226,62 @@ export async function updateParticipantNextStage(
     participant.currentStatus = ParticipantStatus.SUCCESS;
     response.endExperiment = true;
   } else {
-    // Else, progress to next stage
-    const nextStageId = stageIds[currentStageIndex + 1];
-    participant.currentStageId = nextStageId;
-    response.currentStageId = nextStageId;
+    // Else, progress to the next stage, skipping a private chat only when the
+    // treatment for that round sets `_skipPrivateChats`. In a within-subjects
+    // design, a round that skips its own private chat must not also skip
+    // another round's. The round is attributed via the following
+    // transfer's treatmentIndex; if a private chat can't be attributed to a
+    // round, fall back to the round-independent flag. Read directly from the
+    // treatment (not a hoisted field) because a private chat can precede the
+    // transfer stage where treatment is hoisted.
+    let nextStageIndex = currentStageIndex + 1;
+    while (nextStageIndex < stageIds.length) {
+      const candidateId = stageIds[nextStageIndex];
+      const candidate = await getFirestoreStage(experimentId, candidateId);
+      if (candidate?.kind === StageKind.PRIVATE_CHAT) {
+        const roundIndex = await getRoundTreatmentIndex(
+          experimentId,
+          stageIds,
+          nextStageIndex,
+        );
+        const skip =
+          roundIndex !== null
+            ? treatmentAtIndexSkipsPrivateChats(
+                participant.variableMap,
+                roundIndex,
+              )
+            : treatmentSkipsPrivateChats(participant.variableMap);
+        if (skip) {
+          // Bypass this private chat entirely: never mark it reached/current.
+          nextStageIndex++;
+          continue;
+        }
+      }
+      break;
+    }
 
-    // Mark next stage as reached
-    participant.timestamps.readyStages[nextStageId] = timestamp;
+    if (nextStageIndex >= stageIds.length) {
+      // Skipping ran past the last stage, so end the experiment.
+      participant.timestamps.endExperiment = timestamp;
+      participant.currentStatus = ParticipantStatus.SUCCESS;
+      response.endExperiment = true;
+    } else {
+      const nextStageId = stageIds[nextStageIndex];
+      participant.currentStageId = nextStageId;
+      response.currentStageId = nextStageId;
 
-    // If all active participants have reached the next stage,
-    // unlock that stage in CohortConfig
-    await updateCohortStageUnlocked(
-      experimentId,
-      participant.currentCohortId,
-      participant.currentStageId,
-      participant.privateId,
-    );
+      // Mark next stage as reached
+      participant.timestamps.readyStages[nextStageId] = timestamp;
+
+      // If all active participants have reached the next stage,
+      // unlock that stage in CohortConfig
+      await updateCohortStageUnlocked(
+        experimentId,
+        participant.currentCohortId,
+        participant.currentStageId,
+        participant.privateId,
+      );
+    }
   }
 
   return response;
@@ -240,8 +296,9 @@ export async function updateCohortStageUnlocked(
   cohortId: string,
   stageId: string,
   currentParticipantId: string,
+  existingTransaction?: FirebaseFirestore.Transaction,
 ) {
-  await app.firestore().runTransaction(async (transaction) => {
+  const runLogic = async (transaction: FirebaseFirestore.Transaction) => {
     // Get active participants for given cohort
     const activeParticipants = await getFirestoreActiveParticipants(
       experimentId,
@@ -260,8 +317,13 @@ export async function updateCohortStageUnlocked(
         .get()
     ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
 
-    // Consider both participants actively in cohort and pending transfer
-    const participants = [...activeParticipants, ...transferParticipants];
+    // Consider both participants actively in cohort and pending transfer.
+    // Inactive personas are excluded: they never chat or take a turn,
+    // so they must not count toward (or block) the stage unlock gate.
+    const participants = [
+      ...activeParticipants,
+      ...transferParticipants,
+    ].filter((p) => !p.agentConfig?.isInactivePersona);
 
     // Get current stage config
     const stage = (
@@ -341,7 +403,13 @@ export async function updateCohortStageUnlocked(
         completeStageAsAgentParticipant(experiment, participant);
       } // end agent participant if
     } // end participant loop
-  });
+  };
+
+  if (existingTransaction) {
+    await runLogic(existingTransaction);
+  } else {
+    await app.firestore().runTransaction(runLogic);
+  }
 }
 
 /** Automatically transfer participants based on config type. */
@@ -960,28 +1028,27 @@ async function handleConditionAutoTransfer(
         ? definition.maxParticipantsPerCohort
         : experiment.defaultCohortConfig.maxParticipantsPerCohort;
 
-    if (maxParticipants !== null) {
-      const participants = await getFirestoreCohortParticipants(
-        experimentId,
-        targetCohortId,
+    const participants = await getFirestoreCohortParticipants(
+      experimentId,
+      targetCohortId,
+    );
+    if (
+      (maxParticipants !== null &&
+        participants.length + cohortParticipants.length > maxParticipants) ||
+      (participants.some((p) => !p.agentConfig && p.isObserver) &&
+        cohortParticipants.some((p) => !p.agentConfig && !p.isObserver))
+    ) {
+      console.log(
+        `[CONDITION] Cohort ${targetCohortId} full/observer conflict, finding overflow`,
       );
-      const currentCount = participants.length;
-
-      if (currentCount + cohortParticipants.length > maxParticipants) {
-        console.log(
-          `[CONDITION] Cohort ${targetCohortId} at capacity (${currentCount}/${maxParticipants}), finding overflow`,
-        );
-
-        // Find or create overflow cohort with same alias
-        targetCohortId = await findOrCreateOverflowCohort(
-          transaction,
-          experimentId,
-          readyGroup.targetCohortAlias,
-          maxParticipants,
-          cohortParticipants.length,
-          autoTransferConfig.autoCohortParticipantConfig,
-        );
-      }
+      targetCohortId = await findOrCreateOverflowCohort(
+        transaction,
+        experimentId,
+        readyGroup.targetCohortAlias,
+        maxParticipants || 1,
+        cohortParticipants.length,
+        autoTransferConfig.autoCohortParticipantConfig,
+      );
     }
 
     console.log(
@@ -1119,6 +1186,222 @@ export async function executeDirectTransfers(
 }
 
 /**
+ * Reserved (underscore-prefixed) treatment keys mapped to the participant field
+ * each is hoisted onto and the type its raw value is coerced to. These are a
+ * subset of RESERVED_TREATMENT_VARIABLE_KEYS in @deliberation-lab/utils (the
+ * variable editor warns on that full set); keys read directly rather than
+ * hoisted, e.g. _skipPrivateChats, intentionally do not appear here.
+ */
+const TREATMENT_HOIST_FIELDS: Record<
+  string,
+  {field: string; type: 'boolean' | 'number' | 'string'}
+> = {
+  _isObserver: {field: 'isObserver', type: 'boolean'},
+  _hasRepresentative: {field: 'hasRepresentative', type: 'boolean'},
+  _numOtherAgents: {field: 'numOtherAgents', type: 'number'},
+  _numInactivePersonas: {
+    field: 'numInactivePersonas',
+    type: 'number',
+  },
+  _swapMediator: {field: 'swapMediator', type: 'string'},
+};
+
+/**
+ * Coerce a raw treatment value to its declared type. The type is driven by the
+ * key's entry in TREATMENT_HOIST_FIELDS rather than by whatever value is already
+ * on the target, so a missing field on the target can't silently turn a boolean
+ * into a (truthy) string.
+ */
+function coerceTreatmentValue(
+  value: unknown,
+  type: 'boolean' | 'number' | 'string',
+): boolean | number | string {
+  switch (type) {
+    case 'boolean':
+      return String(value) === 'true' || value === true;
+    case 'number':
+      return Number(value);
+    default:
+      return String(value);
+  }
+}
+
+/** Apply one coerced reserved-key value onto the participant target. */
+function applyTreatmentField(
+  target: Record<string, unknown>,
+  field: string,
+  type: 'boolean' | 'number' | 'string',
+  raw: unknown,
+): void {
+  const value = coerceTreatmentValue(raw, type);
+  if (field === 'numOtherAgents' || field === 'numInactivePersonas') {
+    if (!target['otherAgentGeneration']) {
+      target['otherAgentGeneration'] = {numOtherAgents: 0};
+    }
+    const gen = target['otherAgentGeneration'] as {
+      numOtherAgents: number;
+      numInactivePersonas?: number;
+    };
+    (gen as Record<string, number>)[field] = value as number;
+  } else {
+    target[field] = value;
+  }
+}
+
+/**
+ * Collect every hoist-managed reserved key that appears anywhere in a value
+ * (across all rounds of a treatment variable). Used to decide which target
+ * fields to reset before re-hoisting.
+ */
+function collectHoistFieldKeys(value: unknown, into: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectHoistFieldKeys(item, into);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const [key, nested] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    if (key in TREATMENT_HOIST_FIELDS) into.add(key);
+    collectHoistFieldKeys(nested, into);
+  }
+}
+
+/**
+ * Recursively hoist reserved treatment keys found anywhere in a treatment value
+ * (top level or any level of nesting) onto the participant target.
+ */
+function hoistTreatmentObject(
+  target: Record<string, unknown>,
+  value: unknown,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) hoistTreatmentObject(target, item);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const spec = TREATMENT_HOIST_FIELDS[key];
+    if (spec) {
+      applyTreatmentField(target, spec.field, spec.type, raw);
+    } else if (raw && typeof raw === 'object') {
+      hoistTreatmentObject(target, raw);
+    }
+  }
+}
+
+/**
+ * Apply (hoist) a treatment bundle's fields onto a participant-like target,
+ * selecting the treatment for round `index` (0-based). Supports both multi-value
+ * variable formats produced by RandomPermutation/BalancedAssignment:
+ *
+ *  - Array form (expandListToSeparateVariables = false): a single variable holds
+ *    an array [t0, t1, ...]; element [index] is selected.
+ *  - Expanded form (expandListToSeparateVariables = true): separate variables
+ *    name_1, name_2, ...; the one whose 1-based suffix equals index + 1 is
+ *    selected (others skipped).
+ *  - A plain (non-indexed) object value is always applied.
+ *
+ * At creation the experiment hoists round 0; re-running with a different index
+ * at a transfer stage lets a participant rotate through multiple treatments
+ * across repeated deliberations. An out-of-range index is a safe no-op.
+ */
+export function applyHoistedTreatment(
+  target: Record<string, unknown>,
+  variableMap: Record<string, string>,
+  index: number,
+): void {
+  // Reset every hoist field the treatment scheme uses to its "off" default
+  // before applying the selected round. Otherwise, when a participant is
+  // re-hoisted at a transfer (within-subjects rotation), a round whose
+  // treatment omits a key would silently inherit the previous round's value
+  // (e.g. stay an observer / keep swapping the mediator). Only keys the scheme
+  // actually defines are reset, so experiments that set these fields outside
+  // of treatment hoisting are left untouched.
+  const managedKeys = new Set<string>();
+  for (const value of Object.values(variableMap)) {
+    try {
+      collectHoistFieldKeys(JSON.parse(value), managedKeys);
+    } catch {
+      continue; // Not JSON, skip
+    }
+  }
+  for (const key of managedKeys) {
+    const spec = TREATMENT_HOIST_FIELDS[key];
+    const def =
+      spec.type === 'boolean' ? false : spec.type === 'number' ? 0 : '';
+    applyTreatmentField(target, spec.field, spec.type, def);
+  }
+
+  for (const [name, value] of Object.entries(variableMap)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      continue; // Not JSON, skip
+    }
+
+    let treatment: unknown;
+    if (Array.isArray(parsed)) {
+      treatment = parsed[index]; // array form
+    } else if (parsed && typeof parsed === 'object') {
+      const suffix = name.match(/_(\d+)$/); // expanded form: name_1, name_2, ...
+      if (suffix && Number(suffix[1]) !== index + 1) continue;
+      treatment = parsed;
+    } else {
+      continue;
+    }
+
+    if (treatment && typeof treatment === 'object') {
+      hoistTreatmentObject(target, treatment as Record<string, unknown>);
+    }
+  }
+}
+
+/** True if a parsed variable value contains a reserved treatment key anywhere. */
+function valueContainsReservedTreatmentKey(value: unknown): boolean {
+  const reserved: readonly string[] = RESERVED_TREATMENT_VARIABLE_KEYS;
+  if (Array.isArray(value)) {
+    return value.some(valueContainsReservedTreatmentKey);
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (reserved.includes(key)) return true;
+      if (valueContainsReservedTreatmentKey(nested)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Variables a spawned agent should inherit from the participant it is spawned
+ * alongside: copy the participant's content variables (e.g. the deliberation
+ * topic) so the round is coherent, but drop any treatment variable. A spawned
+ * agent must not carry the treatment, since it could later be hoisted into
+ * an observer, gain a representative, swap the mediator, or spawn more agents.
+ */
+function inheritSpawnedAgentVariables(
+  variableMap: Record<string, string> | undefined,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(variableMap ?? {})) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      result[name] = value; // non-JSON can't hold reserved keys; keep as-is
+      continue;
+    }
+    if (!valueContainsReservedTreatmentKey(parsed)) {
+      result[name] = value;
+    }
+  }
+  return result;
+}
+
+/**
  * Complete a participant's transfer to a new cohort.
  * This is the shared logic used by both:
  * - acceptParticipantTransfer endpoint (user-initiated via popup)
@@ -1175,6 +1458,356 @@ export async function completeParticipantTransfer(
     participant,
     targetCohortId,
   );
+
+  // Re-apply this round's treatment bundle (observer role, spawned-agent count,
+  // mediator name, etc.) when the transfer stage names a treatment index. This
+  // lets a participant rotate through multiple treatments across repeated
+  // deliberations; the spawn + mediator-swap logic below then operates on the
+  // round's values. No-op (existing behavior) when treatmentIndex is unset.
+  if (
+    currentStage?.kind === StageKind.TRANSFER &&
+    typeof (currentStage as TransferStageConfig).treatmentIndex === 'number' &&
+    participant.variableMap
+  ) {
+    applyHoistedTreatment(
+      participant as unknown as Record<string, unknown>,
+      participant.variableMap,
+      (currentStage as TransferStageConfig).treatmentIndex as number,
+    );
+  }
+
+  const otherAgentGeneration = participant.otherAgentGeneration;
+  const numOtherAgents = otherAgentGeneration?.numOtherAgents ?? 0;
+  const numInactivePersonas = otherAgentGeneration?.numInactivePersonas ?? 0;
+
+  const hasSpawningRequirement =
+    (participant.isObserver && participant.hasRepresentative) ||
+    numOtherAgents > 0 ||
+    numInactivePersonas > 0;
+
+  if (hasSpawningRequirement) {
+    const experiment = await getFirestoreExperiment(experimentId);
+    if (!experiment) return response;
+
+    const stages = (
+      await app
+        .firestore()
+        .collection(`experiments/${experimentId}/stages`)
+        .get()
+    ).docs.map((doc) => doc.data());
+
+    const profileStage = stages.find(
+      (stage) => (stage as StageConfig).kind === StageKind.PROFILE,
+    ) as ProfileStageConfig | undefined;
+    const profileType =
+      profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
+    const isAnonymousCohort = !!profileStage;
+
+    const now = Timestamp.now();
+
+    // Fetch total experiment-wide participants count for setProfile indexing
+    const numParticipants = (
+      await app
+        .firestore()
+        .collection(`experiments/${experimentId}/participants`)
+        .count()
+        .get()
+    ).data().count;
+
+    // When an observer is present in the target cohort, all AI participants
+    // get a "'s Agent" suffix (the observer's own representative uses
+    // "'s Agent (yours)" below). Count an observer being transferred in now,
+    // plus any non-agent observer already in the cohort.
+    const cohortHasObserver =
+      participant.isObserver ||
+      (
+        await app
+          .firestore()
+          .collection(`experiments/${experimentId}/participants`)
+          .where('currentCohortId', '==', targetCohortId)
+          .get()
+      ).docs.some((doc) => {
+        const p = doc.data() as ParticipantProfileExtended;
+        return (
+          !p.agentConfig &&
+          p.isObserver &&
+          p.currentStatus !== ParticipantStatus.DELETED
+        );
+      });
+
+    const nextStageId = response.currentStageId || participant.currentStageId;
+
+    const getParticipantRef = (id: string) =>
+      app.firestore().doc(`experiments/${experimentId}/participants/${id}`);
+
+    // Spawn the observer's representative agent (strictly for observer cohorts)
+    if (participant.isObserver && participant.hasRepresentative) {
+      const repAgentId = generateId();
+      const repAgentTimestamps = createProgressTimestamps();
+      repAgentTimestamps.startExperiment = now;
+      repAgentTimestamps.acceptedTOS = now;
+      repAgentTimestamps.readyStages[stageIds[0]] = now;
+      repAgentTimestamps.readyStages[nextStageId] = now; // Mark nextStageId as ready so it doesn't block the stage unlock
+
+      const observerName = String(participant.name || participant.publicId);
+      const repProfile = getRepresentativeProfile(
+        observerName,
+        participant.avatar ?? '🤖',
+      );
+      const repAgentProfile = createParticipantProfileExtended({
+        currentCohortId: targetCohortId,
+        name: repProfile.name,
+        avatar: repProfile.avatar,
+        agentConfig: {
+          agentId: repAgentId,
+          promptContext: `You are ${observerName}'s representative in this discussion. Speak and advocate on ${observerName}'s behalf, representing their perspective from their earlier responses rather than expressing your own independent opinions. Ensure you properly separate every paragraph with one empty line.`,
+          // Mirror the other spawn paths below and defer to the experiment's
+          // default model rather than hardcoding a specific Gemini build that
+          // silently fails when the experimenter hasn't configured a Gemini
+          // API key.
+          modelSettings: DEFAULT_AGENT_MODEL_SETTINGS,
+        },
+        timestamps: repAgentTimestamps,
+        publicId: `${participant.publicId}-agent`,
+        privateId: repAgentId,
+        currentStageId: nextStageId,
+        connected: true,
+        currentStatus: ParticipantStatus.IN_PROGRESS,
+        isObserver: false,
+      });
+
+      // The representative deliberates on the observer's behalf, so it shares
+      // the observer's content variables (e.g. topic) but not the treatment.
+      repAgentProfile.variableMap = inheritSpawnedAgentVariables(
+        participant.variableMap,
+      );
+      transaction.set(getParticipantRef(repAgentId), repAgentProfile);
+    }
+
+    // Spawn the other virtual AI agents directly inside targetCohortId
+    const agentParticipantsQuery = await app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('agentParticipants')
+      .get();
+
+    const personas = agentParticipantsQuery.docs.map(
+      (doc) => doc.data() as AgentPersonaConfig,
+    );
+
+    for (let i = 0; i < numOtherAgents; i++) {
+      const agentId = generateId();
+      const agentTimestamps = createProgressTimestamps();
+      agentTimestamps.startExperiment = now;
+      agentTimestamps.acceptedTOS = now;
+      agentTimestamps.readyStages[stageIds[0]] = now;
+      agentTimestamps.readyStages[nextStageId] = now;
+
+      const persona = personas[i % personas.length];
+
+      const agentProfile = createParticipantProfileExtended({
+        currentCohortId: targetCohortId,
+        agentConfig: {
+          agentId: persona?.id ?? '',
+          // Spawned agents always get a generated persona; start from an empty
+          // context so the generated text (appended by onParticipantCreation)
+          // becomes the agent's persona.
+          promptContext: '',
+          modelSettings:
+            persona?.defaultModelSettings ?? DEFAULT_AGENT_MODEL_SETTINGS,
+          needsPersonaGeneration: true,
+          personaSlotKey: `other-${i}`,
+        },
+        timestamps: agentTimestamps,
+        privateId: agentId,
+        currentStageId: nextStageId,
+        connected: false,
+        currentStatus: ParticipantStatus.IN_PROGRESS,
+        isObserver: false,
+      });
+
+      // Draw standard anonymous profile using a unique index offset and the
+      // cohort anonymity setting.
+      setProfile(
+        numParticipants + i + 10,
+        agentProfile,
+        isAnonymousCohort,
+        profileType,
+        (participant.publicId ?? '').split('-')[1],
+      );
+
+      // When an observer is present, suffix every AI participant with
+      // "'s Agent" so the observer can distinguish them from humans (the
+      // observer's own representative uses "'s Agent (yours)" above). Without
+      // an observer, agents keep their drawn profile name.
+      if (cohortHasObserver) {
+        const drawnName = agentProfile.name;
+        agentProfile.name = drawnName
+          ? `${drawnName}'s Agent`
+          : `Agent ${agentProfile.publicId.substring(0, 8)}`;
+        for (const profileSetId of Object.keys(
+          agentProfile.anonymousProfiles,
+        )) {
+          if (agentProfile.anonymousProfiles[profileSetId].name) {
+            agentProfile.anonymousProfiles[profileSetId].name += "'s Agent";
+          }
+        }
+        // A "'s Agent" participant is a representative: it advocates for the
+        // person it stands in for rather than voicing its own independent
+        // opinions, like the observer's representative.
+        if (agentProfile.agentConfig) {
+          const representedName = drawnName || agentProfile.name;
+          // The stored persona (from the persona bank) is appended to this
+          // framing by onParticipantCreation. Phrased parallel to the human
+          // observer's representative above so every representative operates
+          // from the same prompt input: the represented person's own
+          // responses, not a persona to embody.
+          agentProfile.agentConfig.promptContext = `You are ${representedName}'s representative in this discussion. You are a separate agent, not ${representedName} yourself. Speak and advocate on ${representedName}'s behalf, representing their perspective from their persona description below, rather than expressing your own independent opinions or adopting their persona as your own identity. Ensure you properly separate every paragraph with one empty line.\n\n${representedName}'s persona:`;
+        }
+      } else if (!agentProfile.name) {
+        agentProfile.name = `Agent ${agentProfile.publicId.substring(0, 8)}`;
+      }
+
+      // Share the transferring participant's content variables (e.g. the
+      // deliberation topic) so the round is coherent, minus the treatment.
+      agentProfile.variableMap = inheritSpawnedAgentVariables(
+        participant.variableMap,
+      );
+      transaction.set(getParticipantRef(agentId), agentProfile);
+    }
+
+    // Spawn inactive personas. These generate a persona just like
+    // the agents above, but are flagged so they never chat, never take a turn,
+    // and are not counted for stage unlock. They exist solely so a mediator can
+    // reason over real generated personas via OTHER_PROFILE_CONTEXTS.
+    for (let i = 0; i < numInactivePersonas; i++) {
+      const agentId = generateId();
+      const agentTimestamps = createProgressTimestamps();
+      agentTimestamps.startExperiment = now;
+      agentTimestamps.acceptedTOS = now;
+      agentTimestamps.readyStages[stageIds[0]] = now;
+      agentTimestamps.readyStages[nextStageId] = now;
+
+      const persona = personas[i % personas.length];
+
+      const agentProfile = createParticipantProfileExtended({
+        currentCohortId: targetCohortId,
+        agentConfig: {
+          agentId: persona?.id ?? '',
+          promptContext: '',
+          modelSettings:
+            persona?.defaultModelSettings ?? DEFAULT_AGENT_MODEL_SETTINGS,
+          needsPersonaGeneration: true,
+          isInactivePersona: true,
+        },
+        timestamps: agentTimestamps,
+        privateId: agentId,
+        currentStageId: nextStageId,
+        connected: false,
+        currentStatus: ParticipantStatus.IN_PROGRESS,
+        isObserver: false,
+      });
+
+      setProfile(
+        numParticipants + numOtherAgents + i + 10,
+        agentProfile,
+        isAnonymousCohort,
+        profileType,
+        (participant.publicId ?? '').split('-')[1],
+      );
+
+      if (!agentProfile.name) {
+        agentProfile.name = `Agent ${agentProfile.publicId.substring(0, 8)}`;
+      }
+
+      agentProfile.variableMap = inheritSpawnedAgentVariables(
+        participant.variableMap,
+      );
+      transaction.set(getParticipantRef(agentId), agentProfile);
+    }
+  }
+
+  // Dynamically swap the mediator in the cohort if specified
+  if (participant.swapMediator && participant.swapMediator.trim() !== '') {
+    const targetMediatorIdentifier = participant.swapMediator;
+
+    const agentMediators = await app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('agentMediators')
+      .get();
+
+    const matchingDoc = agentMediators.docs.find((doc) => {
+      const persona = doc.data() as AgentPersonaConfig;
+      return (
+        persona.id === targetMediatorIdentifier ||
+        persona.name === targetMediatorIdentifier ||
+        persona.defaultProfile?.name === targetMediatorIdentifier
+      );
+    });
+
+    if (matchingDoc) {
+      const matchingPersona = matchingDoc.data() as AgentPersonaConfig;
+      const existingMediatorsQuery = await app
+        .firestore()
+        .collection('experiments')
+        .doc(experimentId)
+        .collection('mediators')
+        .where('currentCohortId', '==', targetCohortId)
+        .get();
+
+      // Build the swapped mediator so we know which stages it covers (its
+      // configured prompt stages).
+      const newMediator = await createMediatorProfileForPersona(
+        experimentId,
+        targetCohortId,
+        matchingPersona,
+      );
+      newMediator.privateId = `mediator-${targetCohortId}-${matchingPersona.id}`;
+      newMediator.publicId = matchingPersona.id.substring(0, 8);
+      const swappedStageIds = Object.entries(newMediator.activeStageMap ?? {})
+        .filter(([, active]) => active)
+        .map(([stageId]) => stageId);
+
+      // The swap should only take over the group chat(s) the swapped persona
+      // covers; private-chat stages must keep using the default
+      // mediator. So rather than deleting the cohort's existing mediators,
+      // deactivate them only for the stages the swapped mediator covers and
+      // leave them active elsewhere (e.g. private chats).
+      let swappedAlreadyPresent = false;
+      for (const doc of existingMediatorsQuery.docs) {
+        const existing = doc.data() as MediatorProfileExtended;
+        if (existing.agentConfig?.agentId === matchingPersona.id) {
+          swappedAlreadyPresent = true;
+          continue; // already installed; leave it as-is
+        }
+        const activeStageMap = {...(existing.activeStageMap ?? {})};
+        let changed = false;
+        for (const stageId of swappedStageIds) {
+          if (activeStageMap[stageId]) {
+            activeStageMap[stageId] = false;
+            changed = true;
+          }
+        }
+        if (changed) {
+          transaction.set(doc.ref, {...existing, activeStageMap});
+        }
+      }
+
+      if (!swappedAlreadyPresent) {
+        const newMediatorDoc = app
+          .firestore()
+          .collection('experiments')
+          .doc(experimentId)
+          .collection('mediators')
+          .doc(newMediator.privateId);
+
+        transaction.set(newMediatorDoc, newMediator);
+      }
+    }
+  }
 
   // 7. Save participant
   transaction.set(participantDoc, participant);

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -48,6 +48,7 @@ import {
   MediatorProfileExtended,
   DEFAULT_AGENT_MODEL_SETTINGS,
   RESERVED_TREATMENT_VARIABLE_KEYS,
+  MEDIATOR_OBSERVER_COLOR,
 } from '@deliberation-lab/utils';
 import {completeStageAsAgentParticipant} from './agent_participant.utils';
 import {
@@ -1519,6 +1520,17 @@ export async function completeParticipantTransfer(
     ) as ProfileStageConfig | undefined;
     const profileType =
       profileStage?.profileType || ProfileType.ANONYMOUS_ANIMAL;
+    // Spawned agents avoid the human's color, and the reserved mediator color
+    // in observer-capable experiments (key presence mirrors the frontend check).
+    const spawnedProfileExcludeColors = [
+      (participant.publicId ?? '').split('-')[1] ?? '',
+      ...(Object.values(participant.variableMap ?? {}).some((value) =>
+        value.includes('_isObserver'),
+      )
+        ? [MEDIATOR_OBSERVER_COLOR]
+        : []),
+    ].filter((c) => c);
+
     const isAnonymousCohort = !!profileStage;
 
     const now = Timestamp.now();
@@ -1652,7 +1664,7 @@ export async function completeParticipantTransfer(
         agentProfile,
         isAnonymousCohort,
         profileType,
-        (participant.publicId ?? '').split('-')[1],
+        spawnedProfileExcludeColors,
       );
 
       // When an observer is present, suffix every AI participant with
@@ -1752,7 +1764,7 @@ export async function completeParticipantTransfer(
         agentProfile,
         isAnonymousCohort,
         profileType,
-        (participant.publicId ?? '').split('-')[1],
+        spawnedProfileExcludeColors,
       );
 
       if (!agentProfile.name) {

--- a/functions/src/persona_bank.utils.test.ts
+++ b/functions/src/persona_bank.utils.test.ts
@@ -1,0 +1,195 @@
+import {
+  StoredPersona,
+  canonicalStringify,
+  computeRoundVariableMap,
+  personaMatchHash,
+  selectPersonaToClaim,
+} from './persona_bank.utils';
+
+// An example round: a treatment object paired with a content variable. Any
+// external persona generator must hash this identically.
+const TREATMENT = {
+  treatmentName: 'groupB',
+  _isObserver: true,
+  _numOtherAgents: 4,
+  _swapMediator: '',
+  _hasRepresentative: true,
+  displayName: 'Group B',
+  _skipPrivateChats: false,
+  _numInactivePersonas: 0,
+};
+const TOPIC = {
+  topicName: 'Favorite books',
+  priorities: [
+    'Fiction: Novels and short stories.',
+    'Nonfiction: Essays and biographies.',
+  ],
+};
+
+describe('canonicalStringify', () => {
+  it('is independent of object key insertion order', () => {
+    expect(canonicalStringify({b: 1, a: 2})).toBe(
+      canonicalStringify({a: 2, b: 1}),
+    );
+  });
+
+  it('preserves array element order', () => {
+    expect(canonicalStringify([1, 2, 3])).not.toBe(
+      canonicalStringify([3, 2, 1]),
+    );
+    expect(canonicalStringify([1, 2, 3])).toBe('[1,2,3]');
+  });
+
+  it('emits compact, sorted-key JSON', () => {
+    expect(canonicalStringify({z: {y: 2, x: 1}, a: [true, null]})).toBe(
+      '{"a":[true,null],"z":{"x":1,"y":2}}',
+    );
+  });
+});
+
+describe('personaMatchHash', () => {
+  const vars = {treatment: TREATMENT, topic: TOPIC};
+
+  it('is deterministic', () => {
+    expect(personaMatchHash(vars)).toBe(personaMatchHash(vars));
+  });
+
+  it('is independent of key order within treatment/topic', () => {
+    const reordered = {
+      topic: {priorities: TOPIC.priorities, topicName: TOPIC.topicName},
+      treatment: {
+        _numInactivePersonas: 0,
+        displayName: 'Group B',
+        _hasRepresentative: true,
+        treatmentName: 'groupB',
+        _swapMediator: '',
+        _numOtherAgents: 4,
+        _isObserver: true,
+        _skipPrivateChats: false,
+      },
+    };
+    expect(personaMatchHash(reordered)).toBe(personaMatchHash(vars));
+  });
+
+  it('changes when a priority string changes by one character', () => {
+    const tweaked = {
+      treatment: TREATMENT,
+      topic: {
+        topicName: TOPIC.topicName,
+        priorities: [TOPIC.priorities[0] + ' ', TOPIC.priorities[1]],
+      },
+    };
+    expect(personaMatchHash(tweaked)).not.toBe(personaMatchHash(vars));
+  });
+
+  it('changes when priorities are reordered (array order is significant)', () => {
+    const swapped = {
+      treatment: TREATMENT,
+      topic: {
+        topicName: TOPIC.topicName,
+        priorities: [TOPIC.priorities[1], TOPIC.priorities[0]],
+      },
+    };
+    expect(personaMatchHash(swapped)).not.toBe(personaMatchHash(vars));
+  });
+
+  it('changes when the treatment differs', () => {
+    const single = {
+      ...vars,
+      treatment: {...TREATMENT, treatmentName: 'groupC'},
+    };
+    expect(personaMatchHash(single)).not.toBe(personaMatchHash(vars));
+  });
+
+  // Cross-language anchor: the offline persona generator asserts this exact hex
+  // for the same fixture. If it changes, update the generator's self-test too;
+  // they must never diverge or generated personas would miss the bank.
+  it('matches the documented cross-language anchor', () => {
+    expect(personaMatchHash(vars)).toBe(
+      'ba04b332f5b23e57a0021c0d4849c3862eccaafeaacf522f92c1e0e18acee1a4',
+    );
+  });
+});
+
+describe('computeRoundVariableMap', () => {
+  it('resolves array (permutation) variables at the round index', () => {
+    const variableMap = {
+      treatment: JSON.stringify([{a: 1}, {a: 2}, {a: 3}]),
+      topic: JSON.stringify([{t: 'x'}, {t: 'y'}, {t: 'z'}]),
+      plain: 'not-json',
+    };
+    expect(computeRoundVariableMap(variableMap, 1)).toEqual({
+      treatment: {a: 2},
+      topic: {t: 'y'},
+    });
+  });
+
+  it('drops out-of-range indices and undefined maps', () => {
+    expect(computeRoundVariableMap(undefined, 0)).toEqual({});
+    expect(
+      computeRoundVariableMap({treatment: JSON.stringify([{a: 1}])}, 5),
+    ).toEqual({});
+  });
+});
+
+describe('selectPersonaToClaim', () => {
+  const persona = (
+    id: string,
+    usageCount: number,
+    usedBy: string[] = [],
+  ): StoredPersona =>
+    ({
+      id,
+      hash: 'h',
+      variables: {},
+      content: id,
+      usageCount,
+      usedBy,
+    }) as unknown as StoredPersona;
+
+  it('returns null when the bank is empty for the hash', () => {
+    expect(selectPersonaToClaim([], 'pid')).toBeNull();
+  });
+
+  it('prefers the fewest-used persona, tie-broken deterministically by id', () => {
+    const bank = [persona('c', 2), persona('a', 0), persona('b', 0)];
+    // a and b are both least-used (0); id tie-break picks 'a'.
+    expect(selectPersonaToClaim(bank, 'pid')?.id).toBe('a');
+  });
+
+  it('never returns a persona this participant has already used', () => {
+    const bank = [persona('a', 0, ['pid']), persona('b', 5)];
+    // 'a' is least-used but already used by pid, so 'b' is chosen.
+    expect(selectPersonaToClaim(bank, 'pid')?.id).toBe('b');
+  });
+
+  it('returns null once this participant has used every candidate', () => {
+    const bank = [persona('a', 0, ['pid']), persona('b', 0, ['pid'])];
+    expect(selectPersonaToClaim(bank, 'pid')).toBeNull();
+    // ...but a different participant can still claim them.
+    expect(selectPersonaToClaim(bank, 'other')?.id).toBe('a');
+  });
+
+  it('gives a participant distinct personas across successive claims', () => {
+    // Simulate four sequential claims for one participant by replaying the
+    // usedBy/usageCount mutation the transaction would apply.
+    let bank = [
+      persona('p0', 0),
+      persona('p1', 0),
+      persona('p2', 0),
+      persona('p3', 0),
+    ];
+    const claimed: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const chosen = selectPersonaToClaim(bank, 'pid');
+      expect(chosen).not.toBeNull();
+      claimed.push(chosen!.id);
+      bank = bank.map((p) =>
+        p.id === chosen!.id
+          ? {...p, usageCount: p.usageCount + 1, usedBy: [...p.usedBy, 'pid']}
+          : p,
+      );
+    }
+    expect(new Set(claimed).size).toBe(4); // all distinct within the participant
+  });
+});

--- a/functions/src/persona_bank.utils.ts
+++ b/functions/src/persona_bank.utils.ts
@@ -1,0 +1,122 @@
+import {createHash} from 'crypto';
+import {UnifiedTimestamp} from '@deliberation-lab/utils';
+
+/**
+ * Persona bank: pre-generated personas stored per experiment, keyed by a
+ * content hash of the round's resolved variables. Spawned agents claim a
+ * stored persona instead of generating a fresh one; what a persona contains
+ * is experiment-defined.
+ */
+/** A stored persona document at experiments/{id}/personas/{personaId}. */
+export interface StoredPersona {
+  id: string;
+  // SHA-256 of the canonical round-variable map (see personaMatchHash).
+  hash: string;
+  // The round variables this persona was generated for (inspection only).
+  variables: Record<string, unknown>;
+  // Persona content is experiment-defined; fields beyond the bookkeeping ones
+  // are stored as-is. The runtime reads two optional text fields: `content`
+  // (appended to the claiming agent's prompt) and `sketch` (a plain persona
+  // for agents that need one of their own).
+  content?: string;
+  sketch?: string;
+  // Reuse bookkeeping: fewest-used personas are claimed first; a persona is
+  // never claimed twice by the same participant.
+  usageCount: number;
+  usedBy: string[];
+  createdAt: UnifiedTimestamp;
+  [field: string]: unknown;
+}
+
+/**
+ * Choose which persona to claim from the candidates that share a match hash:
+ * never one this participant has already used (so each participant sees a
+ * distinct persona per slot across their whole run), and otherwise the
+ * fewest-used (so reuse is spread evenly across participants), with a
+ * deterministic id tie-break. Returns null when every candidate is exhausted
+ * for this participant. Pure so the selection rule is unit-testable; the
+ * transactional claim that wraps it lives in firestore.ts.
+ */
+export function selectPersonaToClaim(
+  personas: StoredPersona[],
+  participantPrivateId: string,
+): StoredPersona | null {
+  const candidates = personas.filter(
+    (p) => !(p.usedBy ?? []).includes(participantPrivateId),
+  );
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    const ua = a.usageCount ?? 0;
+    const ub = b.usageCount ?? 0;
+    if (ua !== ub) return ua - ub;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return candidates[0];
+}
+
+/**
+ * Deterministic JSON: object keys sorted recursively, arrays kept in order, no
+ * insignificant whitespace. Any external persona generator must serialize
+ * identically.
+ */
+export function canonicalStringify(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalStringify(v)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return `{${keys
+      .map(
+        (k) =>
+          `${JSON.stringify(k)}:${canonicalStringify(
+            (value as Record<string, unknown>)[k],
+          )}`,
+      )
+      .join(',')}}`;
+  }
+  // string | number | boolean.
+  return JSON.stringify(value);
+}
+
+/**
+ * The persona bank match key: a SHA-256 (hex) of the canonical serialization of
+ * the round-resolved variable map. Any change to a variable's literal content
+ * yields a different hash.
+ */
+export function personaMatchHash(
+  roundVariables: Record<string, unknown>,
+): string {
+  return createHash('sha256')
+    .update(canonicalStringify(roundVariables))
+    .digest('hex');
+}
+
+/**
+ * Resolve every template variable to its value for the given round index,
+ * mirroring how applyHoistedTreatment / the prompt resolver pick `name.index`.
+ * Array-valued variables (random permutations) are indexed at `index`; a bare
+ * object value is used as-is; anything that is not JSON is dropped (it can hold
+ * no content the persona depends on). The result is the object that is hashed
+ * at spawn.
+ */
+export function computeRoundVariableMap(
+  variableMap: Record<string, string> | undefined,
+  index: number,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(variableMap ?? {})) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      continue; // non-JSON variables carry no hashable content
+    }
+    if (Array.isArray(parsed)) {
+      if (index >= 0 && index < parsed.length) result[name] = parsed[index];
+    } else if (parsed && typeof parsed === 'object') {
+      result[name] = parsed;
+    }
+  }
+  return result;
+}

--- a/functions/src/stages/chat.time.ts
+++ b/functions/src/stages/chat.time.ts
@@ -96,8 +96,11 @@ async function handleTimeElapsed(
     stageId,
     'The timer for this stage has ended; you can no longer respond.',
   );
+  // An ended discussion is nobody's turn: clear the turn holder so nothing
+  // (e.g. the quiz turn resume) re-dispatches an agent afterwards.
   await getFirestoreStagePublicDataRef(experimentId, cohortId, stageId).update({
     discussionEndTimestamp: Timestamp.now(),
+    currentTurnParticipantId: null,
   });
 }
 
@@ -114,8 +117,11 @@ export async function handleMaxMessagesReached(
   cohortId: string,
   stageId: string,
 ) {
+  // An ended discussion is nobody's turn: clear the turn holder so nothing
+  // (e.g. the quiz turn resume) re-dispatches an agent afterwards.
   await getFirestoreStagePublicDataRef(experimentId, cohortId, stageId).update({
     discussionEndTimestamp: Timestamp.now(),
+    currentTurnParticipantId: null,
   });
   await sendSystemChatMessage(
     experimentId,

--- a/functions/src/stages/chat.time.ts
+++ b/functions/src/stages/chat.time.ts
@@ -100,3 +100,27 @@ async function handleTimeElapsed(
     discussionEndTimestamp: Timestamp.now(),
   });
 }
+
+/**
+ * End the discussion globally because the cohort hit the maximum total
+ * message count for the stage. Writes discussionEndTimestamp before sending
+ * the system notice: the system message re-fires onPublicChatMessageCreated,
+ * and that re-fire must read a stage that is already marked ended so it bails
+ * before recounting. Reversing this order produced two cap-reached system
+ * messages.
+ */
+export async function handleMaxMessagesReached(
+  experimentId: string,
+  cohortId: string,
+  stageId: string,
+) {
+  await getFirestoreStagePublicDataRef(experimentId, cohortId, stageId).update({
+    discussionEndTimestamp: Timestamp.now(),
+  });
+  await sendSystemChatMessage(
+    experimentId,
+    cohortId,
+    stageId,
+    'The discussion has ended. Please proceed to the next stage.',
+  );
+}

--- a/functions/src/structured_prompt.utils.test.ts
+++ b/functions/src/structured_prompt.utils.test.ts
@@ -4,17 +4,35 @@ import {
   MediatorProfileExtended,
   BasePromptConfig,
   PromptItemType,
+  StageKind,
 } from '@deliberation-lab/utils';
-import {getFirestoreDataForStructuredPrompt} from './structured_prompt.utils';
+import {
+  getFirestoreDataForStructuredPrompt,
+  getPromptFromConfig,
+} from './structured_prompt.utils';
 import * as firestoreUtils from './utils/firestore';
 
 // Mock firestore utilities
 jest.mock('./utils/firestore');
-jest.mock('./app', () => ({
-  stageManager: {
-    resolveTemplateVariablesInStage: jest.fn((stage) => stage),
-  },
-}));
+jest.mock('./app', () => {
+  // Delegate getStageDisplayForPrompt to the real private-chat handler so the
+  // merge test exercises the genuine "Private chat with NAME (id)" formatting.
+  const utils = jest.requireActual('@deliberation-lab/utils');
+  const handler = new utils.PrivateChatStageHandler();
+  return {
+    stageManager: {
+      resolveTemplateVariablesInStage: jest.fn((stage) => stage),
+      getStageDisplayForPrompt: jest.fn(
+        (stage, participants, stageContext, includeScaffolding) =>
+          handler.getStageDisplayForPrompt(
+            participants,
+            stageContext,
+            includeScaffolding,
+          ),
+      ),
+    },
+  };
+});
 
 describe('structured_prompt.utils', () => {
   describe('getFirestoreDataForStructuredPrompt', () => {
@@ -249,6 +267,241 @@ describe('structured_prompt.utils', () => {
 
       // Should fall back to default mediator behavior (all participants)
       expect(result.participants).toHaveLength(2);
+    });
+
+    it('re-adds the observer for a group-chat mediator when contextParticipantIds omits them', async () => {
+      // The only human in the chat is an observer, and chat.triggers
+      // builds contextParticipantIds from the non-observer turn-order list, so
+      // only the persona agents are passed. The group-chat mediator must still
+      // see the observer, so getFirestoreDataForStructuredPrompt re-adds
+      // cohort observers (gated to MEDIATOR + group CHAT).
+      const observer: ParticipantProfileExtended = {
+        ...mockParticipant,
+        privateId: 'human-priv',
+        publicId: 'human-pub',
+        name: 'Observer',
+        isObserver: true,
+      };
+      const personaAgent: ParticipantProfileExtended = {
+        ...mockParticipant,
+        privateId: 'persona-priv-1',
+        publicId: 'persona-pub-1',
+        name: 'Persona Agent',
+        agentConfig: {
+          agentId: 'a',
+          model: 'test-model',
+          apiKey: 'test-key',
+          promptContext: 'persona',
+          isInactivePersona: true,
+        },
+      };
+      (
+        firestoreUtils.getFirestoreActiveParticipants as jest.Mock
+      ).mockResolvedValue([observer, personaAgent]);
+      (firestoreUtils.getFirestoreParticipant as jest.Mock).mockImplementation(
+        async (_experimentId: string, participantId: string) => {
+          if (participantId === 'persona-priv-1') return personaAgent;
+          if (participantId === 'human-priv') return observer;
+          return undefined;
+        },
+      );
+
+      const result = await getFirestoreDataForStructuredPrompt(
+        mockExperimentId,
+        mockCohortId,
+        mockStageId,
+        mockMediator,
+        {...mockPromptConfig, type: StageKind.CHAT},
+        ['persona-priv-1'], // the observer is stripped upstream by chat.triggers
+      );
+
+      // The observer must be present so the mediator prompt includes their
+      // answers alongside the persona agents.
+      expect(result.participants.some((p) => p.publicId === 'human-pub')).toBe(
+        true,
+      );
+      expect(
+        result.participants.some((p) => p.publicId === 'persona-pub-1'),
+      ).toBe(true);
+    });
+  });
+
+  // Verifies a mediator sees every participant's private chat in one
+  // STAGE_CONTEXT block (the human merged with inactive personas), rather
+  // than the human split from the personas across separate prompt items.
+  describe('getPromptFromConfig private-chat merge', () => {
+    const experimentId = 'exp';
+    const cohortId = 'cohort';
+    const chatStageId = 'private-chat';
+
+    const chatStage = {
+      id: chatStageId,
+      kind: StageKind.PRIVATE_CHAT,
+      name: 'Private chat',
+      descriptions: {primaryText: '', infoText: '', helpText: ''},
+    };
+
+    const experiment = {
+      id: experimentId,
+      stageIds: [chatStageId],
+      variableConfigs: [],
+      variableMap: {},
+    };
+    const cohort = {id: cohortId, variableMap: {}};
+
+    const human: ParticipantProfileExtended = {
+      id: 'h',
+      privateId: 'h-priv',
+      publicId: 'human-1',
+      type: UserType.PARTICIPANT,
+      name: 'Human',
+      avatar: '🧑',
+      pronouns: null,
+      currentCohortId: cohortId,
+      currentExperimentId: experimentId,
+      currentStageId: chatStageId,
+      timestamps: {
+        accountCreated: {seconds: 0, nanoseconds: 0},
+        lastLogin: {seconds: 0, nanoseconds: 0},
+      },
+      agentConfig: null,
+      prolificId: null,
+      transferCohortId: null,
+      variableMap: {},
+    } as unknown as ParticipantProfileExtended;
+
+    const makePersonaAgent = (
+      publicId: string,
+      name: string,
+      promptContext: string,
+    ) =>
+      ({
+        ...human,
+        id: publicId,
+        privateId: `${publicId}-priv`,
+        publicId,
+        name,
+        agentConfig: {
+          agentId: publicId,
+          promptContext,
+          isInactivePersona: true,
+        },
+      }) as unknown as ParticipantProfileExtended;
+
+    const persona1 = makePersonaAgent('agent-a', 'Avery', 'AVERY_CONTENT');
+    const persona2 = makePersonaAgent('agent-b', 'Blair', 'BLAIR_CONTENT');
+
+    const humanMessages = [
+      {
+        id: 'm0',
+        discussionId: null,
+        type: UserType.PARTICIPANT,
+        message: 'HUMAN_ANSWER_TEXT',
+        timestamp: {seconds: 100, nanoseconds: 0},
+        profile: {name: 'Human', avatar: '🧑', pronouns: null},
+        senderId: 'human',
+      },
+    ];
+
+    const mediator = {
+      id: 'mediator-1',
+      privateId: 'mediator-1-priv',
+      publicId: 'mediator-1',
+      type: UserType.MEDIATOR,
+      name: 'Riley',
+      avatar: '🤖',
+      pronouns: null,
+      currentCohortId: cohortId,
+      currentExperimentId: experimentId,
+      currentStageId: chatStageId,
+      timestamps: {
+        accountCreated: {seconds: 0, nanoseconds: 0},
+        lastLogin: {seconds: 0, nanoseconds: 0},
+      },
+      agentConfig: {agentId: 'mediator-1', promptContext: ''},
+      prolificId: null,
+      transferCohortId: null,
+      variableMap: {},
+    } as unknown as MediatorProfileExtended;
+
+    const promptConfig: BasePromptConfig = {
+      type: StageKind.PRIVATE_CHAT,
+      includeScaffoldingInPrompt: false,
+      prompt: [
+        {
+          type: PromptItemType.STAGE_CONTEXT,
+          stageId: chatStageId,
+          includeParticipantAnswers: true,
+          includePrimaryText: false,
+          includeInfoText: false,
+        },
+      ],
+    } as unknown as BasePromptConfig;
+
+    const setupMocks = (participants: ParticipantProfileExtended[]) => {
+      jest.clearAllMocks();
+      (firestoreUtils.getFirestoreExperiment as jest.Mock).mockResolvedValue(
+        experiment,
+      );
+      (firestoreUtils.getFirestoreCohort as jest.Mock).mockResolvedValue(
+        cohort,
+      );
+      (
+        firestoreUtils.getFirestoreActiveParticipants as jest.Mock
+      ).mockResolvedValue(participants);
+      (firestoreUtils.getFirestoreStage as jest.Mock).mockResolvedValue(
+        chatStage,
+      );
+      (
+        firestoreUtils.getFirestorePrivateChatMessages as jest.Mock
+      ).mockImplementation(async (_exp, privateId) =>
+        privateId === human.privateId ? humanMessages : [],
+      );
+      (
+        firestoreUtils.getFirestoreAnswersForStage as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        firestoreUtils.getFirestoreStagePublicData as jest.Mock
+      ).mockResolvedValue({});
+    };
+
+    it('renders the human and persona agents together in one block', async () => {
+      setupMocks([human, persona1, persona2]);
+      const prompt = await getPromptFromConfig(
+        experimentId,
+        cohortId,
+        chatStageId,
+        mediator,
+        promptConfig,
+      );
+      // The human's chat and both personas' content are in one rendered block.
+      expect(prompt).toContain('Private chat with Human (human-1)');
+      expect(prompt).toContain('HUMAN_ANSWER_TEXT');
+      expect(prompt).toContain('AVERY_CONTENT');
+      expect(prompt).toContain('BLAIR_CONTENT');
+      // Each persona's content appears exactly once (not duplicated).
+      expect(prompt.split('AVERY_CONTENT')).toHaveLength(2);
+    });
+
+    it('is unchanged (real participants only) when no persona agents are present', async () => {
+      const human2 = {
+        ...human,
+        id: 'h2',
+        privateId: 'h2-priv',
+        publicId: 'human-2',
+        name: 'Human2',
+      } as unknown as ParticipantProfileExtended;
+      setupMocks([human, human2]);
+      const prompt = await getPromptFromConfig(
+        experimentId,
+        cohortId,
+        chatStageId,
+        mediator,
+        promptConfig,
+      );
+      expect(prompt).toContain('Private chat with Human (human-1)');
+      expect(prompt).toContain('Private chat with Human2 (human-2)');
+      expect(prompt).not.toContain('isInactivePersona');
     });
   });
 });

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -128,14 +128,84 @@ export async function getFirestoreDataForStructuredPrompt(
         getFirestoreParticipant(experimentId, id),
       ),
     )) as ParticipantProfileExtended[];
+    // A group-chat mediator must also see any observers: contextParticipantIds
+    // is built from the non-observer turn-order list (chat.triggers strips
+    // observers), so an observer's answers would otherwise be missing from the
+    // mediator's prompt. Re-add any cohort observers not already present; with
+    // no observers this adds nothing. Gated to group CHAT so
+    // single-participant private chats (and the rep-suffix re-add below) are
+    // unaffected.
+    if (
+      userProfile.type === UserType.MEDIATOR &&
+      promptConfig.type === StageKind.CHAT
+    ) {
+      const cohortObservers = await getFirestoreActiveParticipants(
+        experimentId,
+        cohortId,
+        null,
+        false,
+        true, // includeObservers
+      );
+      for (const observer of cohortObservers) {
+        if (
+          observer.isObserver &&
+          !answerParticipants.some((a) => a.publicId === observer.publicId)
+        ) {
+          answerParticipants.push(observer);
+        }
+      }
+    }
   } else if (userProfile.type === UserType.PARTICIPANT) {
-    // Participant only needs their own context
+    // Participant only needs their own context.
     answerParticipants = [
       (await getFirestoreParticipant(experimentId, userProfile.privateId))!,
     ];
   } else if (userProfile.type === UserType.MEDIATOR) {
-    // Mediator in group context needs all participants
-    answerParticipants = activeParticipants;
+    // A mediator in a group context needs all participants, including
+    // observers: an observer's variables and prior-stage answers can drive
+    // the prompt, and observers are otherwise filtered out of
+    // activeParticipants.
+    answerParticipants = await getFirestoreActiveParticipants(
+      experimentId,
+      cohortId,
+      null,
+      false,
+      true, // includeObservers
+    );
+  }
+
+  // A representative agent (spawned with publicId `${observer.publicId}-agent`
+  // in the observer's cohort) also needs the observer it stands in for, so
+  // its prompt surfaces the observer's prior-stage answers. This runs
+  // regardless of how answerParticipants was built above: the rep's own id is
+  // normally passed as contextParticipantIds, so it cannot live in the
+  // PARTICIPANT branch alone.
+  const repSuffix = '-agent';
+  if (
+    answerParticipants.some(
+      (p) => p?.agentConfig && p.publicId?.endsWith(repSuffix),
+    )
+  ) {
+    const cohortMembers = await getFirestoreActiveParticipants(
+      experimentId,
+      cohortId,
+      null,
+      false,
+      true, // includeObservers
+    );
+    for (const rep of [...answerParticipants]) {
+      if (!(rep?.agentConfig && rep.publicId?.endsWith(repSuffix))) continue;
+      const observerPublicId = rep.publicId.slice(0, -repSuffix.length);
+      const observer = cohortMembers.find(
+        (m) => m.publicId === observerPublicId && m.isObserver,
+      );
+      if (
+        observer &&
+        !answerParticipants.some((a) => a.publicId === observer.publicId)
+      ) {
+        answerParticipants.push(observer);
+      }
+    }
   }
 
   for (const item of promptConfig.prompt) {
@@ -645,7 +715,7 @@ async function processPromptItems(
         );
         break;
       }
-      case PromptItemType.PROFILE_CONTEXT:
+      case PromptItemType.PROFILE_CONTEXT: {
         const profileContext = getProfileContextForPrompt(
           userProfile,
           includeScaffolding,
@@ -654,6 +724,7 @@ async function processPromptItems(
           items.push(profileContext);
         }
         break;
+      }
       case PromptItemType.PROFILE_INFO:
         items.push(
           getProfileInfoForPrompt(userProfile, includeScaffolding, stageId),
@@ -694,6 +765,7 @@ async function processPromptItems(
               resolvedStageContext,
               promptItem,
               includeScaffolding,
+              cohortId,
             ),
           );
         }
@@ -749,6 +821,25 @@ async function processPromptItems(
         );
         if (groupText) items.push(groupText);
         break;
+      case PromptItemType.OTHER_PROFILE_CONTEXTS: {
+        // Render each other agent participant's persona context, labeled with
+        // its display name.
+        const others = promptData.participants.filter(
+          (p) =>
+            p.agentConfig?.promptContext && p.publicId !== userProfile.publicId,
+        );
+        if (others.length > 0) {
+          items.push(
+            others
+              .map(
+                (p) =>
+                  `${p.name ?? p.publicId}:\n${p.agentConfig?.promptContext}`,
+              )
+              .join('\n\n'),
+          );
+        }
+        break;
+      }
       default:
         break;
     }
@@ -769,6 +860,7 @@ function getStageContextForPrompt(
   stageContext: StageContextData,
   item: StageContextPromptItem,
   includeScaffolding: boolean,
+  cohortId: string,
 ): string {
   const stage = stageContext.stage;
   const textItems: string[] = [];
@@ -786,13 +878,50 @@ function getStageContextForPrompt(
   }
   // Note: Help text not included since the field has been deprecated
 
-  // Always include stage display (with answers if specified by prompt item)
-  const stageDisplay = stageManager.getStageDisplayForPrompt(
-    stage,
-    item.includeParticipantAnswers ? participants : [],
-    stageContext,
-    includeScaffolding,
-  );
+  // Render participant answers for this stage.
+  //
+  // Inactive personas carry stored content in agentConfig.promptContext; it
+  // is self-describing and is included as-is inside this same stage block,
+  // alongside the human, in a per-cohort shuffled order, so a mediator sees
+  // every participant's block in one uniform list. With no persona agents
+  // this is byte-identical to the prior output.
+  const realParticipants = item.includeParticipantAnswers
+    ? participants.filter((p) => !p.agentConfig?.isInactivePersona)
+    : [];
+  // Inactive personas' content must be included whenever participant answers
+  // are (mirroring realParticipants above), not just when the rendered stage
+  // is a private chat; otherwise a summarizing mediator would silently drop
+  // them.
+  const personaAgents = item.includeParticipantAnswers
+    ? participants.filter(
+        (p) => p.agentConfig?.isInactivePersona && p.agentConfig?.promptContext,
+      )
+    : [];
+
+  let stageDisplay: string;
+  if (personaAgents.length === 0) {
+    stageDisplay = stageManager.getStageDisplayForPrompt(
+      stage,
+      realParticipants,
+      stageContext,
+      includeScaffolding,
+    );
+  } else {
+    const blocks: string[] = [
+      ...realParticipants.map((p) =>
+        stageManager.getStageDisplayForPrompt(
+          stage,
+          [p],
+          stageContext,
+          includeScaffolding,
+        ),
+      ),
+      ...personaAgents.map((p) => p.agentConfig?.promptContext ?? ''),
+    ];
+    stageDisplay = shuffleWithSeed(blocks, `${cohortId}::${stage.id}`).join(
+      '\n\n',
+    );
+  }
   textItems.push(stageDisplay);
 
   return textItems.join('\n');

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -713,6 +713,9 @@ async function processPromptItems(
             ? DEFAULT_AGENT_PARTICIPANT_CHAT_TURN_TAKING_PROMPT
             : DEFAULT_AGENT_PARTICIPANT_CHAT_PROMPT,
         );
+        const extraParticipantInstr = (stage as ChatStageConfig)
+          ?.additionalParticipantInstructions;
+        if (extraParticipantInstr) items.push(extraParticipantInstr);
         break;
       }
       case PromptItemType.PROFILE_CONTEXT: {

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -822,8 +822,7 @@ async function processPromptItems(
         if (groupText) items.push(groupText);
         break;
       case PromptItemType.OTHER_PROFILE_CONTEXTS: {
-        // Render each other agent participant's persona context, labeled with
-        // its display name.
+        // Render each other agent's persona under its display name.
         const others = promptData.participants.filter(
           (p) =>
             p.agentConfig?.promptContext && p.publicId !== userProfile.publicId,

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -31,6 +31,11 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_PROMPT_INSTRUCTIONS,
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
+  ChatStagePublicData,
+  TURN_CYCLE_STATUS_PLACEHOLDER,
+  TextPromptItem,
+  getTurnCycleInfo,
+  substituteTurnCycleStatus,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -46,6 +51,25 @@ import {
   getFirestorePrivateChatMessages,
 } from './utils/firestore';
 import {stageManager} from './app';
+
+// Recursively check whether `{{_turnCycleStatus}}` appears in prompt items.
+function containsTurnCyclePlaceholder(items: PromptItem[]): boolean {
+  return items.some((item) => {
+    if (item.type === PromptItemType.TEXT) {
+      return (
+        (item as TextPromptItem).text?.includes(
+          TURN_CYCLE_STATUS_PLACEHOLDER,
+        ) ?? false
+      );
+    }
+    if (item.type === PromptItemType.GROUP) {
+      return containsTurnCyclePlaceholder(
+        (item as PromptItemGroup).items ?? [],
+      );
+    }
+    return false;
+  });
+}
 
 /** Attempts to fetch corresponding prompt config from storage,
  * else returns the stage's default config.
@@ -654,6 +678,34 @@ async function processPromptItems(
       it.type === PromptItemType.GROUP &&
       (it as PromptItemGroup).shuffleConfig?.shuffle,
   );
+
+  // Resolve {{_turnCycleStatus}} where the experimenter placed it: the cycle
+  // line for a turn-based group chat with a message cap, empty text otherwise.
+  let turnCycleInfo: {currentCycle: number; totalCycles: number} | null = null;
+  if (stageKind === StageKind.CHAT) {
+    const stage = (promptData.data[stageId]?.stage ??
+      (await getFirestoreStage(experiment.id, stageId))) as
+      | ChatStageConfig
+      | undefined;
+    const usesTurnCycle =
+      containsTurnCyclePlaceholder(promptItems) ||
+      (stage?.additionalParticipantInstructions?.includes(
+        TURN_CYCLE_STATUS_PLACEHOLDER,
+      ) ??
+        false);
+    if (usesTurnCycle && stage?.isTurnBased) {
+      const publicData = ((promptData.data[stageId]?.publicData as
+        | ChatStagePublicData
+        | undefined) ??
+        (await getFirestoreStagePublicData(
+          experiment.id,
+          cohortId,
+          stageId,
+        ))) as ChatStagePublicData | undefined;
+      turnCycleInfo = getTurnCycleInfo(publicData, stage);
+    }
+  }
+
   for (const [itemIndex, promptItem] of promptItems.entries()) {
     // Check condition if present (only for private chat contexts)
     if (
@@ -671,7 +723,7 @@ async function processPromptItems(
       case PromptItemType.TEXT: {
         // Resolve template variables in text prompt items
         const resolvedText = resolveTemplateVariables(
-          promptItem.text,
+          substituteTurnCycleStatus(promptItem.text, turnCycleInfo),
           variableDefinitions,
           valueMap,
         );
@@ -702,7 +754,11 @@ async function processPromptItems(
         );
         const extraParticipantInstr = (stage as ChatStageConfig)
           ?.additionalParticipantInstructions;
-        if (extraParticipantInstr) items.push(extraParticipantInstr);
+        if (extraParticipantInstr) {
+          items.push(
+            substituteTurnCycleStatus(extraParticipantInstr, turnCycleInfo),
+          );
+        }
         break;
       }
       case PromptItemType.PROFILE_CONTEXT: {

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -702,7 +702,13 @@ async function processPromptItems(
           cohortId,
           stageId,
         ))) as ChatStagePublicData | undefined;
-      turnCycleInfo = getTurnCycleInfo(publicData, stage);
+      // The order keeps a place for anyone who is not in the cohort at the
+      // moment, so the number of speakers in a cycle has to be counted from
+      // who is there now.
+      const speakers = (
+        promptData.data[stageId]?.participants ?? promptData.participants
+      ).map((participant) => participant.publicId);
+      turnCycleInfo = getTurnCycleInfo(publicData, stage, speakers);
     }
   }
 

--- a/functions/src/treatment.utils.ts
+++ b/functions/src/treatment.utils.ts
@@ -1,0 +1,134 @@
+import {StageKind, TransferStageConfig} from '@deliberation-lab/utils';
+
+import {getFirestoreStage} from './utils/firestore';
+
+/**
+ * Helpers for reading per-round treatment flags BEFORE the treatment is
+ * hoisted onto the participant.
+ *
+ * Supports within-subjects designs where `treatment` is a per-participant
+ * random permutation of condition objects and each round runs
+ *   ...private chat -> transfer -> group chat...
+ * Treatment is hoisted onto participant fields only at the transfer (see
+ * applyHoistedTreatment), which is AFTER the private chat. So anything the
+ * private chat needs from the round's treatment (e.g. whether the mediator should
+ * appear as the participant's representative) must be read directly from the
+ * treatment value for that round rather than from a hoisted field.
+ */
+
+/**
+ * True if the treatment selected for round `index` sets `key` to `true`.
+ * Mirrors applyHoistedTreatment's parsing: handles the array form (a single
+ * `treatment` variable holding `[t0, t1, t2]`) and the expanded `name_N` form
+ * (`treatment_1`, `treatment_2`, ...). Scans every variable so multiple
+ * treatment-like variables are all considered.
+ */
+function treatmentFlagAtIndex(
+  variableMap: Record<string, string> | undefined,
+  index: number,
+  key: string,
+): boolean {
+  if (!variableMap) return false;
+  for (const [name, value] of Object.entries(variableMap)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      continue; // Not JSON, skip.
+    }
+    let treatment: unknown;
+    if (Array.isArray(parsed)) {
+      treatment = parsed[index];
+    } else if (parsed && typeof parsed === 'object') {
+      const suffix = name.match(/_(\d+)$/);
+      if (suffix && Number(suffix[1]) !== index + 1) continue;
+      treatment = parsed;
+    } else {
+      continue;
+    }
+    if (
+      treatment &&
+      typeof treatment === 'object' &&
+      (treatment as Record<string, unknown>)[key] === true
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True if ANY of the participant's treatment conditions sets
+ * `_skipPrivateChats`. Read directly from the treatment (not a hoisted field)
+ * so it covers private chats that precede the transfer where treatment is
+ * hoisted. Round-INDEPENDENT: when set on any round, this reports true for the
+ * whole participant. Prefer `treatmentAtIndexSkipsPrivateChats` to decide a
+ * specific round's private chat (a participant's rounds can differ on this);
+ * this round-independent form is only a fallback
+ * for when a private chat can't be attributed to a round.
+ */
+export function treatmentSkipsPrivateChats(
+  variableMap: Record<string, string> | undefined,
+): boolean {
+  if (!variableMap) return false;
+  for (const value of Object.values(variableMap)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      continue; // Not JSON, skip.
+    }
+    const conditions = Array.isArray(parsed) ? parsed : [parsed];
+    for (const condition of conditions) {
+      if (
+        condition &&
+        typeof condition === 'object' &&
+        (condition as Record<string, unknown>)['_skipPrivateChats'] === true
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** True if the treatment selected for round `index` sets `_hasRepresentative`. */
+export function treatmentAtIndexHasRepresentative(
+  variableMap: Record<string, string> | undefined,
+  index: number,
+): boolean {
+  return treatmentFlagAtIndex(variableMap, index, '_hasRepresentative');
+}
+
+/** True if the treatment selected for round `index` sets `_skipPrivateChats`. */
+export function treatmentAtIndexSkipsPrivateChats(
+  variableMap: Record<string, string> | undefined,
+  index: number,
+): boolean {
+  return treatmentFlagAtIndex(variableMap, index, '_skipPrivateChats');
+}
+
+/**
+ * For a private chat at `privateChatIndex`, return the treatment
+ * index of the round it belongs to, i.e. the `treatmentIndex` of the next
+ * transfer stage (each round runs ...private chat -> transfer -> group
+ * chat...). Returns
+ * null if no attributable transfer is found (e.g. another private chat appears
+ * first, or there is no following transfer).
+ */
+export async function getRoundTreatmentIndex(
+  experimentId: string,
+  stageIds: string[],
+  privateChatIndex: number,
+): Promise<number | null> {
+  for (let i = privateChatIndex + 1; i < stageIds.length; i++) {
+    const stage = await getFirestoreStage(experimentId, stageIds[i]);
+    if (stage?.kind === StageKind.TRANSFER) {
+      const treatmentIndex = (stage as TransferStageConfig).treatmentIndex;
+      return typeof treatmentIndex === 'number' ? treatmentIndex : null;
+    }
+    // Another private chat before any transfer => can't attribute a round.
+    if (stage?.kind === StageKind.PRIVATE_CHAT) return null;
+  }
+  return null;
+}

--- a/functions/src/triggers/agent_participant.triggers.ts
+++ b/functions/src/triggers/agent_participant.triggers.ts
@@ -3,6 +3,8 @@ import {
   Experiment,
   ParticipantProfileExtended,
   ParticipantStatus,
+  PrivateChatStageConfig,
+  StageKind,
 } from '@deliberation-lab/utils';
 import {completeStageAsAgentParticipant} from '../agent_participant.utils';
 import {sendInitialChatMessages} from '../chat/chat.agent';
@@ -10,6 +12,7 @@ import {
   getFirestoreCohort,
   getFirestoreParticipant,
   getFirestoreParticipantRef,
+  getFirestoreStage,
 } from '../utils/firestore';
 import {app} from '../app';
 
@@ -40,10 +43,23 @@ export const updateAgentParticipant = onDocumentUpdated(
       // Check if the stage is unlocked before sending initial messages.
       // This prevents sending messages for stages that are gated by "waiting"
       // where all participants must be on the current stage first. Observers
-      // bypass the waiting phase.
+      // testing the experiment bypass the waiting phase.
       const isStageUnlocked = cohort?.stageUnlockMap[after.currentStageId];
 
-      if (isStageUnlocked || after.isObserver) {
+      // Group-style turn-based private chats are mediator-goes-first and their
+      // data is scoped to the individual participant, so the opening message
+      // must be sent on stage entry without waiting for the whole cohort to
+      // unlock. In a within-subjects design the other participants advance
+      // through phases on their own cadence and never co-occupy this
+      // per-participant chat, so a cohort-wide unlock (waitForAllParticipants)
+      // can never be satisfied and the mediator would otherwise never speak.
+      // Ordinary (non-group-style) private chats still respect the unlock gate.
+      const stage = await getFirestoreStage(experimentId, after.currentStageId);
+      const isGroupStylePrivateChat =
+        stage?.kind === StageKind.PRIVATE_CHAT &&
+        (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true;
+
+      if (isStageUnlocked || isGroupStylePrivateChat || after.isObserver) {
         await sendInitialChatMessages(
           experimentId,
           after.currentCohortId,

--- a/functions/src/triggers/agent_participant.triggers.ts
+++ b/functions/src/triggers/agent_participant.triggers.ts
@@ -37,11 +37,13 @@ export const updateAgentParticipant = onDocumentUpdated(
         experimentId,
         after.currentCohortId,
       );
-
-      // Check if the stage is unlocked before sending initial messages
+      // Check if the stage is unlocked before sending initial messages.
       // This prevents sending messages for stages that are gated by "waiting"
-      // where all participants must be on the current stage first
-      if (cohort?.stageUnlockMap[after.currentStageId]) {
+      // where all participants must be on the current stage first. Observers
+      // bypass the waiting phase.
+      const isStageUnlocked = cohort?.stageUnlockMap[after.currentStageId];
+
+      if (isStageUnlocked || after.isObserver) {
         await sendInitialChatMessages(
           experimentId,
           after.currentCohortId,

--- a/functions/src/triggers/chat.triggers.test.ts
+++ b/functions/src/triggers/chat.triggers.test.ts
@@ -366,6 +366,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'p2',
           turnOrder: ['m1', 'p1', 'p2', 'p3'],
           cycleIndex: 0,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );
@@ -423,6 +424,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'p3',
           turnOrder: ['m1', 'p1', 'p2', 'p3'],
           cycleIndex: 0,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );
@@ -474,8 +476,14 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
 
       await onPublicChatMessageCreated.run(event as any);
 
-      // Assert that Firestore setMock was NOT called to advance the turn
-      expect(__mocks__.setMock).not.toHaveBeenCalled();
+      // Assert the turn did not advance; only the processed message id is
+      // recorded
+      expect(__mocks__.setMock).toHaveBeenCalledTimes(1);
+      expect(__mocks__.setMock).toHaveBeenCalledWith(
+        'experiments/exp123/cohorts/cohort123/publicStageData/stage123',
+        {turnProcessedMessageId: 'msg123'},
+        {merge: true},
+      );
       // Assert no AI agent or mediator was triggered
       expect(mockInternalCreateAgentChatMessage).not.toHaveBeenCalled();
     });
@@ -511,8 +519,14 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
 
       await onPublicChatMessageCreated.run(event as any);
 
-      // Assert turn did not advance in database
-      expect(__mocks__.setMock).not.toHaveBeenCalled();
+      // Assert the turn did not advance; only the processed message id is
+      // recorded
+      expect(__mocks__.setMock).toHaveBeenCalledTimes(1);
+      expect(__mocks__.setMock).toHaveBeenCalledWith(
+        'experiments/exp123/cohorts/cohort123/publicStageData/stage123',
+        {turnProcessedMessageId: 'msg123'},
+        {merge: true},
+      );
 
       // Assert mediator is triggered to speak the initial message
       expect(mockInternalCreateAgentChatMessage).toHaveBeenCalledWith(
@@ -646,6 +660,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'm1', // mediator starts new cycle
           turnOrder: expectedTurnOrder,
           cycleIndex: 1,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );
@@ -710,6 +725,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'p3',
           turnOrder: ['m1', 'p1', 'p3'],
           cycleIndex: 0,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );
@@ -770,6 +786,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'm1',
           turnOrder: expectedTurnOrder,
           cycleIndex: 1,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );
@@ -840,6 +857,7 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
           currentTurnParticipantId: 'm1',
           turnOrder: ['m1'],
           cycleIndex: 1,
+          turnProcessedMessageId: 'msg123',
         },
         {merge: true},
       );

--- a/functions/src/triggers/chat.triggers.test.ts
+++ b/functions/src/triggers/chat.triggers.test.ts
@@ -6,6 +6,7 @@ import {
   UserType,
   ChatMessage,
   shuffleWithSeed,
+  ParticipantStatus,
 } from '@deliberation-lab/utils';
 
 // -----------------------------------------------------------------------------
@@ -780,6 +781,76 @@ describe('Chat Triggers - Turn Taking Mechanics', () => {
         ['priv1'], // all remaining participants for context
         'stage123',
         '', // empty triggerChatId indicates initial/reset mediator message
+        expect.objectContaining({publicId: 'm1', type: UserType.MEDIATOR}),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. OBSERVER TURN TAKING ROBUSTNESS
+  // ---------------------------------------------------------------------------
+  describe('7. Observer Turn Taking Robustness', () => {
+    it('allows turn-taking to continue if there is an observer but zero active participants', async () => {
+      mockGetFirestoreActiveParticipants.mockResolvedValue([
+        {
+          publicId: 'obs1',
+          privateId: 'priv-obs1',
+          isObserver: true,
+          agentConfig: null,
+          currentCohortId: 'cohort123',
+          currentStageId: 'stage123',
+          currentStatus: ParticipantStatus.IN_PROGRESS,
+        },
+      ]);
+
+      mockGetFirestoreStagePublicData.mockResolvedValue({
+        id: 'stage123',
+        currentTurnParticipantId: 'm1',
+        turnOrder: ['m1'],
+        cycleIndex: 0,
+      });
+
+      const chatMessage = {
+        id: 'msg123',
+        senderId: 'm1',
+        message: 'Hello observer.',
+        type: UserType.MEDIATOR,
+        timestamp: {} as any,
+      } as ChatMessage;
+
+      const event = {
+        data: {
+          data: () => chatMessage,
+          exists: true,
+        },
+        params: {
+          experimentId: 'exp123',
+          cohortId: 'cohort123',
+          stageId: 'stage123',
+          chatId: 'msg123',
+        },
+      };
+
+      await onPublicChatMessageCreated.run(event as any);
+
+      // Assert turnOrder stays ['m1'], currentTurnParticipantId stays 'm1', cycleIndex increments to 1
+      expect(__mocks__.setMock).toHaveBeenCalledWith(
+        'experiments/exp123/cohorts/cohort123/publicStageData/stage123',
+        {
+          currentTurnParticipantId: 'm1',
+          turnOrder: ['m1'],
+          cycleIndex: 1,
+        },
+        {merge: true},
+      );
+
+      // Assert mediator is auto-triggered!
+      expect(mockInternalCreateAgentChatMessage).toHaveBeenCalledWith(
+        'exp123',
+        'cohort123',
+        [], // observer is filtered out of recipient private IDs for context
+        'stage123',
+        'msg123',
         expect.objectContaining({publicId: 'm1', type: UserType.MEDIATOR}),
       );
     });

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -14,6 +14,7 @@ import {
   MediatorProfileExtended,
 } from '@deliberation-lab/utils';
 import {
+  getAgentMediatorPrompt,
   getFirestoreActiveMediators,
   getFirestoreActiveParticipants,
   getFirestoreParticipant,
@@ -26,7 +27,7 @@ import {
   canSendAgentChatMessage,
 } from '../chat/chat.agent';
 import {sendErrorPrivateChatMessage} from '../chat/chat.utils';
-import {startTimeElapsed} from '../stages/chat.time';
+import {handleMaxMessagesReached, startTimeElapsed} from '../stages/chat.time';
 import {getStructuredPromptConfig} from '../structured_prompt.utils';
 import {app} from '../app';
 
@@ -58,14 +59,136 @@ export const onPublicChatMessageCreated = onDocumentCreated(
 
     // Take action for specific stages
     switch (stage.kind) {
-      case StageKind.CHAT:
+      case StageKind.CHAT: {
         // Start tracking elapsed time
         startTimeElapsed(
           event.params.experimentId,
           event.params.cohortId,
           publicStageData as ChatStagePublicData,
         );
+        // End the discussion globally when the group chat's message cap is
+        // reached. A per-mediator override (set on an active mediator's chat
+        // settings for this stage) replaces the stage-level maxNumberOfMessages;
+        // otherwise the stage value applies. Lets experimenters set a different
+        // cap for group chats running certain mediator personas.
+        const alreadyEnded = (publicStageData as ChatStagePublicData)
+          .discussionEndTimestamp;
+        if (!alreadyEnded) {
+          const stageMax = (stage as ChatStageConfig).maxNumberOfMessages;
+          const activeMediators = await getFirestoreActiveMediators(
+            event.params.experimentId,
+            event.params.cohortId,
+            stage.id,
+            true, // checkIsAgent
+          );
+          const mediatorOverrides: number[] = [];
+          const mediatorMinOverrides: number[] = [];
+          for (const mediator of activeMediators) {
+            const personaId = mediator.agentConfig?.agentId;
+            if (!personaId) continue;
+            const mediatorPrompt = await getAgentMediatorPrompt(
+              event.params.experimentId,
+              stage.id,
+              personaId,
+            );
+            const override = mediatorPrompt?.chatSettings?.maxNumberOfMessages;
+            if (override != null) mediatorOverrides.push(override);
+            const minOverride =
+              mediatorPrompt?.chatSettings?.minNumberOfMessages;
+            if (minOverride != null) mediatorMinOverrides.push(minOverride);
+          }
+          // A per-mediator override replaces the stage-level cap for this group
+          // chat. If multiple active mediators set one, the most restrictive
+          // (smallest) among them applies.
+          const effectiveMax =
+            mediatorOverrides.length > 0
+              ? Math.min(...mediatorOverrides)
+              : stageMax;
+
+          // A per-mediator override likewise replaces the stage-level
+          // minimum; the largest override wins. Published to publicStageData
+          // so the participant view's advance gate honors it, since the
+          // frontend cannot read mediator chat settings. Write only when it
+          // changes.
+          const stageMin = (stage as ChatStageConfig).minNumberOfMessages ?? 0;
+          let effectiveMin =
+            mediatorMinOverrides.length > 0
+              ? Math.max(...mediatorMinOverrides)
+              : stageMin;
+          // The max cap also caps the advancement requirement: participants can
+          // never be required to send more messages than the discussion
+          // allows, so the minimum is clamped down to the effective maximum.
+          if (effectiveMax != null && effectiveMin > effectiveMax) {
+            effectiveMin = effectiveMax;
+          }
+          // Only publish when an override moves a bound off the stage default.
+          // With no override the participant view already falls back to the
+          // stage value, so writing nothing leaves the effective bound equal to
+          // the stage bound.
+          const existingPublic = publicStageData as ChatStagePublicData;
+          const effectiveUpdates: {
+            effectiveMinNumberOfMessages?: number;
+            effectiveMaxNumberOfMessages?: number;
+          } = {};
+          if (
+            effectiveMin !== stageMin &&
+            existingPublic.effectiveMinNumberOfMessages !== effectiveMin
+          ) {
+            effectiveUpdates.effectiveMinNumberOfMessages = effectiveMin;
+          }
+          // Publish the effective max the same way, so the frontend's
+          // conversation-over / banner logic and the send-time cap guard use
+          // the cap the backend actually enforces (a per-mediator override
+          // replaces the stage value). The frontend otherwise compares against
+          // the stage value, hiding the banner before the final message and
+          // making the chat look like it ran past the limit.
+          if (
+            effectiveMax != null &&
+            effectiveMax !== stageMax &&
+            existingPublic.effectiveMaxNumberOfMessages !== effectiveMax
+          ) {
+            effectiveUpdates.effectiveMaxNumberOfMessages = effectiveMax;
+          }
+          if (Object.keys(effectiveUpdates).length > 0) {
+            await app
+              .firestore()
+              .collection('experiments')
+              .doc(event.params.experimentId)
+              .collection('cohorts')
+              .doc(event.params.cohortId)
+              .collection('publicStageData')
+              .doc(event.params.stageId)
+              .set(effectiveUpdates, {merge: true});
+          }
+          if (effectiveMax != null) {
+            const allChatMessages = await getFirestorePublicStageChatMessages(
+              event.params.experimentId,
+              event.params.cohortId,
+              event.params.stageId,
+            );
+            // `isReasoningOnly` is an optional field; when it is not set the
+            // access resolves to undefined (falsy), so a message is only
+            // excluded when the field is present and true. Keeps the backend
+            // cap aligned with the frontend, which excludes reasoning-only
+            // messages from chatMap entirely.
+            const cohortMessageCount = allChatMessages.filter(
+              (m) =>
+                m.type !== UserType.SYSTEM &&
+                !m.isError &&
+                !(m as {isReasoningOnly?: boolean}).isReasoningOnly,
+            ).length;
+            if (cohortMessageCount >= effectiveMax) {
+              await handleMaxMessagesReached(
+                event.params.experimentId,
+                event.params.cohortId,
+                event.params.stageId,
+              );
+              return;
+            }
+          }
+        }
         break;
+      }
       case StageKind.SALESPERSON:
         // TODO: Add API calls for salesperson back in
         return; // Don't call any of the usual chat functions

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -302,6 +302,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
             {
               currentTurnParticipantId: null,
               turnOrder: [],
+              turnProcessedMessageId: message.id,
             },
             {merge: true},
           );
@@ -458,6 +459,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                 currentTurnParticipantId,
                 turnOrder,
                 cycleIndex,
+                turnProcessedMessageId: message.id,
               },
               {merge: true},
             );
@@ -468,6 +470,12 @@ export const onPublicChatMessageCreated = onDocumentCreated(
             );
             nextMediatorHolder = mediators.find(
               (m) => m.publicId === currentTurnParticipantId,
+            );
+          } else {
+            transaction.set(
+              publicStageDataRef,
+              {turnProcessedMessageId: message.id},
+              {merge: true},
             );
           }
           return;
@@ -588,6 +596,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
                 currentTurnParticipantId,
                 turnOrder,
                 cycleIndex,
+                turnProcessedMessageId: message.id,
               },
               {merge: true},
             );
@@ -598,6 +607,12 @@ export const onPublicChatMessageCreated = onDocumentCreated(
             );
             nextMediatorHolder = mediators.find(
               (m) => m.publicId === currentTurnParticipantId,
+            );
+          } else {
+            transaction.set(
+              publicStageDataRef,
+              {turnProcessedMessageId: message.id},
+              {merge: true},
             );
           }
         }

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -79,9 +79,12 @@ export const onPublicChatMessageCreated = onDocumentCreated(
       event.params.cohortId,
       stage.id,
       false, // Get all participants, not just agents
+      true, // Include observers
     );
 
-    const allParticipantIds = allParticipants.map((p) => p.privateId);
+    const allParticipantIds = allParticipants
+      .filter((p) => !p.isObserver)
+      .map((p) => p.privateId);
 
     const chatStage = stage as ChatStageConfig;
     const chatPublicData = publicStageData as ChatStagePublicData;
@@ -103,6 +106,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
         event.params.cohortId,
         stage.id,
         true, // get AI mediators
+        stage,
       );
       const allMediatorIds = mediators.map((m) => m.publicId);
 
@@ -138,8 +142,10 @@ export const onPublicChatMessageCreated = onDocumentCreated(
         let currentTurnParticipantId = chatPublicData.currentTurnParticipantId;
         let cycleIndex = chatPublicData.cycleIndex ?? 0;
 
-        // Get active IDs for validation and filtering. Filter out completed/booted/timed-out participants.
+        // Get active IDs for validation and filtering. Filter out completed/booted/timed-out participants and observers.
         const activeParticipants = allParticipants.filter((p) => {
+          if (p.isObserver) return false;
+          if (p.agentConfig?.isInactivePersona) return false;
           if (
             p.currentCohortId !== undefined &&
             p.currentCohortId !== event.params.cohortId
@@ -159,7 +165,15 @@ export const onPublicChatMessageCreated = onDocumentCreated(
           return !isExplicitlyInactive && !isExplicitlyCompleted;
         });
 
-        if (activeParticipants.length === 0) {
+        // Pause turn-taking once there are no active (non-observer)
+        // participants left, unless an observer is present to watch the
+        // agents. Without an observer, the chat pauses as before so the
+        // mediator does not monologue after every participant has left.
+        const hasObserver = allParticipants.some((p) => p.isObserver);
+        if (
+          activeParticipants.length === 0 &&
+          (allMediatorIds.length === 0 || !hasObserver)
+        ) {
           transaction.set(
             publicStageDataRef,
             {
@@ -514,9 +528,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
             await createAgentChatMessageFromPrompt(
               event.params.experimentId,
               event.params.cohortId,
-              mediator
-                ? allParticipants.map((p) => p.privateId)
-                : [agent.privateId],
+              mediator ? allParticipantIds : [agent.privateId],
               stage.id,
               '', // empty triggerChatId indicates initial message
               agent,
@@ -531,7 +543,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
           await createAgentChatMessageFromPrompt(
             event.params.experimentId,
             event.params.cohortId,
-            allParticipants.map((p) => p.privateId),
+            allParticipantIds,
             stage.id,
             finalTriggerChatId,
             nextMediatorHolder,
@@ -554,6 +566,7 @@ export const onPublicChatMessageCreated = onDocumentCreated(
         event.params.cohortId,
         stage.id,
         true,
+        stage,
       );
       await Promise.all(
         mediators.map((mediator) =>
@@ -572,7 +585,9 @@ export const onPublicChatMessageCreated = onDocumentCreated(
       // the experiment
       const agentParticipants = allParticipants.filter(
         (p) =>
-          p.agentConfig && p.currentStatus === ParticipantStatus.IN_PROGRESS,
+          p.agentConfig &&
+          !p.agentConfig.isInactivePersona &&
+          p.currentStatus === ParticipantStatus.IN_PROGRESS,
       );
       await Promise.all(
         agentParticipants.map((participant) =>
@@ -635,6 +650,7 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
       participant.currentCohortId,
       stage.id,
       true,
+      stage,
     );
 
     await Promise.all(

--- a/functions/src/triggers/chat.triggers.ts
+++ b/functions/src/triggers/chat.triggers.ts
@@ -8,6 +8,7 @@ import {
   UserType,
   createParticipantProfileBase,
   createSystemChatMessage,
+  getQuizPauseCheckpointForCount,
   shuffleWithSeed,
   ChatPromptConfig,
   ParticipantProfileExtended,
@@ -20,6 +21,7 @@ import {
   getFirestoreParticipant,
   getFirestoreStage,
   getFirestoreStagePublicData,
+  getFirestoreStagePublicDataRef,
   getFirestorePublicStageChatMessages,
 } from '../utils/firestore';
 import {
@@ -35,6 +37,44 @@ import {app} from '../app';
 // TRIGGER FUNCTIONS                                                         //
 // ************************************************************************* //
 
+/**
+ * Start the next agent's turn in a turn-based group chat. This is the single
+ * chokepoint that dispatches the next agent message after a turn advances.
+ * Exported so the quiz resume path (submitParticipantThought) can
+ * re-fire the stalled turn once the pause is cleared. No new chat message
+ * arrives to re-trigger onPublicChatMessageCreated, so the resume must be
+ * explicit.
+ */
+export async function triggerNextTurnHolder(
+  experimentId: string,
+  cohortId: string,
+  allParticipantIds: string[], // non-observer participant private IDs (mediator context)
+  stageId: string,
+  triggerChatId: string,
+  nextMediatorHolder: MediatorProfileExtended | null | undefined,
+  nextTurnHolder: ParticipantProfileExtended | null | undefined,
+) {
+  if (nextMediatorHolder) {
+    await createAgentChatMessageFromPrompt(
+      experimentId,
+      cohortId,
+      allParticipantIds,
+      stageId,
+      triggerChatId,
+      nextMediatorHolder,
+    );
+  } else if (nextTurnHolder?.agentConfig) {
+    await createAgentChatMessageFromPrompt(
+      experimentId,
+      cohortId,
+      [nextTurnHolder.privateId],
+      stageId,
+      triggerChatId,
+      nextTurnHolder,
+    );
+  }
+}
+
 /** When a chat message is created under publicStageData */
 export const onPublicChatMessageCreated = onDocumentCreated(
   {
@@ -44,6 +84,10 @@ export const onPublicChatMessageCreated = onDocumentCreated(
     timeoutSeconds: 300,
   },
   async (event) => {
+    if ((event.data?.data() as ChatMessage | undefined)?.isReasoningOnly) {
+      return;
+    }
+
     const stage = await getFirestoreStage(
       event.params.experimentId,
       event.params.stageId,
@@ -160,31 +204,91 @@ export const onPublicChatMessageCreated = onDocumentCreated(
               .doc(event.params.stageId)
               .set(effectiveUpdates, {merge: true});
           }
-          if (effectiveMax != null) {
-            const allChatMessages = await getFirestorePublicStageChatMessages(
+          const allChatMessages =
+            (await getFirestorePublicStageChatMessages(
+              event.params.experimentId,
+              event.params.cohortId,
+              event.params.stageId,
+            )) ?? [];
+          // `isReasoningOnly` is an optional field; when it is not set the
+          // access resolves to undefined (falsy), so a message is only
+          // excluded when the field is present and true. Keeps the backend
+          // cap aligned with the frontend, which excludes reasoning-only
+          // messages from chatMap entirely.
+          const cohortMessageCount = allChatMessages.filter(
+            (m) =>
+              m.type !== UserType.SYSTEM &&
+              !m.isError &&
+              !(m as {isReasoningOnly?: boolean}).isReasoningOnly,
+          ).length;
+          // Quiz-participant presence + quiz state. Computed before the cap check so
+          // the after-final-message quiz can pause the cap.
+          const cohortParticipants = await getFirestoreActiveParticipants(
+            event.params.experimentId,
+            event.params.cohortId,
+            stage.id,
+            false, // Get all participants
+            true, // Include observers
+          );
+          // Quiz applies per the participant's _isQuizzed variable, and only
+          // in turn-based chats (the pause gates the next agent turn);
+          // otherwise the variable is ignored.
+          const hasQuizParticipant =
+            (stage as ChatStageConfig).isTurnBased === true &&
+            cohortParticipants.some((p) => p.isQuizzed);
+          const answeredCheckpoint = existingPublic.quizAnsweredCheckpoint ?? 0;
+          const alreadyPaused = (existingPublic.quizPauseCheckpoint ?? 0) > 0;
+          // Checkpoints are thirds of the effective minimum message count
+          // (fewer than 3 quizzes when the minimum is under 3; none without a
+          // minimum).
+          const newCheckpoint = getQuizPauseCheckpointForCount(
+            cohortMessageCount,
+            effectiveMin,
+          );
+
+          if (effectiveMax != null && cohortMessageCount >= effectiveMax) {
+            // Final message sent -> end the discussion. If a participant
+            // still owes the after-final quiz (the last checkpoint quiz),
+            // also raise its pause so they answer before proceeding; the chat
+            // is ended either way, and submitting just clears the quiz (its
+            // turn-resume is then a no-op against the already-ended discussion).
+            if (
+              hasQuizParticipant &&
+              !alreadyPaused &&
+              newCheckpoint >= 1 &&
+              answeredCheckpoint < newCheckpoint
+            ) {
+              await getFirestoreStagePublicDataRef(
+                event.params.experimentId,
+                event.params.cohortId,
+                event.params.stageId,
+              ).update({quizPauseCheckpoint: newCheckpoint});
+            }
+            await handleMaxMessagesReached(
               event.params.experimentId,
               event.params.cohortId,
               event.params.stageId,
             );
-            // `isReasoningOnly` is an optional field; when it is not set the
-            // access resolves to undefined (falsy), so a message is only
-            // excluded when the field is present and true. Keeps the backend
-            // cap aligned with the frontend, which excludes reasoning-only
-            // messages from chatMap entirely.
-            const cohortMessageCount = allChatMessages.filter(
-              (m) =>
-                m.type !== UserType.SYSTEM &&
-                !m.isError &&
-                !(m as {isReasoningOnly?: boolean}).isReasoningOnly,
-            ).length;
-            if (cohortMessageCount >= effectiveMax) {
-              await handleMaxMessagesReached(
-                event.params.experimentId,
-                event.params.cohortId,
-                event.params.stageId,
-              );
-              return;
-            }
+            return;
+          }
+
+          // Intermediate quizzes (~1/3 and ~2/3 through): pause at a new
+          // checkpoint below the cap so the participant answers; cleared and the
+          // turn resumed on submit. Only the pause flag is set: the frontend
+          // renders the "paused" banner and suppresses the typing indicator.
+          // No system chat message is posted, since it read like a real
+          // message and left a stale typing indicator.
+          if (
+            hasQuizParticipant &&
+            !alreadyPaused &&
+            newCheckpoint > answeredCheckpoint &&
+            newCheckpoint >= 1
+          ) {
+            await getFirestoreStagePublicDataRef(
+              event.params.experimentId,
+              event.params.cohortId,
+              event.params.stageId,
+            ).update({quizPauseCheckpoint: newCheckpoint});
           }
         }
         break;
@@ -676,26 +780,24 @@ export const onPublicChatMessageCreated = onDocumentCreated(
       }
 
       if (shouldTriggerAgent && updatedTurnParticipantId) {
-        const finalTriggerChatId = wasTurnHolderDroppedOut ? '' : message.id;
-        if (nextMediatorHolder) {
-          await createAgentChatMessageFromPrompt(
-            event.params.experimentId,
-            event.params.cohortId,
-            allParticipantIds,
-            stage.id,
-            finalTriggerChatId,
-            nextMediatorHolder,
-          );
-        } else if (nextTurnHolder?.agentConfig) {
-          await createAgentChatMessageFromPrompt(
-            event.params.experimentId,
-            event.params.cohortId,
-            [nextTurnHolder.privateId],
-            stage.id,
-            finalTriggerChatId,
-            nextTurnHolder,
-          );
+        // Quiz pause: while the chat is paused for a quiz, do not start the
+        // next agent turn. turnOrder / currentTurnParticipantId / cycleIndex
+        // are already persisted, so the turn resumes cleanly when the
+        // participant submits (see submitParticipantThought ->
+        // triggerNextTurnHolder).
+        if ((updatedPublicStageData?.quizPauseCheckpoint ?? 0) > 0) {
+          return;
         }
+        const finalTriggerChatId = wasTurnHolderDroppedOut ? '' : message.id;
+        await triggerNextTurnHolder(
+          event.params.experimentId,
+          event.params.cohortId,
+          allParticipantIds,
+          stage.id,
+          finalTriggerChatId,
+          nextMediatorHolder,
+          nextTurnHolder,
+        );
       }
     } else {
       // Send agent mediator messages
@@ -766,7 +868,7 @@ export const onPrivateChatMessageCreated = onDocumentCreated(
         .doc(event.params.chatId)
         .get()
     ).data() as ChatMessage;
-    if (message.isError) {
+    if (message.isError || message.isReasoningOnly) {
       return;
     }
 

--- a/functions/src/triggers/participant.triggers.ts
+++ b/functions/src/triggers/participant.triggers.ts
@@ -34,6 +34,8 @@ import {
   getExperimenterDataFromExperiment,
   getStoredPersona,
   saveStoredPersona,
+  claimStoredPersonaByHash,
+  claimStoredPersonaSketch,
 } from '../utils/firestore';
 import {
   canSendAgentChatMessage,
@@ -71,6 +73,10 @@ export const onParticipantCreation = onDocumentCreated(
         // it is reused across cohorts. Unset for representatives, which always
         // generate fresh.
         const slotKey = participant.agentConfig.personaSlotKey;
+        // Persona bank match key. Set on representatives and inactive
+        // personas so they retrieve a pre-generated persona (keyed by the
+        // round's variables) rather than generating one.
+        const personaHash = participant.agentConfig.personaHash;
 
         // Apply a persona (stored or freshly generated) to the participant:
         // append it to any context already set at spawn, mark the agent
@@ -129,6 +135,51 @@ export const onParticipantCreation = onDocumentCreated(
         const maxRetries = promptConfig?.numRetries ?? 0;
         const initialDelay = 1000;
         let success = false;
+
+        // Agents that participate directly claim a plain persona sketch from
+        // the bank. Sketches are topic-agnostic, so any bucket works; claims
+        // are keyed to the human so a participant never gets the same persona
+        // twice across rounds. Falls through to live generation if no unused
+        // sketch remains.
+        const sketchForHumanId =
+          participant.agentConfig.personaSketchForHumanId;
+        if (sketchForHumanId) {
+          const sketch = await claimStoredPersonaSketch(
+            experimentId,
+            sketchForHumanId,
+          );
+          if (sketch) {
+            console.log(
+              `Claimed bank persona SKETCH for participant ${participant.privateId} (human ${sketchForHumanId.slice(0, 8)}).`,
+            );
+            await applyPersona(sketch);
+            success = true;
+          }
+        }
+
+        // If this agent has a persona-bank match key, claim a pre-generated
+        // persona (distinct per participant, reuse spread evenly). Skips LLM
+        // generation; falls through to standard generation on no match.
+        if (!success && personaHash) {
+          const content = await claimStoredPersonaByHash(
+            experimentId,
+            personaHash,
+            participant.privateId,
+          );
+          if (content) {
+            // Content may reference the claiming agent's profile.
+            const resolved = content
+              .split('{{name}}')
+              .join(String(participant.name ?? participant.publicId))
+              .split('{{publicId}}')
+              .join(participant.publicId);
+            console.log(
+              `Claimed bank persona for participant ${participant.privateId} (hash ${personaHash.slice(0, 8)}).`,
+            );
+            await applyPersona(resolved);
+            success = true;
+          }
+        }
 
         // If this agent has a persona slot and one is already stored for the
         // experiment, reuse it (reproducible across cohorts) and skip the LLM

--- a/functions/src/triggers/participant.triggers.ts
+++ b/functions/src/triggers/participant.triggers.ts
@@ -12,6 +12,10 @@ import {
   StageConfig,
   StageKind,
   shuffleWithSeed,
+  buildGeneratePersonaPrompt,
+  createModelGenerationConfig,
+  ModelResponseStatus,
+  DEFAULT_AGENT_MODEL_SETTINGS,
 } from '@deliberation-lab/utils';
 import {startAgentParticipant} from '../agent_participant.utils';
 import {
@@ -23,15 +27,21 @@ import {
   getFirestoreActiveMediators,
   getFirestoreActiveParticipants,
   getFirestoreParticipant,
+  getFirestoreParticipantRef,
   getFirestorePublicStageChatMessages,
   getFirestoreStage,
   getFirestoreStagePublicDataRef,
+  getExperimenterDataFromExperiment,
+  getStoredPersona,
+  saveStoredPersona,
 } from '../utils/firestore';
 import {
   canSendAgentChatMessage,
   createAgentChatMessageFromPrompt,
   skipTimedOutTurnBasedAgentTurn,
 } from '../chat/chat.agent';
+import {getAgentResponse} from '../agent.utils';
+import {samplePersonaParams} from '../agent_persona_sampling';
 import {getStructuredPromptConfig} from '../structured_prompt.utils';
 
 import {app} from '../app';
@@ -46,11 +56,179 @@ export const onParticipantCreation = onDocumentCreated(
     );
     if (!participant) return;
 
+    let activeParticipant = participant;
+
+    // 1. Generate persona if flagged. This awaits the generation (and any
+    // retries) before the participant is initialized below, so a flagged
+    // participant stays uninitialized until its persona context is ready.
+    if (participant.agentConfig?.needsPersonaGeneration) {
+      const experimentId = event.params.experimentId;
+      const experimenterData =
+        await getExperimenterDataFromExperiment(experimentId);
+
+      if (experimenterData) {
+        // Stable key for storing/retrieving this agent's generated persona so
+        // it is reused across cohorts. Unset for representatives, which always
+        // generate fresh.
+        const slotKey = participant.agentConfig.personaSlotKey;
+
+        // Apply a persona (stored or freshly generated) to the participant:
+        // append it to any context already set at spawn, mark the agent
+        // connected, and clear the generation flag.
+        const applyPersona = async (generated: string) => {
+          await app.firestore().runTransaction(async (transaction) => {
+            const pRef = getFirestoreParticipantRef(
+              experimentId,
+              participant.privateId,
+            );
+            const pDoc = (
+              await transaction.get(pRef)
+            ).data() as ParticipantProfileExtended;
+            if (pDoc?.agentConfig) {
+              // Append the persona to any context already set at spawn (e.g. a
+              // representative's framing) rather than overwriting it.
+              const base = pDoc.agentConfig.promptContext ?? '';
+              pDoc.agentConfig.promptContext = base
+                ? `${base}\n\n${generated}`
+                : generated;
+              pDoc.connected = true;
+              pDoc.agentConfig.needsPersonaGeneration = false;
+              transaction.set(pRef, pDoc);
+              activeParticipant = pDoc;
+            }
+          });
+        };
+
+        const params = samplePersonaParams();
+        const generationConfig = createModelGenerationConfig({
+          includeReasoning: false,
+          providerOptions: {
+            google: {thinkingConfig: {thinkingBudget: 0}},
+            anthropic: {thinking: {type: 'disabled'}},
+          },
+        });
+
+        // Fetch stage prompt config to dynamically retrieve configured numRetries
+        const stage = await getFirestoreStage(
+          experimentId,
+          participant.currentStageId,
+        );
+        const promptConfig = stage
+          ? await getStructuredPromptConfig(experimentId, stage, participant)
+          : undefined;
+
+        // When the agent is spawned into a chat stage that configures a
+        // position prompt, elicit the position alongside the persona in a
+        // single call (persona first, then position).
+        const positionPrompt =
+          stage?.kind === StageKind.CHAT
+            ? (stage as ChatStageConfig).personaPositionPrompt
+            : undefined;
+        const prompt = buildGeneratePersonaPrompt(params, positionPrompt);
+
+        const maxRetries = promptConfig?.numRetries ?? 0;
+        const initialDelay = 1000;
+        let success = false;
+
+        // If this agent has a persona slot and one is already stored for the
+        // experiment, reuse it (reproducible across cohorts) and skip the LLM
+        // generation entirely.
+        if (!success && slotKey) {
+          const storedPersona = await getStoredPersona(experimentId, slotKey);
+          if (storedPersona) {
+            console.log(
+              `Reusing stored persona for participant ${participant.privateId} (slot ${slotKey}).`,
+            );
+            await applyPersona(storedPersona);
+            success = true;
+          }
+        }
+
+        for (let attempt = 0; !success && attempt <= maxRetries; attempt++) {
+          try {
+            const response = await getAgentResponse(
+              experimenterData.apiKeys,
+              prompt,
+              DEFAULT_AGENT_MODEL_SETTINGS,
+              generationConfig,
+            );
+
+            if (response.status === ModelResponseStatus.OK && response.text) {
+              const generated = response.text;
+              // Store the raw generated persona (before the base-append) so it
+              // is reused by later cohorts sharing this slot.
+              if (slotKey) {
+                await saveStoredPersona(experimentId, slotKey, generated);
+              }
+              await applyPersona(generated);
+              success = true;
+              break;
+            }
+
+            // Check if we should retry
+            const shouldRetry =
+              attempt < maxRetries &&
+              (response.status ===
+                ModelResponseStatus.PROVIDER_UNAVAILABLE_ERROR ||
+                response.status === ModelResponseStatus.INTERNAL_ERROR ||
+                response.status === ModelResponseStatus.UNKNOWN_ERROR);
+
+            if (!shouldRetry) {
+              if (attempt === maxRetries) {
+                console.error(
+                  `Failed to generate persona context: Non-retryable response status: ${response.status}`,
+                );
+              }
+              break;
+            }
+
+            const delay = initialDelay * Math.pow(2, attempt);
+            console.log(
+              `Persona generation API error (${response.status}), retrying after ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          } catch (error) {
+            console.error(`Attempt ${attempt} threw error:`, error);
+            if (attempt < maxRetries) {
+              const delay = initialDelay * Math.pow(2, attempt);
+              await new Promise((resolve) => setTimeout(resolve, delay));
+            } else {
+              break;
+            }
+          }
+        }
+
+        if (!success) {
+          console.error(
+            `Failed to generate persona context for participant ${participant.privateId} after ${maxRetries} retries. Reverting to base promptContext.`,
+          );
+          await app.firestore().runTransaction(async (transaction) => {
+            const pRef = getFirestoreParticipantRef(
+              experimentId,
+              participant.privateId,
+            );
+            const pDoc = (
+              await transaction.get(pRef)
+            ).data() as ParticipantProfileExtended;
+            if (pDoc?.agentConfig) {
+              pDoc.connected = true;
+              pDoc.agentConfig.needsPersonaGeneration = false;
+              transaction.set(pRef, pDoc);
+              activeParticipant = pDoc;
+            }
+          });
+        }
+      }
+    }
+
     // Set up participant stage answers
-    initializeParticipantStageAnswers(event.params.experimentId, participant);
+    initializeParticipantStageAnswers(
+      event.params.experimentId,
+      activeParticipant,
+    );
 
     // Start making agent calls for participants with agent configs
-    startAgentParticipant(event.params.experimentId, participant);
+    startAgentParticipant(event.params.experimentId, activeParticipant);
   },
 );
 
@@ -88,10 +266,11 @@ async function advanceTurnBasedChatIfCurrentParticipantLeft(
 
   const [allActiveParticipants, activeMediators] = await Promise.all([
     getFirestoreActiveParticipants(experimentId, cohortId, stageId, false),
-    getFirestoreActiveMediators(experimentId, cohortId, stageId, true),
+    getFirestoreActiveMediators(experimentId, cohortId, stageId, true, stage),
   ]);
   const activeParticipants = allActiveParticipants.filter(
-    (p) => p.timestamps?.completedStages?.[stageId] === undefined,
+    (p) =>
+      p.timestamps?.completedStages?.[stageId] === undefined && !p.isObserver,
   );
   const activeIds = new Set([
     ...activeMediators.map((mediator) => mediator.publicId),

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -20,6 +20,8 @@ import {
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 
+import {StoredPersona, selectPersonaToClaim} from '../persona_bank.utils';
+
 import {app} from '../app';
 
 /** Utils functions for handling Firestore docs. */
@@ -137,6 +139,74 @@ export async function saveStoredPersona(
 ): Promise<void> {
   const ref = getStoredPersonaRef(experimentId, slotKey);
   await ref.set({id: slotKey, text, createdAt: Timestamp.now()});
+}
+
+/**
+ * Claim a pre-generated persona from the bank for the given match hash. Returns
+ * the persona's content text, or null if the bank has no persona
+ * for the hash that this participant has not already used. Selection prefers the
+ * fewest-used persona and never returns one already used by this participant, so
+ * a participant sees a distinct persona per slot across their whole run and
+ * reuse is spread evenly across participants. The claim is transactional, so
+ * concurrent cohort spawns deterministically land on distinct personas.
+ */
+export async function claimStoredPersonaByHash(
+  experimentId: string,
+  hash: string,
+  participantPrivateId: string,
+): Promise<string | null> {
+  const personasRef = app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('personas');
+  const query = personasRef.where('hash', '==', hash);
+
+  return app.firestore().runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(query);
+    const personas = snapshot.docs.map((doc) => doc.data() as StoredPersona);
+    const chosen = selectPersonaToClaim(personas, participantPrivateId);
+    if (!chosen) return null;
+
+    transaction.update(personasRef.doc(chosen.id), {
+      usageCount: (chosen.usageCount ?? 0) + 1,
+      usedBy: [...(chosen.usedBy ?? []), participantPrivateId],
+    });
+    return chosen.content ?? null;
+  });
+}
+
+/**
+ * Claim a plain persona SKETCH for an agent that participates directly.
+ * Sketches are topic and treatment agnostic, so any unused bank persona
+ * works: query the whole
+ * experiment bank (not a single hash bucket) and pick the fewest-used persona
+ * not already claimed by this participant. Keyed by the HUMAN's private ID so a
+ * participant never gets the same persona twice across rounds. Returns the
+ * sketch text, or null if no persona with an unclaimed sketch remains.
+ */
+export async function claimStoredPersonaSketch(
+  experimentId: string,
+  participantPrivateId: string,
+): Promise<string | null> {
+  const personasRef = app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('personas');
+  return app.firestore().runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(personasRef);
+    const personas = snapshot.docs
+      .map((doc) => doc.data() as StoredPersona)
+      .filter((p) => p.sketch);
+    const chosen = selectPersonaToClaim(personas, participantPrivateId);
+    if (!chosen) return null;
+    transaction.update(personasRef.doc(chosen.id), {
+      usageCount: (chosen.usageCount ?? 0) + 1,
+      usedBy: [...(chosen.usedBy ?? []), participantPrivateId],
+    });
+    return chosen.sketch ?? null;
+  });
 }
 
 /** True for the turn-based chat variants (group chat with isTurnBased, or a

--- a/functions/src/utils/firestore.ts
+++ b/functions/src/utils/firestore.ts
@@ -1,6 +1,7 @@
 import {
   AgentPersonaConfig,
   ChatMessage,
+  ChatStageConfig,
   CohortConfig,
   Experiment,
   ExperimenterData,
@@ -10,11 +11,14 @@ import {
   ParticipantPromptConfig,
   ParticipantProfileExtended,
   ParticipantStatus,
+  PrivateChatStageConfig,
   StageConfig,
+  StageKind,
   StageParticipantAnswer,
   StagePublicData,
   getParticipantDisplayName,
 } from '@deliberation-lab/utils';
+import {Timestamp} from 'firebase-admin/firestore';
 
 import {app} from '../app';
 
@@ -103,13 +107,67 @@ export async function getFirestoreCohortParticipants(
   ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
 }
 
+/** Return ref for a stored persona doc. */
+export function getStoredPersonaRef(experimentId: string, slotKey: string) {
+  return app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('personas')
+    .doc(slotKey);
+}
+
+/** Fetch a stored persona's text from Firestore, or null if it does not exist. */
+export async function getStoredPersona(
+  experimentId: string,
+  slotKey: string,
+): Promise<string | null> {
+  const ref = getStoredPersonaRef(experimentId, slotKey);
+  const doc = await ref.get();
+  if (!doc.exists) return null;
+
+  return (doc.data()?.text as string) ?? null;
+}
+
+/** Save a generated persona's text to Firestore for reuse across cohorts. */
+export async function saveStoredPersona(
+  experimentId: string,
+  slotKey: string,
+  text: string,
+): Promise<void> {
+  const ref = getStoredPersonaRef(experimentId, slotKey);
+  await ref.set({id: slotKey, text, createdAt: Timestamp.now()});
+}
+
+/** True for the turn-based chat variants (group chat with isTurnBased, or a
+ * group-style turn-based private chat). */
+function isTurnBasedStage(stage: StageConfig | null | undefined): boolean {
+  if (!stage) return false;
+  if (stage.kind === StageKind.CHAT) {
+    return (stage as ChatStageConfig).isTurnBased === true;
+  }
+  if (stage.kind === StageKind.PRIVATE_CHAT) {
+    return (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true;
+  }
+  return false;
+}
+
 /** Fetch active mediators for current cohort/stage. */
 export async function getFirestoreActiveMediators(
   experimentId: string,
   cohortId: string,
   stageId: string | null = null, // if null, can be in any stage
   checkIsAgent = false, // whether to check if participant is agent
+  stage: StageConfig | null = null, // stage config, for turn-based filtering
 ) {
+  // In turn-based stages, only mediators active for the stage respond. A
+  // cohort may hold several mediators (e.g. a swapped group-chat mediator
+  // alongside the default that runs the private chats); querying one with no
+  // prompt for the current stage would otherwise put a spurious "Error
+  // fetching response" in the chat and stall the turn cycle. Non-turn-based
+  // stages keep the existing behavior (no activeStageMap filtering), since a
+  // failed mediator response there does not block anyone.
+  const filterByActiveStage = stageId !== null && isTurnBasedStage(stage);
   const activeMediators = (
     await app
       .firestore()
@@ -123,7 +181,9 @@ export async function getFirestoreActiveMediators(
     .filter(
       (participant) =>
         participant.currentStatus === MediatorStatus.ACTIVE &&
-        (checkIsAgent ? participant.agentConfig : true),
+        (checkIsAgent ? participant.agentConfig : true) &&
+        (!filterByActiveStage ||
+          (participant.activeStageMap ?? {})[stageId as string]),
     );
   return activeMediators;
 }
@@ -134,6 +194,7 @@ export async function getFirestoreActiveParticipants(
   cohortId: string,
   stageId: string | null = null, // if null, can be in any stage
   checkIsAgent = false, // whether to check if participant is agent
+  includeObservers = false,
 ) {
   // TODO: Use isActiveParticipant utils function?
   const activeStatuses = [
@@ -157,7 +218,10 @@ export async function getFirestoreActiveParticipants(
 
   const activeParticipants = (await query.get()).docs
     .map((doc) => doc.data() as ParticipantProfileExtended)
-    .filter((participant) => (checkIsAgent ? participant.agentConfig : true));
+    .filter((participant) => {
+      if (participant.isObserver && !includeObservers) return false;
+      return checkIsAgent ? participant.agentConfig : true;
+    });
 
   return activeParticipants;
 }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -981,6 +981,7 @@ class ChatStageConfig(BaseModel):
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
     isTurnBased: bool | None = None
     personaPositionPrompt: str | None = None
+    additionalParticipantInstructions: str | None = None
 
 
 class RankingStageConfig(

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -979,6 +979,7 @@ class ChatStageConfig(BaseModel):
     timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
     isTurnBased: bool | None = None
+    personaPositionPrompt: str | None = None
 
 
 class RankingStageConfig(
@@ -1297,6 +1298,7 @@ class TransferStageConfig(BaseModel):
         | ConditionAutoTransferConfig
         | None
     ) = None
+    treatmentIndex: Annotated[int | None, Field(ge=0)] = None
 
 
 class ConditionAutoTransferConfig(BaseModel):
@@ -1356,6 +1358,7 @@ class ChatPromptConfig(BaseModel):
         | StageContextPromptItem
         | ChatMediatorInstructionsPromptItem
         | ChatParticipantInstructionsPromptItem
+        | OtherProfileContextsPromptItem
         | PromptItemGroup
     ]
     includeScaffoldingInPrompt: bool | None = None
@@ -1428,6 +1431,15 @@ class ChatParticipantInstructionsPromptItem(BaseModel):
     condition: ComparisonCondition | ConditionGroup | None = None
 
 
+class OtherProfileContextsPromptItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+    type: Literal["OTHER_PROFILE_CONTEXTS"] = "OTHER_PROFILE_CONTEXTS"
+    condition: ComparisonCondition | ConditionGroup | None = None
+
+
 class PromptItemGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1442,6 +1454,7 @@ class PromptItemGroup(BaseModel):
         | StageContextPromptItem
         | ChatMediatorInstructionsPromptItem
         | ChatParticipantInstructionsPromptItem
+        | OtherProfileContextsPromptItem
         | PromptItemGroup
     ]
     shuffleConfig: ShuffleConfig | None = None
@@ -1509,6 +1522,7 @@ class GenericPromptConfig(BaseModel):
         | StageContextPromptItem
         | ChatMediatorInstructionsPromptItem
         | ChatParticipantInstructionsPromptItem
+        | OtherProfileContextsPromptItem
         | PromptItemGroup
     ]
     includeScaffoldingInPrompt: bool | None = None

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -756,6 +756,8 @@ class AgentChatSettings(BaseModel):
     minMessagesBeforeResponding: int
     canSelfTriggerCalls: bool
     maxResponses: int | None = None
+    maxNumberOfMessages: Annotated[int | None, Field(ge=1)] = None
+    minNumberOfMessages: Annotated[int | None, Field(ge=0)] = None
     initialMessage: str
 
 
@@ -982,6 +984,8 @@ class ChatStageConfig(BaseModel):
     isTurnBased: bool | None = None
     personaPositionPrompt: str | None = None
     additionalParticipantInstructions: str | None = None
+    minNumberOfMessages: Annotated[int | None, Field(ge=0)] = None
+    maxNumberOfMessages: Annotated[int | None, Field(ge=1)] = None
 
 
 class RankingStageConfig(

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -357,6 +357,7 @@ class PrivateChatStageConfig(BaseModel):
     timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
     timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     isTurnBasedChat: bool | None = None
+    isTurnBasedChatGroupStyle: bool | None = None
     minNumberOfTurns: float | None = None
     maxNumberOfTurns: float | None = None
     preventCancellation: bool | None = None

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -110,6 +110,14 @@ export interface AgentChatSettings {
   // Maximum total responses agent can make during the chat conversation
   // (or null if no max)
   maxResponses: number | null;
+  // Per-mediator max-messages override for group chats. Replaces the stage's
+  // maxNumberOfMessages while this mediator is active; the smallest override
+  // wins. Set to null to defer to the stage value.
+  maxNumberOfMessages: number | null;
+  // Per-mediator min-messages override for group chats. Replaces the stage's
+  // minNumberOfMessages while this mediator is active; the largest override
+  // wins. Set to null to defer to the stage value.
+  minNumberOfMessages: number | null;
   // Initial message to send when the conversation begins
   initialMessage: string;
 }
@@ -221,6 +229,8 @@ export function createAgentChatSettings(
     minMessagesBeforeResponding: config.minMessagesBeforeResponding ?? 0,
     canSelfTriggerCalls: config.canSelfTriggerCalls ?? false,
     maxResponses: config.maxResponses ?? 100,
+    maxNumberOfMessages: config.maxNumberOfMessages ?? null,
+    minNumberOfMessages: config.minNumberOfMessages ?? null,
     initialMessage: config.initialMessage ?? '',
   };
 }

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -36,6 +36,17 @@ export interface ProfileAgentConfig {
   // takes a turn, and is not counted when deciding whether a cohort can unlock
   // or advance a stage.
   isInactivePersona?: boolean;
+  // Persona bank match key: SHA-256 of the round's canonical variable map. Set
+  // on representative and inactive personas so they retrieve a pre-generated
+  // persona from the bank instead of generating a fresh one. Unset for agents
+  // that use slot-based reuse or fresh generation.
+  personaHash?: string;
+  // Set on direct-participation agents: the private ID of the HUMAN this agent
+  // was spawned alongside. The persona-generation trigger claims a plain
+  // character sketch from the bank keyed to this human (so the human never gets
+  // the same persona twice across rounds) and uses it as the agent's own
+  // persona instead of generating one live.
+  personaSketchForHumanId?: string;
 }
 
 /** Reasoning level - mapped to provider-specific options by backend */

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -26,6 +26,16 @@ export interface ProfileAgentConfig {
   agentId: string; // ID of agent persona used
   promptContext: string; // Additional text to concatenate to agent prompts
   modelSettings: AgentModelSettings;
+  needsPersonaGeneration?: boolean;
+  // Stable key used to store/retrieve this agent's generated persona so it is
+  // reused across cohorts. Unset for agents that should not reuse a stored
+  // persona (e.g. representatives).
+  personaSlotKey?: string;
+  // If true, this agent exists only to supply persona context to other agents'
+  // prompts (via OTHER_PROFILE_CONTEXTS). It never posts chat messages, never
+  // takes a turn, and is not counted when deciding whether a cohort can unlock
+  // or advance a stage.
+  isInactivePersona?: boolean;
 }
 
 /** Reasoning level - mapped to provider-specific options by backend */

--- a/utils/src/agent_persona_generation.ts
+++ b/utils/src/agent_persona_generation.ts
@@ -99,9 +99,17 @@ function buildDimensionsList(verbosity: number): string {
  */
 export function buildGeneratePersonaPrompt(
   params: PersonaGenerationParams,
+  // Optional question to elicit the persona's position, appended after the
+  // sketch in the same generation (persona first, then position).
+  positionPrompt?: string,
 ): string {
   const birthDecade =
     Math.floor((new Date().getFullYear() - params.age) / 10) * 10 + 's';
+
+  const closingInstruction =
+    positionPrompt && positionPrompt.trim()
+      ? `First write the character sketch, starting directly with "You are" (250-300 words). Then add a blank line and, speaking in this person's own voice and consistent with the persona above, state their position on the following in 1-2 paragraphs:\n\n${positionPrompt}\n\nOutput only the character sketch followed by their position, with no preamble, labels, or meta-commentary.`
+      : `Write ONLY the character sketch text, starting directly with "You are". No preamble, no labels, no meta-commentary.`;
 
   return `You are helping configure an AI research agent that will simulate a real human participant in an online study.
 
@@ -140,7 +148,7 @@ Aim for 250–300 words. ${ACT_INSTRUCTION}
 
 CRITICAL: Your character must strictly adhere to the parameters above. Make the blind spots and internal contradiction feel genuinely specific to this person — not generic. Each sketch you write should feel completely unlike the last.
 
-Write ONLY the character sketch text, starting directly with "You are". No preamble, no labels, no meta-commentary.`;
+${closingInstruction}`;
 }
 
 /**

--- a/utils/src/data.ts
+++ b/utils/src/data.ts
@@ -11,7 +11,7 @@ import {
 import {AlertMessage} from './alert';
 import {CohortConfig} from './cohort';
 import {Experiment} from './experiment';
-import {ParticipantProfileExtended} from './participant';
+import {ParticipantProfileExtended, ParticipantThought} from './participant';
 import {ChatMessage} from './chat_message';
 import {
   StageConfig,
@@ -54,6 +54,8 @@ export interface ParticipantDownload {
   profile: ParticipantProfileExtended;
   // Maps from stage ID to participant's stage answer
   answerMap: Record<string, StageParticipantAnswer>;
+  // Maps from stage ID to list of participant's thoughts in that stage
+  thoughtMap: Record<string, ParticipantThought[]>;
 }
 
 export interface CohortDownload {
@@ -86,6 +88,7 @@ export function createParticipantDownload(
   return {
     profile,
     answerMap: {},
+    thoughtMap: {},
   };
 }
 

--- a/utils/src/data.ts
+++ b/utils/src/data.ts
@@ -56,6 +56,10 @@ export interface ParticipantDownload {
   answerMap: Record<string, StageParticipantAnswer>;
   // Maps from stage ID to list of participant's thoughts in that stage
   thoughtMap: Record<string, ParticipantThought[]>;
+  // Maps from stage ID to the participant's private-chat (e.g. interview)
+  // messages in that stage, ordered chronologically. Private chats live in a
+  // per-participant subcollection and were previously absent from the download.
+  privateChatMap: Record<string, ChatMessage[]>;
 }
 
 export interface CohortDownload {
@@ -89,6 +93,7 @@ export function createParticipantDownload(
     profile,
     answerMap: {},
     thoughtMap: {},
+    privateChatMap: {},
   };
 }
 

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -58,6 +58,15 @@ export interface ParticipantProfile extends UserProfileBase {
   timestamps: ProgressTimestamps;
   anonymousProfiles: Record<string, AnonymousProfileMetadata>;
   connected: boolean | null;
+  isObserver?: boolean; // Read-only observer participant type
+  hasRepresentative?: boolean; // Whether the observer has a representative agent spawned
+  otherAgentGeneration?: {
+    numOtherAgents: number;
+    // Number of inactive personas to spawn alongside numOtherAgents.
+    // These generate a persona for prompt context but do not chat or take turns.
+    numInactivePersonas?: number;
+  };
+  swapMediator?: string; // Name or ID of mediator to swap to when entering a group chat
   // Maps variable name to value assigned specifically for this participant
   // This overrides any variable values set at the cohort/experiment levels.
   variableMap?: Record<string, string>;
@@ -161,6 +170,20 @@ export function createParticipantProfileBase(
   };
 }
 
+/**
+ * Display profile (name + avatar) for an observer's AI representative.
+ * The avatar defaults to a robot.
+ */
+export function getRepresentativeProfile(
+  observerName: string,
+  avatar = '🤖',
+): {
+  name: string;
+  avatar: string;
+} {
+  return {name: `${observerName}'s Agent (yours)`, avatar};
+}
+
 /** Create private participant config. */
 export function createParticipantProfileExtended(
   config: Partial<ParticipantProfileExtended> = {},
@@ -181,6 +204,12 @@ export function createParticipantProfileExtended(
     anonymousProfiles: {},
     connected: config.agentConfig ? true : false,
     agentConfig: config.agentConfig ?? null,
+    isObserver: config.isObserver ?? false,
+    hasRepresentative: config.hasRepresentative ?? false,
+    otherAgentGeneration: config.otherAgentGeneration ?? {
+      numOtherAgents: 0,
+    },
+    swapMediator: config.swapMediator ?? '',
     variableMap: config.variableMap ?? {},
   };
 }
@@ -191,6 +220,7 @@ export function setProfile(
   config: ParticipantProfileExtended,
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
+  excludeColor?: string,
 ) {
   const generateProfileFromSet = (
     profileSet: {name: string; avatar: string}[],
@@ -245,7 +275,11 @@ export function setProfile(
 
   // Define public ID (using anonymous animal 1 set)
   const mainProfile = profileAnimal1;
-  const color = COLORS[Math.floor(Math.random() * COLORS.length)];
+  const colorPool =
+    excludeColor && COLORS.length > 1
+      ? COLORS.filter((c) => c.toLowerCase() !== excludeColor.toLowerCase())
+      : COLORS;
+  const color = colorPool[Math.floor(Math.random() * colorPool.length)];
 
   config.publicId =
     `${mainProfile.name}-${color}-${randomNumber}`.toLowerCase();

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -131,6 +131,10 @@ export enum ParticipantStatus {
 // ************************************************************************* //
 // CONSTANTS                                                                 //
 // ************************************************************************* //
+// Reserved for mediators when an experiment assigns observers; participant
+// profiles must never be generated with it in those experiments.
+export const MEDIATOR_OBSERVER_COLOR = 'blue';
+
 export const COLORS: string[] = [
   'Red',
   'Orange',
@@ -220,7 +224,7 @@ export function setProfile(
   config: ParticipantProfileExtended,
   setAnonymousProfile = false,
   profileType: ProfileType = ProfileType.ANONYMOUS_ANIMAL,
-  excludeColor?: string,
+  excludeColor?: string | string[],
 ) {
   const generateProfileFromSet = (
     profileSet: {name: string; avatar: string}[],
@@ -275,10 +279,17 @@ export function setProfile(
 
   // Define public ID (using anonymous animal 1 set)
   const mainProfile = profileAnimal1;
-  const colorPool =
-    excludeColor && COLORS.length > 1
-      ? COLORS.filter((c) => c.toLowerCase() !== excludeColor.toLowerCase())
-      : COLORS;
+  const excludedColors = (
+    Array.isArray(excludeColor)
+      ? excludeColor
+      : excludeColor
+        ? [excludeColor]
+        : []
+  ).map((c) => c.toLowerCase());
+  const filteredPool = COLORS.filter(
+    (c) => !excludedColors.includes(c.toLowerCase()),
+  );
+  const colorPool = filteredPool.length > 0 ? filteredPool : COLORS;
   const color = colorPool[Math.floor(Math.random() * colorPool.length)];
 
   config.publicId =

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -60,6 +60,7 @@ export interface ParticipantProfile extends UserProfileBase {
   connected: boolean | null;
   isObserver?: boolean; // Read-only observer participant type
   hasRepresentative?: boolean; // Whether the observer has a representative agent spawned
+  isQuizzed?: boolean; // Whether this round's treatment includes the periodic group-chat quiz (hoisted from _isQuizzed at the transfer)
   otherAgentGeneration?: {
     numOtherAgents: number;
     // Number of inactive personas to spawn alongside numOtherAgents.
@@ -77,6 +78,13 @@ export interface AnonymousProfileMetadata {
   name: string;
   repeat: number; // e.g., if 1, then profile is Cat 2; if 2, then Cat 3
   avatar: string;
+}
+
+/** Participant observation thought structure. */
+export interface ParticipantThought {
+  id: string;
+  text: string;
+  timestamp: UnifiedTimestamp;
 }
 
 /** Participant profile available in private participants collection. */
@@ -210,6 +218,7 @@ export function createParticipantProfileExtended(
     agentConfig: config.agentConfig ?? null,
     isObserver: config.isObserver ?? false,
     hasRepresentative: config.hasRepresentative ?? false,
+    isQuizzed: config.isQuizzed ?? false,
     otherAgentGeneration: config.otherAgentGeneration ?? {
       numOtherAgents: 0,
     },

--- a/utils/src/participant.validation.ts
+++ b/utils/src/participant.validation.ts
@@ -148,9 +148,19 @@ export const CreateParticipantData = Type.Object(
           apiType: Type.String(),
           modelName: Type.String(),
         }),
+        personaSlotKey: Type.Optional(Type.String()),
       }),
     ),
     prolificId: Type.Optional(Type.Union([Type.Null(), Type.String()])),
+    isObserver: Type.Optional(Type.Boolean()),
+    hasRepresentative: Type.Optional(Type.Boolean()),
+    otherAgentGeneration: Type.Optional(
+      Type.Object({
+        numOtherAgents: Type.Number(),
+        numInactivePersonas: Type.Optional(Type.Number()),
+      }),
+    ),
+    swapMediator: Type.Optional(Type.String()),
   },
   strict,
 );

--- a/utils/src/participant.validation.ts
+++ b/utils/src/participant.validation.ts
@@ -155,6 +155,7 @@ export const CreateParticipantData = Type.Object(
     prolificId: Type.Optional(Type.Union([Type.Null(), Type.String()])),
     isObserver: Type.Optional(Type.Boolean()),
     hasRepresentative: Type.Optional(Type.Boolean()),
+    isQuizzed: Type.Optional(Type.Boolean()),
     otherAgentGeneration: Type.Optional(
       Type.Object({
         numOtherAgents: Type.Number(),
@@ -221,3 +222,27 @@ export const AnonymousProfileSchema = Type.Object({
   repeat: Type.Number(),
   avatar: Type.String(),
 });
+
+// ************************************************************************* //
+// submitParticipantThought endpoint for participants                        //
+// ************************************************************************* //
+export const SubmitParticipantThoughtData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    participantId: Type.String({minLength: 1}),
+    stageId: Type.String({minLength: 1}),
+    text: Type.String({minLength: 1}),
+    // Quiz checkpoint being answered. When set (and the participant is
+    // quizzed), submitting clears the chat's quizPauseCheckpoint and resumes
+    // the paused group chat turn.
+    checkpoint: Type.Optional(Type.Number()),
+    // Quiz Likert rating (1-7), saved as a structured field alongside the
+    // free-text thought (not embedded in the text).
+    rating: Type.Optional(Type.Number()),
+  },
+  strict,
+);
+
+export type SubmitParticipantThoughtData = Static<
+  typeof SubmitParticipantThoughtData
+>;

--- a/utils/src/participant.validation.ts
+++ b/utils/src/participant.validation.ts
@@ -149,6 +149,7 @@ export const CreateParticipantData = Type.Object(
           modelName: Type.String(),
         }),
         personaSlotKey: Type.Optional(Type.String()),
+        personaHash: Type.Optional(Type.String()),
       }),
     ),
     prolificId: Type.Optional(Type.Union([Type.Null(), Type.String()])),

--- a/utils/src/prompt.validation.ts
+++ b/utils/src/prompt.validation.ts
@@ -32,6 +32,7 @@ export const PromptItemTypeData = Type.Union(
     Type.Literal('GROUP'),
     Type.Literal('CHAT_MEDIATOR_INSTRUCTIONS'),
     Type.Literal('CHAT_PARTICIPANT_INSTRUCTIONS'),
+    Type.Literal('OTHER_PROFILE_CONTEXTS'),
   ],
   {$id: 'PromptItemType'},
 );
@@ -106,6 +107,15 @@ export const ChatParticipantInstructionsPromptItemData = Type.Object(
   {$id: 'ChatParticipantInstructionsPromptItem', ...strict},
 );
 
+/** Other agents' persona contexts prompt item */
+export const OtherProfileContextsPromptItemData = Type.Object(
+  {
+    type: Type.Literal('OTHER_PROFILE_CONTEXTS'),
+    ...BasePromptItemFields,
+  },
+  {$id: 'OtherProfileContextsPromptItem', ...strict},
+);
+
 /** Prompt item group (recursive).
  * Uses Type.Recursive to properly handle nested groups in items array.
  */
@@ -123,6 +133,7 @@ export const PromptItemGroupData = Type.Recursive(
             StageContextPromptItemData,
             ChatMediatorInstructionsPromptItemData,
             ChatParticipantInstructionsPromptItemData,
+            OtherProfileContextsPromptItemData,
             This,
           ]),
         ),
@@ -142,6 +153,7 @@ export const PromptItemData = Type.Union([
   StageContextPromptItemData,
   ChatMediatorInstructionsPromptItemData,
   ChatParticipantInstructionsPromptItemData,
+  OtherProfileContextsPromptItemData,
   PromptItemGroupData,
 ]);
 

--- a/utils/src/prompt.validation.ts
+++ b/utils/src/prompt.validation.ts
@@ -168,6 +168,12 @@ export const AgentChatSettingsData = Type.Object(
     minMessagesBeforeResponding: Type.Integer(),
     canSelfTriggerCalls: Type.Boolean(),
     maxResponses: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+    maxNumberOfMessages: Type.Optional(
+      Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+    ),
+    minNumberOfMessages: Type.Optional(
+      Type.Union([Type.Integer({minimum: 0}), Type.Null()]),
+    ),
     initialMessage: Type.String(),
   },
   {$id: 'AgentChatSettings', ...strict},

--- a/utils/src/stages/chat_stage.manager.ts
+++ b/utils/src/stages/chat_stage.manager.ts
@@ -54,16 +54,18 @@ export class GroupChatStageHandler extends BaseStageHandler {
       }
       return '';
     };
-    // Get participant names (from all active participants)
-    const participantNames = stageContext.participants.map((participant) =>
-      getNameFromPublicId(
-        [participant],
-        participant.publicId,
-        getProfileSetId(),
-        true,
-        true,
-      ),
-    );
+    // Get participant names (exclude observers)
+    const participantNames = stageContext.participants
+      .filter((participant) => !participant.isObserver)
+      .map((participant) =>
+        getNameFromPublicId(
+          [participant],
+          participant.publicId,
+          getProfileSetId(),
+          true,
+          true,
+        ),
+      );
 
     const users = `Participants in chat: ${participantNames.join(', ')}`;
     const history = getChatPromptMessageHistory(messages, stage);

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -71,6 +71,19 @@ First, react: read the last 1-2 messages and ask yourself how this specific pers
 
 ${DEFAULT_AGENT_PARTICIPANT_CHAT_STYLE_INSTRUCTIONS}`;
 
+/**
+ * One-line round/cycle status appended to a turn-based agent's chat prompt (for
+ * both participants and mediators) so they know which cycle they are in and how
+ * many remain before the discussion ends. See `getTurnCycleInfo` for how the
+ * numbers are derived.
+ */
+export function getTurnCycleStatusForPrompt(
+  currentCycle: number,
+  totalCycles: number,
+): string {
+  return `This is cycle ${currentCycle} of ${totalCycles} cycles, where each participant speaks once per cycle. The discussion ends after cycle ${totalCycles}, so pace your contribution accordingly.`;
+}
+
 /** Hardcoded text used in stage display of chat transcript. */
 export const CHAT_PROMPT_TRANSCRIPT_EXPLANATION = `Below is the transcript of your discussion. Messages are shown in chronological order; new messages appear at the bottom. Each message / turn follows the format: (HH:MM) Name: message.`;
 

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -71,19 +71,6 @@ First, react: read the last 1-2 messages and ask yourself how this specific pers
 
 ${DEFAULT_AGENT_PARTICIPANT_CHAT_STYLE_INSTRUCTIONS}`;
 
-/**
- * One-line round/cycle status appended to a turn-based agent's chat prompt (for
- * both participants and mediators) so they know which cycle they are in and how
- * many remain before the discussion ends. See `getTurnCycleInfo` for how the
- * numbers are derived.
- */
-export function getTurnCycleStatusForPrompt(
-  currentCycle: number,
-  totalCycles: number,
-): string {
-  return `This is cycle ${currentCycle} of ${totalCycles} cycles, where each participant speaks once per cycle. The discussion ends after cycle ${totalCycles}, so pace your contribution accordingly.`;
-}
-
 /** Hardcoded text used in stage display of chat transcript. */
 export const CHAT_PROMPT_TRANSCRIPT_EXPLANATION = `Below is the transcript of your discussion. Messages are shown in chronological order; new messages appear at the bottom. Each message / turn follows the format: (HH:MM) Name: message.`;
 

--- a/utils/src/stages/chat_stage.prompts.ts
+++ b/utils/src/stages/chat_stage.prompts.ts
@@ -71,6 +71,45 @@ First, react: read the last 1-2 messages and ask yourself how this specific pers
 
 ${DEFAULT_AGENT_PARTICIPANT_CHAT_STYLE_INSTRUCTIONS}`;
 
+/**
+ * Placeholder an experimenter can put anywhere in prompt text (text items or
+ * additionalParticipantInstructions) to show a turn-based agent the cycle
+ * status. Substituted when the prompt is assembled; outside a turn-based
+ * group chat with a message cap it renders as empty text.
+ */
+export const TURN_CYCLE_STATUS_PLACEHOLDER = '{{_turnCycleStatus}}';
+
+/**
+ * One-line round/cycle status for a turn-based agent's chat prompt (for both
+ * participants and mediators) so they know which cycle they are in and how
+ * many remain before the discussion ends. See `getTurnCycleInfo` for how the
+ * numbers are derived.
+ */
+export function getTurnCycleStatusForPrompt(
+  currentCycle: number,
+  totalCycles: number,
+): string {
+  return `This is cycle ${currentCycle} of ${totalCycles} cycles, where each participant speaks once per cycle. The discussion ends after cycle ${totalCycles}, so pace your contribution accordingly.`;
+}
+
+/** With no cycle info, the placeholder and one adjacent blank line collapse. */
+export function substituteTurnCycleStatus(
+  text: string,
+  cycleInfo: {currentCycle: number; totalCycles: number} | null,
+): string {
+  if (!text.includes(TURN_CYCLE_STATUS_PLACEHOLDER)) return text;
+  if (!cycleInfo) {
+    return text
+      .replaceAll(`${TURN_CYCLE_STATUS_PLACEHOLDER}\n\n`, '')
+      .replaceAll(`\n\n${TURN_CYCLE_STATUS_PLACEHOLDER}`, '\n')
+      .replaceAll(TURN_CYCLE_STATUS_PLACEHOLDER, '');
+  }
+  return text.replaceAll(
+    TURN_CYCLE_STATUS_PLACEHOLDER,
+    getTurnCycleStatusForPrompt(cycleInfo.currentCycle, cycleInfo.totalCycles),
+  );
+}
+
 /** Hardcoded text used in stage display of chat transcript. */
 export const CHAT_PROMPT_TRANSCRIPT_EXPLANATION = `Below is the transcript of your discussion. Messages are shown in chronological order; new messages appear at the bottom. Each message / turn follows the format: (HH:MM) Name: message.`;
 

--- a/utils/src/stages/chat_stage.test.ts
+++ b/utils/src/stages/chat_stage.test.ts
@@ -1,0 +1,58 @@
+import {
+  ChatStageConfig,
+  ChatStagePublicData,
+  getTurnCycleInfo,
+} from './chat_stage';
+
+describe('getTurnCycleInfo', () => {
+  const stage = (
+    maxNumberOfMessages: number | null,
+    isTurnBased = true,
+  ): ChatStageConfig => ({isTurnBased, maxNumberOfMessages}) as ChatStageConfig;
+
+  const publicData = (
+    overrides: Partial<ChatStagePublicData> = {},
+  ): ChatStagePublicData =>
+    ({
+      turnOrder: ['a', 'b', 'c'],
+      cycleIndex: 0,
+      ...overrides,
+    }) as ChatStagePublicData;
+
+  it('computes current/total cycles from cap and turn-order length', () => {
+    // 3 speakers per cycle, cap 9 => 3 cycles.
+    expect(getTurnCycleInfo(publicData({cycleIndex: 0}), stage(9))).toEqual({
+      currentCycle: 1,
+      totalCycles: 3,
+    });
+    expect(getTurnCycleInfo(publicData({cycleIndex: 2}), stage(9))).toEqual({
+      currentCycle: 3,
+      totalCycles: 3,
+    });
+  });
+
+  it('rounds total cycles up when the cap is not a clean multiple', () => {
+    // 3 speakers, cap 19 => ceil(19 / 3) = 7 cycles.
+    expect(getTurnCycleInfo(publicData(), stage(19))?.totalCycles).toBe(7);
+  });
+
+  it('clamps the current cycle to the total', () => {
+    expect(
+      getTurnCycleInfo(publicData({cycleIndex: 99}), stage(9))?.currentCycle,
+    ).toBe(3);
+  });
+
+  it('prefers effectiveMaxNumberOfMessages over the stage value', () => {
+    expect(
+      getTurnCycleInfo(publicData({effectiveMaxNumberOfMessages: 6}), stage(9))
+        ?.totalCycles,
+    ).toBe(2);
+  });
+
+  it('returns null when not turn-based, uncapped, or turn order is empty', () => {
+    expect(getTurnCycleInfo(publicData(), stage(9, false))).toBeNull();
+    expect(getTurnCycleInfo(publicData(), stage(null))).toBeNull();
+    expect(getTurnCycleInfo(publicData({turnOrder: []}), stage(9))).toBeNull();
+    expect(getTurnCycleInfo(undefined, stage(9))).toBeNull();
+  });
+});

--- a/utils/src/stages/chat_stage.test.ts
+++ b/utils/src/stages/chat_stage.test.ts
@@ -3,6 +3,11 @@ import {
   ChatStagePublicData,
   getTurnCycleInfo,
 } from './chat_stage';
+import {
+  TURN_CYCLE_STATUS_PLACEHOLDER,
+  getTurnCycleStatusForPrompt,
+  substituteTurnCycleStatus,
+} from './chat_stage.prompts';
 
 describe('getTurnCycleInfo', () => {
   const stage = (
@@ -54,5 +59,39 @@ describe('getTurnCycleInfo', () => {
     expect(getTurnCycleInfo(publicData(), stage(null))).toBeNull();
     expect(getTurnCycleInfo(publicData({turnOrder: []}), stage(9))).toBeNull();
     expect(getTurnCycleInfo(undefined, stage(9))).toBeNull();
+  });
+});
+
+describe('substituteTurnCycleStatus', () => {
+  const info = {currentCycle: 2, totalCycles: 4};
+
+  it('replaces the placeholder with the cycle status line', () => {
+    expect(
+      substituteTurnCycleStatus(
+        `Before.\n\n${TURN_CYCLE_STATUS_PLACEHOLDER}\n\nAfter.`,
+        info,
+      ),
+    ).toBe(`Before.\n\n${getTurnCycleStatusForPrompt(2, 4)}\n\nAfter.`);
+  });
+
+  it('collapses the placeholder and one adjacent blank line without info', () => {
+    expect(
+      substituteTurnCycleStatus(
+        `Before.\n\n${TURN_CYCLE_STATUS_PLACEHOLDER}\n\nAfter.`,
+        null,
+      ),
+    ).toBe('Before.\n\nAfter.');
+    expect(
+      substituteTurnCycleStatus(
+        `Line.\n\n${TURN_CYCLE_STATUS_PLACEHOLDER}`,
+        null,
+      ),
+    ).toBe('Line.\n');
+  });
+
+  it('leaves text without the placeholder untouched', () => {
+    expect(substituteTurnCycleStatus('No placeholder here.', info)).toBe(
+      'No placeholder here.',
+    );
   });
 });

--- a/utils/src/stages/chat_stage.test.ts
+++ b/utils/src/stages/chat_stage.test.ts
@@ -36,6 +36,25 @@ describe('getTurnCycleInfo', () => {
     });
   });
 
+  it('counts only the places that can still be spoken from', () => {
+    // 'b' has left, so a cycle is two speakers, not three: cap 9 over two
+    // speakers is five cycles, where counting b's kept place would say three.
+    expect(
+      getTurnCycleInfo(publicData({cycleIndex: 0}), stage(9), ['a', 'c']),
+    ).toEqual({currentCycle: 1, totalCycles: 5});
+  });
+
+  it('counts every place when the caller does not say who is there', () => {
+    expect(getTurnCycleInfo(publicData(), stage(9))?.totalCycles).toBe(3);
+  });
+
+  it('ignores speakers who hold no place in the order', () => {
+    expect(
+      getTurnCycleInfo(publicData(), stage(9), ['a', 'b', 'c', 'd'])
+        ?.totalCycles,
+    ).toBe(3);
+  });
+
   it('rounds total cycles up when the cap is not a clean multiple', () => {
     // 3 speakers, cap 19 => ceil(19 / 3) = 7 cycles.
     expect(getTurnCycleInfo(publicData(), stage(19))?.totalCycles).toBe(7);

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -111,6 +111,10 @@ export interface ChatStagePublicData extends BaseStagePublicData {
   currentTurnParticipantId?: string | null; // ID of the participant whose turn it is
   turnOrder?: string[]; // Array of participant IDs defining the turn order
   cycleIndex?: number; // Counter to track turn cycles for seeded random
+  // Id of the last chat message the turn logic processed. The holder shown in
+  // this data is current only when this matches the newest participant or
+  // mediator message.
+  turnProcessedMessageId?: string;
   // Effective cohort-total minimum messages after applying any active
   // mediator's per-stage override (group chat only). Resolved by the backend;
   // the frontend advance-gate falls back to the stage value when null.
@@ -228,6 +232,7 @@ export function createChatStagePublicData(
     currentTurnParticipantId: null,
     turnOrder: [],
     cycleIndex: 0,
+    turnProcessedMessageId: '',
     effectiveMinNumberOfMessages: null,
     effectiveMaxNumberOfMessages: null,
   };

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -34,6 +34,12 @@ export interface ChatStageConfig extends BaseStageConfig {
   // Extra instructions appended to spawned agent-participants' chat prompt for
   // this stage (shapes how they engage, e.g. push for changes). Unset = none.
   additionalParticipantInstructions?: string;
+  // Minimum total messages from all participants/mediators combined before
+  // a participant is eligible to advance. 0 = no minimum.
+  minNumberOfMessages?: number;
+  // Maximum total messages from all participants/mediators combined; the
+  // discussion ends globally for the whole cohort once reached. null = no cap.
+  maxNumberOfMessages?: number | null;
 }
 
 /** Chat discussion. */
@@ -105,11 +111,46 @@ export interface ChatStagePublicData extends BaseStagePublicData {
   currentTurnParticipantId?: string | null; // ID of the participant whose turn it is
   turnOrder?: string[]; // Array of participant IDs defining the turn order
   cycleIndex?: number; // Counter to track turn cycles for seeded random
+  // Effective cohort-total minimum messages after applying any active
+  // mediator's per-stage override (group chat only). Resolved by the backend;
+  // the frontend advance-gate falls back to the stage value when null.
+  effectiveMinNumberOfMessages?: number | null;
+  // Effective cohort-total maximum messages after applying any active
+  // mediator's per-stage override (group chat only). Resolved by the backend;
+  // the frontend's conversation-over / banner logic falls back to the stage
+  // value when null. Published so the frontend uses the cap the backend
+  // actually enforces (an override replaces the stage value), rather than
+  // tripping early at the stage value and hiding the banner / appearing to
+  // run past the limit.
+  effectiveMaxNumberOfMessages?: number | null;
 }
 
 // ************************************************************************* //
 // FUNCTIONS                                                                 //
 // ************************************************************************* //
+
+/**
+ * For a turn-based group chat with a message cap, compute the current cycle and
+ * the total number of cycles. A "cycle" is one full pass through the turn order
+ * (every participant and any mediator in the rotation takes one turn), as
+ * tracked by `cycleIndex`. Returns null when the stage isn't turn-based, has no
+ * message cap, or the turn order hasn't been established yet, so callers can
+ * choose not to show a cycle indicator.
+ */
+export function getTurnCycleInfo(
+  publicData: ChatStagePublicData | undefined | null,
+  stage: ChatStageConfig,
+): {currentCycle: number; totalCycles: number} | null {
+  if (!stage.isTurnBased) return null;
+  const max =
+    publicData?.effectiveMaxNumberOfMessages ?? stage.maxNumberOfMessages;
+  if (max === null || max === undefined || max <= 0) return null;
+  const speakersPerCycle = (publicData?.turnOrder ?? []).length;
+  if (speakersPerCycle <= 0) return null;
+  const totalCycles = Math.ceil(max / speakersPerCycle);
+  const currentCycle = Math.min((publicData?.cycleIndex ?? 0) + 1, totalCycles);
+  return {currentCycle, totalCycles};
+}
 
 /** Create chat stage. */
 export function createChatStage(
@@ -130,6 +171,8 @@ export function createChatStage(
     personaPositionPrompt: config.personaPositionPrompt ?? '',
     additionalParticipantInstructions:
       config.additionalParticipantInstructions ?? '',
+    minNumberOfMessages: config.minNumberOfMessages ?? 0,
+    maxNumberOfMessages: config.maxNumberOfMessages ?? null,
   };
 }
 
@@ -185,5 +228,7 @@ export function createChatStagePublicData(
     currentTurnParticipantId: null,
     turnOrder: [],
     cycleIndex: 0,
+    effectiveMinNumberOfMessages: null,
+    effectiveMaxNumberOfMessages: null,
   };
 }

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -115,6 +115,16 @@ export interface ChatStagePublicData extends BaseStagePublicData {
   // this data is current only when this matches the newest participant or
   // mediator message.
   turnProcessedMessageId?: string;
+  // Quiz pause checkpoint. When > 0 the group chat is paused at an
+  // intermediate message-count checkpoint while the quizzed participant
+  // answers the quiz; the next agent turn is gated until they submit, which
+  // resets this to 0. 0 = not paused. See getQuizPauseCheckpointForCount.
+  quizPauseCheckpoint?: number;
+  // Highest quiz checkpoint the participant has already answered (monotonic).
+  // The backend pauses only when a newly crossed checkpoint exceeds this, so
+  // the chat is not re-paused for a checkpoint already answered after the
+  // pause clears.
+  quizAnsweredCheckpoint?: number;
   // Effective cohort-total minimum messages after applying any active
   // mediator's per-stage override (group chat only). Resolved by the backend;
   // the frontend advance-gate falls back to the stage value when null.
@@ -233,7 +243,31 @@ export function createChatStagePublicData(
     turnOrder: [],
     cycleIndex: 0,
     turnProcessedMessageId: '',
+    quizPauseCheckpoint: 0,
+    quizAnsweredCheckpoint: 0,
     effectiveMinNumberOfMessages: null,
     effectiveMaxNumberOfMessages: null,
   };
+}
+
+/**
+ * Quiz pause checkpoints: thirds of the effective minimum message count
+ * (ceil(min/3), ceil(2*min/3), and min, deduplicated and at least 1). Ceiling,
+ * so a quiz never fires before its third of the conversation has completed.
+ * Returns how many checkpoints the running non-system count has reached, so a
+ * minimum under 3 yields fewer than 3 quizzes and no minimum yields none.
+ */
+export function getQuizPauseCheckpointForCount(
+  nonSystemCount: number,
+  effectiveMin?: number | null,
+): number {
+  if (effectiveMin == null || effectiveMin <= 0) return 0;
+  const thresholds = [
+    ...new Set([
+      Math.ceil(effectiveMin / 3),
+      Math.ceil((2 * effectiveMin) / 3),
+      effectiveMin,
+    ]),
+  ].filter((t) => t >= 1);
+  return thresholds.filter((t) => nonSystemCount >= t).length;
 }

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -27,6 +27,10 @@ export interface ChatStageConfig extends BaseStageConfig {
   timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
   timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
   isTurnBased?: boolean; // Whether the conversation is turn-based
+  // When agents are spawned into this stage with generated personas, this
+  // optional prompt elicits each persona's position (appended after the
+  // persona text in a single generation). Empty/unset = persona only.
+  personaPositionPrompt?: string;
 }
 
 /** Chat discussion. */
@@ -120,6 +124,7 @@ export function createChatStage(
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
     timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
     isTurnBased: config.isTurnBased ?? false,
+    personaPositionPrompt: config.personaPositionPrompt ?? '',
   };
 }
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -31,6 +31,9 @@ export interface ChatStageConfig extends BaseStageConfig {
   // optional prompt elicits each persona's position (appended after the
   // persona text in a single generation). Empty/unset = persona only.
   personaPositionPrompt?: string;
+  // Extra instructions appended to spawned agent-participants' chat prompt for
+  // this stage (shapes how they engage, e.g. push for changes). Unset = none.
+  additionalParticipantInstructions?: string;
 }
 
 /** Chat discussion. */
@@ -125,6 +128,8 @@ export function createChatStage(
     timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
     isTurnBased: config.isTurnBased ?? false,
     personaPositionPrompt: config.personaPositionPrompt ?? '',
+    additionalParticipantInstructions:
+      config.additionalParticipantInstructions ?? '',
   };
 }
 

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -157,12 +157,20 @@ export interface ChatStagePublicData extends BaseStagePublicData {
 export function getTurnCycleInfo(
   publicData: ChatStagePublicData | undefined | null,
   stage: ChatStageConfig,
+  // Who can still speak, when the caller knows. The turn order keeps a place
+  // for anyone who is not there at the moment, so that someone who comes back
+  // finds their own place again. Counting those places would make a cycle look
+  // longer than it is, and so make it look as though fewer cycles remain.
+  speakerIds?: string[],
 ): {currentCycle: number; totalCycles: number} | null {
   if (!stage.isTurnBased) return null;
   const max =
     publicData?.effectiveMaxNumberOfMessages ?? stage.maxNumberOfMessages;
   if (max === null || max === undefined || max <= 0) return null;
-  const speakersPerCycle = (publicData?.turnOrder ?? []).length;
+  const order = publicData?.turnOrder ?? [];
+  const speakersPerCycle = speakerIds
+    ? order.filter((id) => speakerIds.includes(id)).length
+    : order.length;
   if (speakersPerCycle <= 0) return null;
   const totalCycles = Math.ceil(max / speakersPerCycle);
   const currentCycle = Math.min((publicData?.cycleIndex ?? 0) + 1, totalCycles);

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -71,6 +71,7 @@ export const ChatStageConfigData = Type.Composite(
         discussions: Type.Array(ChatDiscussionData),
         isTurnBased: Type.Optional(Type.Boolean()),
         personaPositionPrompt: Type.Optional(Type.String()),
+        additionalParticipantInstructions: Type.Optional(Type.String()),
       },
       strict,
     ),

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -72,6 +72,10 @@ export const ChatStageConfigData = Type.Composite(
         isTurnBased: Type.Optional(Type.Boolean()),
         personaPositionPrompt: Type.Optional(Type.String()),
         additionalParticipantInstructions: Type.Optional(Type.String()),
+        minNumberOfMessages: Type.Optional(Type.Integer({minimum: 0})),
+        maxNumberOfMessages: Type.Optional(
+          Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+        ),
       },
       strict,
     ),

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -70,6 +70,7 @@ export const ChatStageConfigData = Type.Composite(
         ),
         discussions: Type.Array(ChatDiscussionData),
         isTurnBased: Type.Optional(Type.Boolean()),
+        personaPositionPrompt: Type.Optional(Type.String()),
       },
       strict,
     ),

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -32,6 +32,14 @@ export interface PrivateChatStageConfig extends BaseStageConfig {
   // If true, requires participant to go back and forth with mediator(s)
   // (rather than being able to send multiple messages at once)
   isTurnBasedChat: boolean;
+  // If true, displays the group-chat-style turn UI: an "It's your
+  // turn"/"Waiting for ..." banner, an inline typing indicator with the
+  // mediator's avatar, and mediator-goes-first ordering. Mutually exclusive
+  // with isTurnBasedChat (the private chat editor disables one when the
+  // other is checked). When neither is true, the legacy private-chat turn UX
+  // is used (input disabled while waiting, with a per-message spinner and
+  // cancel button).
+  isTurnBasedChatGroupStyle: boolean;
   // Minimum number of messages participant must send to move on
   minNumberOfTurns: number;
   // If turn based chat set to true, this specifies the max
@@ -61,6 +69,7 @@ export function createPrivateChatStage(
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
     timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
     isTurnBasedChat: config.isTurnBasedChat ?? true,
+    isTurnBasedChatGroupStyle: config.isTurnBasedChatGroupStyle ?? false,
     minNumberOfTurns: config.minNumberOfTurns ?? 0,
     maxNumberOfTurns: config.maxNumberOfTurns ?? null,
     preventCancellation: config.preventCancellation ?? false,

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -28,6 +28,9 @@ export const PrivateChatStageConfigData = Type.Composite(
         // If true, requires participant to go back and forth with mediator(s)
         // (rather than being able to send multiple messages at once)
         isTurnBasedChat: Type.Optional(Type.Boolean()),
+        // If true, uses the group-chat turn UI (banner + typing indicator +
+        // mediator-goes-first). Mutually exclusive with isTurnBasedChat.
+        isTurnBasedChatGroupStyle: Type.Optional(Type.Boolean()),
         // Minimum number of messages participant must send to move on
         minNumberOfTurns: Type.Optional(Type.Number()),
         // If turn based chat set to true, this specifies the max

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -22,6 +22,13 @@ export interface TransferStageConfig extends BaseStageConfig {
   enableTimeout: boolean;
   timeoutSeconds: number;
   autoTransferConfig: AutoTransferConfig | null; // if null, no auto-transfer
+  // Optional index into the participant's treatment variable (a multi-value
+  // RandomPermutation/BalancedAssignment). When set, the participant's treatment
+  // fields (isObserver, numOtherAgents, swapMediator, etc.) are re-hoisted from
+  // treatment[treatmentIndex] as this transfer completes, so a participant can
+  // rotate through multiple treatments across repeated deliberations. When
+  // unset, no re-hoisting occurs (existing behavior).
+  treatmentIndex?: number;
 }
 
 export type AutoTransferConfig =
@@ -125,6 +132,9 @@ export function createTransferStage(
     enableTimeout: config.enableTimeout ?? false,
     timeoutSeconds: config.timeoutSeconds ?? 600, // 10 minutes
     autoTransferConfig: config.autoTransferConfig ?? null,
+    ...(config.treatmentIndex !== undefined
+      ? {treatmentIndex: config.treatmentIndex}
+      : {}),
   };
 }
 

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -89,6 +89,7 @@ export const TransferStageConfigData = Type.Composite(
         enableTimeout: Type.Boolean(),
         timeoutSeconds: Type.Number(),
         autoTransferConfig: Type.Union([AutoTransferConfigSchema, Type.Null()]),
+        treatmentIndex: Type.Optional(Type.Integer({minimum: 0})),
       },
       strict,
     ),

--- a/utils/src/structured_prompt.ts
+++ b/utils/src/structured_prompt.ts
@@ -98,7 +98,8 @@ export type PromptItem =
   | StageContextPromptItem
   | PromptItemGroup
   | ChatMediatorInstructionsPromptItem
-  | ChatParticipantInstructionsPromptItem;
+  | ChatParticipantInstructionsPromptItem
+  | OtherProfileContextsPromptItem;
 
 export interface BasePromptItem {
   type: PromptItemType;
@@ -123,6 +124,9 @@ export enum PromptItemType {
   // to the turn-based or free-form variant based on stage config.
   CHAT_MEDIATOR_INSTRUCTIONS = 'CHAT_MEDIATOR_INSTRUCTIONS',
   CHAT_PARTICIPANT_INSTRUCTIONS = 'CHAT_PARTICIPANT_INSTRUCTIONS',
+  // Persona contexts (PROFILE_CONTEXT) of the other agent participants in the
+  // cohort, so an agent can aggregate the generated or retrieved personas.
+  OTHER_PROFILE_CONTEXTS = 'OTHER_PROFILE_CONTEXTS',
 }
 
 export interface TextPromptItem extends BasePromptItem {
@@ -180,6 +184,14 @@ export interface ChatMediatorInstructionsPromptItem extends BasePromptItem {
 /** Group chat participant behavior instructions, resolved at build time. */
 export interface ChatParticipantInstructionsPromptItem extends BasePromptItem {
   type: PromptItemType.CHAT_PARTICIPANT_INSTRUCTIONS;
+}
+
+/**
+ * The persona contexts of the other agent participants in the cohort,
+ * concatenated. Resolved at build time from each other agent's promptContext.
+ */
+export interface OtherProfileContextsPromptItem extends BasePromptItem {
+  type: PromptItemType.OTHER_PROFILE_CONTEXTS;
 }
 
 // ****************************************************************************

--- a/utils/src/variables.ts
+++ b/utils/src/variables.ts
@@ -37,6 +37,23 @@ export type ScopeContext =
     };
 
 /**
+ * Reserved variable names with special behavior. The variable editor warns
+ * when an experimenter uses one of these names.
+ */
+export const RESERVED_TREATMENT_VARIABLE_KEYS = [
+  '_isObserver',
+  '_hasRepresentative',
+  '_numOtherAgents',
+  '_numInactivePersonas',
+  '_swapMediator',
+  '_skipPrivateChats',
+] as const;
+
+/** GitHub link surfaced alongside the reserved-key warning. */
+export const RESERVED_TREATMENT_VARIABLE_GITHUB_URL =
+  'https://github.com/PAIR-code/deliberate-lab';
+
+/**
  * Defines the structure and metadata for a variable.
  * This describes what the variable is and how it's used in templates.
  */

--- a/utils/src/variables.ts
+++ b/utils/src/variables.ts
@@ -47,6 +47,7 @@ export const RESERVED_TREATMENT_VARIABLE_KEYS = [
   '_numInactivePersonas',
   '_swapMediator',
   '_skipPrivateChats',
+  '_isQuizzed',
 ] as const;
 
 /**

--- a/utils/src/variables.ts
+++ b/utils/src/variables.ts
@@ -49,6 +49,23 @@ export const RESERVED_TREATMENT_VARIABLE_KEYS = [
   '_skipPrivateChats',
 ] as const;
 
+/**
+ * Whether any variable config's values can assign observers. Presence of the
+ * reserved observer key in a value marks an observer-capable experiment,
+ * matching the frontend's per-participant check.
+ */
+export function variableConfigsIncludeObserver(
+  configs: VariableConfig[],
+): boolean {
+  return configs.some(
+    (config) =>
+      'values' in config &&
+      ((config as {values?: string[]}).values ?? []).some((value) =>
+        value.includes('_isObserver'),
+      ),
+  );
+}
+
 /** GitHub link surfaced alongside the reserved-key warning. */
 export const RESERVED_TREATMENT_VARIABLE_GITHUB_URL =
   'https://github.com/PAIR-code/deliberate-lab';


### PR DESCRIPTION
This PR builds on #1171 and should only be merged after it is merged.

This PR adds a periodic quiz for the participant to share their reactions to the group chat. By default, this pauses the turn-based group chat after each third of the minimum message count (up to 3 quizzes; fewer if the minimum is fewer than 3). It asks two questions: a 7-point Likert ("Do you like the process so far?") and a free-text explanation ("In one sentence, describe what you currently like or dislike.").

This is gated by a magic participant variable, `_isQuizzed` (boolean). If the chat is not turn-based, then this variable is ignored, and the variable editor warns the experimenter that it is being ignored.

<img width="1087" height="1258" alt="quiz-example" src="https://github.com/user-attachments/assets/a989b8f3-f531-4e9e-85c8-7400eec58598" />