### PR TITLE
Add message replies and reactions to group chat

### DIFF
--- a/frontend/src/components/chat/chat_input.scss
+++ b/frontend/src/components/chat/chat_input.scss
@@ -6,6 +6,12 @@
   width: 100%;
 }
 
+.chat-input {
+  @include common.flex-column;
+  gap: common.$spacing-small;
+  width: 100%;
+}
+
 .input {
   align-items: center;
   background: var(--md-sys-color-surface);
@@ -38,4 +44,40 @@
       pointer-events: none;
     }
   }
+}
+
+.reply-banner {
+  align-items: center;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: common.$spacing-medium;
+  box-sizing: border-box;
+  display: flex;
+  gap: common.$spacing-small;
+  justify-content: space-between;
+  padding: common.$spacing-small common.$spacing-small common.$spacing-small
+    common.$spacing-large;
+  width: 100%;
+}
+
+.reply-preview {
+  @include common.flex-column;
+  border-left: 3px solid var(--md-sys-color-outline-variant);
+  gap: 2px;
+  min-width: 0;
+  padding-left: common.$spacing-medium;
+}
+
+.reply-author {
+  @include typescale.label-small;
+  color: var(--md-sys-color-on-surface-variant);
+  font-weight: 500;
+}
+
+.reply-text {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/frontend/src/components/chat/chat_input.ts
+++ b/frontend/src/components/chat/chat_input.ts
@@ -1,6 +1,6 @@
 import {MobxLitElement} from '@adobe/lit-mobx';
 
-import {CSSResultGroup, html} from 'lit';
+import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 
 import {core} from '../../core/core';
@@ -26,8 +26,12 @@ export class ChatInputComponent extends MobxLitElement {
     input: string,
   ) => {
     if (!this.stageId || !input || input.trim() === '') return;
-    await this.participantService.createChatMessage({message: input.trim()});
+    await this.participantService.createChatMessage({
+      message: input.trim(),
+      replyTo: this.participantAnswerService.getChatReply(this.stageId),
+    });
     this.participantAnswerService.updateChatInput(this.stageId, '');
+    this.participantAnswerService.clearChatReply(this.stageId);
   };
   @property() storeUserInput: (input: string) => void = (input: string) => {
     if (!this.stageId) return;
@@ -81,30 +85,64 @@ export class ChatInputComponent extends MobxLitElement {
     };
 
     return html`
-      <div class="input ${this.isDisabled ? 'disabled' : ''}">
-        <pr-textarea
-          size="small"
-          placeholder="Send message"
-          .value=${this.getUserInput()}
-          ?focused=${shouldFocus()}
-          ?disabled=${this.isDisabled}
-          @keydown=${handleKeyDown}
-          @input=${handleInput}
-          @paste=${handlePaste}
-        >
-        </pr-textarea>
-        <pr-tooltip
-          text="Send message"
-          color="tertiary"
-          variant="outlined"
-          position="TOP_END"
-        >
-          <pr-icon-button
-            icon="send"
-            variant="tonal"
+      <div class="chat-input">
+        ${this.renderReplyBanner()}
+        <div class="input ${this.isDisabled ? 'disabled' : ''}">
+          <pr-textarea
+            size="small"
+            placeholder="Send message"
+            .value=${this.getUserInput()}
+            ?focused=${shouldFocus()}
             ?disabled=${this.isDisabled}
-            ?loading=${this.isLoading}
-            @click=${sendInput}
+            @keydown=${handleKeyDown}
+            @input=${handleInput}
+            @paste=${handlePaste}
+          >
+          </pr-textarea>
+          <pr-tooltip
+            text="Send message"
+            color="tertiary"
+            variant="outlined"
+            position="TOP_END"
+          >
+            <pr-icon-button
+              icon="send"
+              variant="tonal"
+              ?disabled=${this.isDisabled}
+              ?loading=${this.isLoading}
+              @click=${sendInput}
+            >
+            </pr-icon-button>
+          </pr-tooltip>
+        </div>
+      </div>
+    `;
+  }
+
+  /** Show the message being replied to, with the option to cancel the reply. */
+  private renderReplyBanner() {
+    if (!this.stageId) return nothing;
+
+    const reply = this.participantAnswerService.getChatReply(this.stageId);
+    if (!reply) return nothing;
+
+    return html`
+      <div class="reply-banner">
+        <div class="reply-preview">
+          <div class="reply-author">
+            Replying to ${reply.name.length > 0 ? reply.name : reply.senderId}
+          </div>
+          <div class="reply-text">
+            ${reply.message.length > 0 ? reply.message : 'Attachment'}
+          </div>
+        </div>
+        <pr-tooltip text="Cancel reply" position="TOP_END">
+          <pr-icon-button
+            icon="close"
+            color="neutral"
+            variant="default"
+            @click=${() =>
+              this.participantAnswerService.clearChatReply(this.stageId)}
           >
           </pr-icon-button>
         </pr-tooltip>

--- a/frontend/src/components/chat/chat_message.scss
+++ b/frontend/src/components/chat/chat_message.scss
@@ -101,6 +101,90 @@ $bubble-width: 400px;
     border-radius: $bubble-radius $bubble-radius $bubble-radius-small
       $bubble-radius;
   }
+
+  .reply-quote {
+    align-self: end;
+  }
+
+  .actions {
+    justify-content: flex-end;
+  }
+}
+
+.reply-quote {
+  @include common.flex-column;
+  border-left: 3px solid var(--md-sys-color-outline-variant);
+  color: var(--md-sys-color-on-surface-variant);
+  gap: 2px;
+  max-width: $bubble-width;
+  padding: common.$spacing-xs 0 common.$spacing-xs common.$spacing-medium;
+}
+
+.reply-author {
+  @include typescale.label-small;
+  font-weight: 500;
+}
+
+.reply-text {
+  @include typescale.label-small;
+  // Keep the quote to a couple of lines so it cannot dwarf the reply itself
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  @include common.flex-row;
+  align-items: center;
+  gap: common.$spacing-xs;
+  min-height: 24px;
+}
+
+.action-chip {
+  @include typescale.label-small;
+  align-items: center;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 20px;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  display: flex;
+  gap: common.$spacing-xs;
+  line-height: 1;
+  padding: common.$spacing-xs common.$spacing-small;
+
+  &:hover:not(:disabled) {
+    background: var(--md-sys-color-surface-variant);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  &.active {
+    background: var(--md-sys-color-secondary-container);
+    border-color: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  // Chips with no reactions yet stay hidden until the message is hovered,
+  // so an untouched conversation is not cluttered with empty buttons
+  &.empty {
+    opacity: 0;
+    transition: opacity 0.1s ease-in-out;
+  }
+}
+
+.chat-message:hover .action-chip.empty,
+.action-chip.empty:focus-visible {
+  opacity: 1;
+}
+
+.count {
+  font-variant-numeric: tabular-nums;
 }
 
 .discuss-message {

--- a/frontend/src/components/chat/chat_message.ts
+++ b/frontend/src/components/chat/chat_message.ts
@@ -1,3 +1,6 @@
+import '../../pair-components/icon';
+import '../../pair-components/tooltip';
+
 import '../participant_profile/avatar_icon';
 import '../shared/media_preview';
 import '../shared/media_preview_fullscreen';
@@ -12,10 +15,19 @@ import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
+import {CohortService} from '../../services/cohort.service';
 import {ExperimentService} from '../../services/experiment.service';
+import {ParticipantAnswerService} from '../../services/participant.answer';
 import {ParticipantService} from '../../services/participant.service';
 
-import {ChatMessage, StoredFile, UserType} from '@deliberation-lab/utils';
+import {
+  ChatMessage,
+  ChatMessageReaction,
+  StoredFile,
+  UserType,
+  createChatMessageReply,
+  getChatMessageReactors,
+} from '@deliberation-lab/utils';
 import {
   convertMarkdownToHTML,
   convertUnifiedTimestampToDate,
@@ -25,16 +37,33 @@ import {
 
 import {styles} from './chat_message.scss';
 
+/** Reactions offered on each chat message, in display order. */
+const REACTIONS: {
+  reaction: ChatMessageReaction;
+  emoji: string;
+  label: string;
+}[] = [
+  {reaction: ChatMessageReaction.HEART, emoji: '❤️', label: 'Heart'},
+  {reaction: ChatMessageReaction.THUMBS_UP, emoji: '👍', label: 'Thumbs up'},
+];
+
 /** Chat message component */
 @customElement('chat-message')
 export class ChatMessageComponent extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly authService = core.getService(AuthService);
+  private readonly cohortService = core.getService(CohortService);
   private readonly experimentService = core.getService(ExperimentService);
+  private readonly participantAnswerService = core.getService(
+    ParticipantAnswerService,
+  );
   private readonly participantService = core.getService(ParticipantService);
 
   @property() chat: ChatMessage | undefined = undefined;
+  // Stage that this message belongs to. Replying and reacting are only offered
+  // when a stage is given (e.g. not in experimenter previews).
+  @property() stageId = '';
   private fullscreenElement: HTMLElement | null = null;
 
   override disconnectedCallback() {
@@ -118,6 +147,7 @@ export class ChatMessageComponent extends MobxLitElement {
               )}</span
             >
           </div>
+          ${this.renderReplyQuote(chatMessage)}
           ${chatMessage.message
             ? html`<div class="chat-bubble">
                 ${unsafeHTML(convertMarkdownToHTML(chatMessage.message))}
@@ -125,6 +155,7 @@ export class ChatMessageComponent extends MobxLitElement {
             : nothing}
           ${this.renderDebuggingInfo(chatMessage)}
           ${this.renderFiles(chatMessage.files)}
+          ${this.renderMessageActions(chatMessage)}
         </div>
       </div>
     `;
@@ -150,6 +181,7 @@ export class ChatMessageComponent extends MobxLitElement {
               )}</span
             >
           </div>
+          ${this.renderReplyQuote(chatMessage)}
           ${chatMessage.message
             ? html`<div class="chat-bubble">
                 ${unsafeHTML(convertMarkdownToHTML(chatMessage.message))}
@@ -157,6 +189,7 @@ export class ChatMessageComponent extends MobxLitElement {
             : nothing}
           ${this.renderDebuggingInfo(chatMessage)}
           ${this.renderFiles(chatMessage.files)}
+          ${this.renderMessageActions(chatMessage)}
         </div>
       </div>
     `;
@@ -170,6 +203,109 @@ export class ChatMessageComponent extends MobxLitElement {
         </div>
       </div>
     `;
+  }
+
+  /** Render the quoted message that this message is replying to. */
+  private renderReplyQuote(chatMessage: ChatMessage) {
+    const replyTo = chatMessage.replyTo;
+    if (!replyTo) return nothing;
+
+    return html`
+      <div class="reply-quote">
+        <div class="reply-author">
+          ${replyTo.name.length > 0 ? replyTo.name : replyTo.senderId}
+        </div>
+        <div class="reply-text">
+          ${replyTo.message.length > 0 ? replyTo.message : 'Attachment'}
+        </div>
+      </div>
+    `;
+  }
+
+  /** Render reaction counts, plus reply/react buttons for participants. */
+  private renderMessageActions(chatMessage: ChatMessage) {
+    const publicId = this.participantService.profile?.publicId ?? '';
+    // Only a participant viewing a real stage can react or reply. Everyone else
+    // (e.g. an experimenter previewing the chat) still sees existing reactions.
+    const canReact = Boolean(this.stageId) && Boolean(publicId);
+    const isDisabled = this.participantService.disableStage;
+
+    const reactions = REACTIONS.map((config) => {
+      const reactors = getChatMessageReactors(chatMessage, config.reaction);
+      // Reactions nobody has used are shown only to those who can add them
+      if (reactors.length === 0 && !canReact) return nothing;
+
+      const isActive = reactors.includes(publicId);
+      const classes = classMap({
+        'action-chip': true,
+        active: isActive,
+        // Chips with no reactions are revealed on hover, so that untouched
+        // messages stay visually quiet
+        empty: reactors.length === 0,
+      });
+
+      return html`
+        <pr-tooltip
+          text=${this.getReactionTooltip(config.label, reactors)}
+          position="TOP_START"
+        >
+          <button
+            class=${classes}
+            ?disabled=${!canReact || isDisabled}
+            @click=${() =>
+              this.participantService.updateChatMessageReaction(
+                this.stageId,
+                chatMessage.id,
+                config.reaction,
+                !isActive,
+              )}
+          >
+            <span class="emoji">${config.emoji}</span>
+            ${reactors.length > 0
+              ? html`<span class="count">${reactors.length}</span>`
+              : nothing}
+          </button>
+        </pr-tooltip>
+      `;
+    });
+
+    if (!canReact && reactions.every((item) => item === nothing)) {
+      return nothing;
+    }
+
+    return html`
+      <div class="actions">
+        ${reactions}
+        ${canReact
+          ? html`
+              <pr-tooltip text="Reply" position="TOP_START">
+                <button
+                  class="action-chip empty"
+                  ?disabled=${isDisabled}
+                  @click=${() =>
+                    this.participantAnswerService.setChatReply(
+                      this.stageId,
+                      createChatMessageReply(chatMessage),
+                    )}
+                >
+                  <pr-icon icon="reply" size="small"></pr-icon>
+                </button>
+              </pr-tooltip>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  /** Tooltip naming everyone who applied a reaction. */
+  private getReactionTooltip(label: string, reactors: string[]) {
+    if (reactors.length === 0) return label;
+
+    const names = reactors.map((publicId) => {
+      if (publicId === this.participantService.profile?.publicId) return 'You';
+      return this.cohortService.participantMap[publicId]?.name ?? publicId;
+    });
+    return `${label}: ${names.join(', ')}`;
   }
 
   renderFiles(files?: StoredFile[]) {

--- a/frontend/src/components/stages/group_chat_participant_view.ts
+++ b/frontend/src/components/stages/group_chat_participant_view.ts
@@ -49,7 +49,10 @@ export class GroupChatView extends MobxLitElement {
   @state() readyToEndDiscussionLoading = false;
 
   private renderChatMessage(chatMessage: ChatMessage) {
-    return html` <chat-message .chat=${chatMessage}></chat-message> `;
+    return html`
+      <chat-message .chat=${chatMessage} .stageId=${this.stage?.id ?? ''}>
+      </chat-message>
+    `;
   }
 
   private isConversationOver() {

--- a/frontend/src/services/cohort.service.ts
+++ b/frontend/src/services/cohort.service.ts
@@ -1,4 +1,4 @@
-import {computed, makeObservable, observable} from 'mobx';
+import {computed, makeObservable, observable, runInAction} from 'mobx';
 import {
   collection,
   doc,
@@ -353,18 +353,13 @@ export class CohortService extends Service {
             orderBy('timestamp', 'asc'),
           ),
           (snapshot) => {
-            let changedDocs = snapshot.docChanges().map((change) => change.doc);
-            if (changedDocs.length === 0) {
-              changedDocs = snapshot.docs;
-            }
+            // Rebuild from the full snapshot rather than appending the changed
+            // docs: a chat message doc is updated in place when someone reacts
+            // to it, and appending would render that message twice.
+            const messages: ChatMessage[] = [];
+            const discussionMap: Record<string, ChatMessage[]> = {};
 
-            changedDocs.forEach((doc) => {
-              if (!this.chatMap[stageId]) {
-                this.chatMap[stageId] = [];
-              }
-              if (!this.chatDiscussionMap[stageId]) {
-                this.chatDiscussionMap[stageId] = {};
-              }
+            snapshot.docs.forEach((doc) => {
               const message = {
                 senderId: doc.data().participantPublicId ?? '', // backwards compatibility pre version 16
                 agentId: '', // backwards compatibility pre version 16
@@ -372,17 +367,20 @@ export class CohortService extends Service {
                 ...doc.data(),
               } as ChatMessage;
               if (!message.discussionId) {
-                this.chatMap[stageId].push(message);
+                messages.push(message);
               } else {
-                if (!this.chatDiscussionMap[stageId][message.discussionId]) {
-                  this.chatDiscussionMap[stageId][message.discussionId] = [];
+                if (!discussionMap[message.discussionId]) {
+                  discussionMap[message.discussionId] = [];
                 }
-                this.chatDiscussionMap[stageId][message.discussionId].push(
-                  message,
-                );
+                discussionMap[message.discussionId].push(message);
               }
             });
-            this.isChatLoading = false;
+
+            runInAction(() => {
+              this.chatMap[stageId] = messages;
+              this.chatDiscussionMap[stageId] = discussionMap;
+              this.isChatLoading = false;
+            });
           },
         ),
       );

--- a/frontend/src/services/participant.answer.ts
+++ b/frontend/src/services/participant.answer.ts
@@ -14,6 +14,7 @@ import {
 import {
   AssetAllocation,
   AssetAllocationStageParticipantAnswer,
+  ChatMessageReply,
   ParticipantProfileBase,
   RankingStageParticipantAnswer,
   StageKind,
@@ -51,6 +52,8 @@ export class ParticipantAnswerService extends Service {
   @observable answerMap: Record<string, StageParticipantAnswer> = {};
   // Map of stage ID to current chat input
   @observable chatInputMap: Record<string, string> = {};
+  // Map of stage ID to the message the participant is currently replying to
+  @observable chatReplyMap: Record<string, ChatMessageReply | null> = {};
   // Profile
   @observable profile: ParticipantProfileBase | null = null;
 
@@ -220,6 +223,18 @@ export class ParticipantAnswerService extends Service {
 
   getChatInput(stageId: string) {
     return this.chatInputMap[stageId] ?? '';
+  }
+
+  setChatReply(stageId: string, reply: ChatMessageReply) {
+    this.chatReplyMap[stageId] = reply;
+  }
+
+  getChatReply(stageId: string): ChatMessageReply | null {
+    return this.chatReplyMap[stageId] ?? null;
+  }
+
+  clearChatReply(stageId: string) {
+    this.chatReplyMap[stageId] = null;
   }
 
   updateProfile(config: Partial<ParticipantProfileBase>) {

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -3,6 +3,7 @@ import {
   AlertStatus,
   AssetAllocation,
   ChatMessage,
+  ChatMessageReaction,
   ChatStageParticipantAnswer,
   ChipOffer,
   CreateChatMessageData,
@@ -16,6 +17,7 @@ import {
   SurveyPerParticipantStageParticipantAnswer,
   SurveyStageParticipantAnswer,
   UnifiedTimestamp,
+  UpdateChatMessageReactionData,
   UpdateChatStageParticipantAnswerData,
   createChatMessage,
   createChatStageParticipantAnswer,
@@ -62,6 +64,7 @@ import {
   updateParticipantProfileCallable,
   updateParticipantToNextStageCallable,
   updateParticipantWaitingCallable,
+  updateChatMessageReactionCallable,
   updateChatStageParticipantAnswerCallable,
   updateFlipCardStageParticipantAnswerCallable,
   updateSurveyPerParticipantStageParticipantAnswerCallable,
@@ -661,6 +664,32 @@ export class ParticipantService extends Service {
     }
     this.isSendingChat = false;
     return response;
+  }
+
+  /** Apply or remove a reaction on a chat message. */
+  async updateChatMessageReaction(
+    stageId: string,
+    chatMessageId: string,
+    reaction: ChatMessageReaction,
+    add: boolean,
+  ) {
+    if (!this.experimentId || !this.profile) return;
+
+    const reactionData: UpdateChatMessageReactionData = {
+      experimentId: this.experimentId,
+      cohortId: this.profile.currentCohortId,
+      stageId,
+      participantId: this.profile.privateId,
+      chatMessageId,
+      senderId: this.profile.publicId,
+      reaction,
+      add,
+    };
+
+    return await updateChatMessageReactionCallable(
+      this.sp.firebaseService.functions,
+      reactionData,
+    );
   }
 
   /** Send error chat message. */

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -36,6 +36,7 @@ import {
   SuccessResponse,
   UpdateAssetAllocationStageParticipantAnswerData,
   UpdateMultiAssetAllocationStageParticipantAnswerData,
+  UpdateChatMessageReactionData,
   UpdateChatStageParticipantAnswerData,
   UpdateCohortMetadataData,
   UpdateFlipCardStageParticipantAnswerData,
@@ -479,6 +480,21 @@ export const createChatMessageCallable = async (
   const {data} = await httpsCallable<CreateChatMessageData, CreationResponse>(
     functions,
     'createChatMessage',
+  )(config);
+  return data;
+};
+
+/** Endpoint to apply or remove a reaction on a chat message. */
+export const updateChatMessageReactionCallable = async (
+  functions: Functions,
+  config: UpdateChatMessageReactionData,
+) => {
+  const {data} = await httpsCallable<
+    UpdateChatMessageReactionData,
+    CreationResponse
+  >(
+    functions,
+    'updateChatMessageReaction',
   )(config);
   return data;
 };

--- a/frontend/src/shared/file.utils.test.ts
+++ b/frontend/src/shared/file.utils.test.ts
@@ -1,5 +1,8 @@
 import * as file_utils from './file.utils';
 import {
+  ChatMessageReaction,
+  createChatMessageReply,
+  createParticipantChatMessage,
   createSurveyStage,
   generateId,
   createTextSurveyQuestion,
@@ -49,5 +52,97 @@ describe('File utils', () => {
     ].map(expect.stringMatching);
 
     expect(columns).toEqual(expectedColumns);
+  });
+});
+
+describe('Chat history CSV', () => {
+  it('writes reply and reaction headers', () => {
+    expect(file_utils.getChatMessageCSVColumns()).toEqual([
+      'Timestamp',
+      'Message ID',
+      'Discussion ID',
+      'Message type',
+      'Sender ID',
+      'Sender name',
+      'Sender avatar',
+      'Sender pronouns',
+      'Message content',
+      'Reply to message ID',
+      'Reply to sender ID',
+      'Reply to content',
+      'Heart count',
+      'Heart by',
+      'Thumbs up count',
+      'Thumbs up by',
+    ]);
+  });
+
+  it('writes replies and reactions, aligned with the headers', () => {
+    const original = createParticipantChatMessage({
+      message: 'The original point',
+      senderId: 'alice',
+      profile: {name: 'Alice', avatar: '🦊', pronouns: 'she/her'},
+    });
+
+    const reply = createParticipantChatMessage({
+      message: 'I disagree',
+      senderId: 'bob',
+      profile: {name: 'Bob', avatar: '🐻', pronouns: 'he/him'},
+      replyTo: createChatMessageReply(original),
+      reactionMap: {
+        [ChatMessageReaction.HEART]: ['alice', 'carol'],
+        [ChatMessageReaction.THUMBS_UP]: ['alice'],
+      },
+    });
+
+    const headers = file_utils.getChatMessageCSVColumns();
+    const row = file_utils.getChatMessageCSVColumns(reply);
+    const cells = Object.fromEntries(
+      headers.map((header, index) => [header, row[index]]),
+    );
+
+    expect(cells['Message content']).toBe('I disagree');
+    expect(cells['Reply to message ID']).toBe(original.id);
+    expect(cells['Reply to sender ID']).toBe('alice');
+    expect(cells['Reply to content']).toBe('The original point');
+    expect(cells['Heart count']).toBe('2');
+    expect(cells['Heart by']).toBe('alice; carol');
+    expect(cells['Thumbs up count']).toBe('1');
+    expect(cells['Thumbs up by']).toBe('alice');
+  });
+
+  it('leaves reply and reaction cells empty for a plain message', () => {
+    const message = createParticipantChatMessage({
+      message: 'Just a message',
+      senderId: 'alice',
+    });
+
+    const headers = file_utils.getChatMessageCSVColumns();
+    const row = file_utils.getChatMessageCSVColumns(message);
+    const cells = Object.fromEntries(
+      headers.map((header, index) => [header, row[index]]),
+    );
+
+    expect(cells['Reply to message ID']).toBe('');
+    expect(cells['Reply to content']).toBe('');
+    expect(cells['Heart count']).toBe('0');
+    expect(cells['Heart by']).toBe('');
+  });
+
+  it('does not break CSV cells when a reply quotes a comma', () => {
+    const original = createParticipantChatMessage({
+      message: 'One, two, three',
+      senderId: 'alice',
+    });
+    const reply = createParticipantChatMessage({
+      message: 'Counting, are we?',
+      senderId: 'bob',
+      replyTo: createChatMessageReply(original),
+    });
+
+    const row = file_utils.getChatMessageCSVColumns(reply);
+    // Every cell must be comma-free, or the row would shift columns
+    row.forEach((cell) => expect(cell).not.toContain(','));
+    expect(row).toHaveLength(file_utils.getChatMessageCSVColumns().length);
   });
 });

--- a/frontend/src/shared/file.utils.ts
+++ b/frontend/src/shared/file.utils.ts
@@ -6,6 +6,7 @@ import {stringify as csvStringify} from 'csv-stringify/sync';
 import {
   AlertMessage,
   ChatMessage,
+  ChatMessageReaction,
   ChipItem,
   ChipStageConfig,
   ChipStagePublicData,
@@ -26,12 +27,19 @@ import {
   UnifiedTimestamp,
   calculatePayoutResult,
   calculatePayoutTotal,
+  getChatMessageReactors,
 } from '@deliberation-lab/utils';
 import {convertUnifiedTimestampToISO} from './utils';
 
 // ****************************************************************************
 // FILE DOWNLOAD FUNCTIONS
 // ****************************************************************************
+
+/** Column labels for each chat message reaction. */
+const CHAT_REACTION_CSV_LABELS: Record<ChatMessageReaction, string> = {
+  [ChatMessageReaction.HEART]: 'Heart',
+  [ChatMessageReaction.THUMBS_UP]: 'Thumbs up',
+};
 
 const CSV_STRINGIFY_OPTIONS = {
   header: true,
@@ -1312,6 +1320,25 @@ export function getChatMessageCSVColumns(
 
   // Message content
   columns.push(!message ? 'Message content' : toCSV(message.message));
+
+  // Message that this message replies to (blank if not a reply)
+  columns.push(!message ? 'Reply to message ID' : (message.replyTo?.id ?? ''));
+  columns.push(
+    !message ? 'Reply to sender ID' : toCSV(message.replyTo?.senderId ?? ''),
+  );
+  columns.push(
+    !message ? 'Reply to content' : toCSV(message.replyTo?.message ?? ''),
+  );
+
+  // Reactions: a count, plus the IDs of everyone who reacted, per reaction
+  for (const reaction of Object.values(ChatMessageReaction)) {
+    const label = CHAT_REACTION_CSV_LABELS[reaction];
+    const reactors = message ? getChatMessageReactors(message, reaction) : [];
+
+    columns.push(!message ? `${label} count` : String(reactors.length));
+    // Semicolon-separated: toCSV strips commas out of cell values
+    columns.push(!message ? `${label} by` : toCSV(reactors.join('; ')));
+  }
 
   return columns;
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,7 @@
     "node": "22"
   },
   "config": {
-    "firestore_tests": "src/data.test.ts src/log.utils.test.ts src/dl_api/experiments.dl_api.integration.test.ts src/dl_api/cohorts.dl_api.integration.test.ts src/variables.utils.test.ts src/cohort_definitions.integration.test.ts src/alert.endpoints.test.ts"
+    "firestore_tests": "src/data.test.ts src/log.utils.test.ts src/dl_api/experiments.dl_api.integration.test.ts src/dl_api/cohorts.dl_api.integration.test.ts src/variables.utils.test.ts src/cohort_definitions.integration.test.ts src/alert.endpoints.test.ts src/chat/chat_reaction.integration.test.ts"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/chat/chat.utils.ts
+++ b/functions/src/chat/chat.utils.ts
@@ -3,12 +3,19 @@ import {
   ChatStageConfig,
   ChatStagePublicData,
   ChatStageParticipantAnswer,
+  StageKind,
+  UpdateChatMessageReactionData,
   createChatMessage,
   createChatStageParticipantAnswer,
   createSystemChatMessage,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
-import {Timestamp} from 'firebase-admin/firestore';
+import {
+  DocumentReference,
+  FieldPath,
+  FieldValue,
+  Timestamp,
+} from 'firebase-admin/firestore';
 import {app} from '../app';
 import {
   getFirestoreParticipant,
@@ -20,6 +27,89 @@ import {
   getFirestoreParticipantRef,
 } from '../utils/firestore';
 import {updateParticipantNextStage} from '../participant.utils';
+
+/** Thrown when a reaction targets a chat message that does not exist. */
+export class ChatMessageNotFoundError extends Error {}
+
+/**
+ * Resolve the doc that a chat message is stored under.
+ *
+ * Private chat messages live under the participant, group chat messages under
+ * the cohort's public stage data.
+ */
+export function getChatMessageRef(
+  stageKind: StageKind,
+  experimentId: string,
+  cohortId: string,
+  participantId: string, // private ID, used for private chats
+  stageId: string,
+  chatMessageId: string,
+): DocumentReference {
+  if (stageKind === StageKind.PRIVATE_CHAT) {
+    return app
+      .firestore()
+      .collection('experiments')
+      .doc(experimentId)
+      .collection('participants')
+      .doc(participantId)
+      .collection('stageData')
+      .doc(stageId)
+      .collection('privateChats')
+      .doc(chatMessageId);
+  }
+
+  return app
+    .firestore()
+    .collection('experiments')
+    .doc(experimentId)
+    .collection('cohorts')
+    .doc(cohortId)
+    .collection('publicStageData')
+    .doc(stageId)
+    .collection('chats')
+    .doc(chatMessageId);
+}
+
+/**
+ * Apply or remove a participant's reaction on a chat message.
+ *
+ * The reaction is stored as the list of participants who applied it (rather
+ * than as a counter), so that a count can never disagree with who reacted.
+ * arrayUnion/arrayRemove are applied atomically by Firestore, so simultaneous
+ * reactions from different participants cannot overwrite each other, and
+ * reacting twice cannot double-count.
+ */
+export async function updateChatMessageReaction(
+  stageKind: StageKind,
+  data: UpdateChatMessageReactionData,
+) {
+  const document = getChatMessageRef(
+    stageKind,
+    data.experimentId,
+    data.cohortId,
+    data.participantId,
+    data.stageId,
+    data.chatMessageId,
+  );
+
+  const reactors = data.add
+    ? FieldValue.arrayUnion(data.senderId)
+    : FieldValue.arrayRemove(data.senderId);
+
+  await app.firestore().runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(document);
+    if (!snapshot.exists) {
+      throw new ChatMessageNotFoundError(
+        `Chat message ${data.chatMessageId} not found`,
+      );
+    }
+    transaction.update(
+      document,
+      new FieldPath('reactionMap', data.reaction),
+      reactors,
+    );
+  });
+}
 
 /** Used for private chats if model response fails. */
 export async function sendErrorPrivateChatMessage(

--- a/functions/src/chat/chat_reaction.integration.test.ts
+++ b/functions/src/chat/chat_reaction.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Integration tests for chat message reactions.
+ *
+ * This test requires a Firestore emulator running. Run via:
+ * npm run test:firestore
+ */
+
+import {app} from '../app';
+import {
+  ChatMessage,
+  ChatMessageReaction,
+  StageKind,
+  createParticipantChatMessage,
+  generateId,
+  getChatMessageReactionCount,
+  getChatMessageReactors,
+  hasChatMessageReaction,
+} from '@deliberation-lab/utils';
+import {
+  ChatMessageNotFoundError,
+  getChatMessageRef,
+  updateChatMessageReaction,
+} from './chat.utils';
+
+const firestore = app.firestore();
+
+const EXPERIMENT_ID = 'reaction-test-experiment';
+const COHORT_ID = 'reaction-test-cohort';
+const STAGE_ID = 'reaction-test-stage';
+const PARTICIPANT_PRIVATE_ID = 'reaction-test-participant';
+
+/** Write a group chat message and return it. */
+async function seedGroupChatMessage(): Promise<ChatMessage> {
+  const chatMessage = createParticipantChatMessage({
+    id: generateId(),
+    message: 'A message worth reacting to',
+    senderId: 'author-public-id',
+  });
+
+  await getChatMessageRef(
+    StageKind.CHAT,
+    EXPERIMENT_ID,
+    COHORT_ID,
+    PARTICIPANT_PRIVATE_ID,
+    STAGE_ID,
+    chatMessage.id,
+  ).set(JSON.parse(JSON.stringify(chatMessage)));
+
+  return chatMessage;
+}
+
+/** Read a chat message back out of Firestore. */
+async function readGroupChatMessage(
+  chatMessageId: string,
+): Promise<ChatMessage> {
+  const snapshot = await getChatMessageRef(
+    StageKind.CHAT,
+    EXPERIMENT_ID,
+    COHORT_ID,
+    PARTICIPANT_PRIVATE_ID,
+    STAGE_ID,
+    chatMessageId,
+  ).get();
+  return snapshot.data() as ChatMessage;
+}
+
+/** Build the endpoint payload for a reaction. */
+function reactionData(
+  chatMessageId: string,
+  senderId: string,
+  reaction: ChatMessageReaction,
+  add: boolean,
+) {
+  return {
+    experimentId: EXPERIMENT_ID,
+    cohortId: COHORT_ID,
+    stageId: STAGE_ID,
+    participantId: PARTICIPANT_PRIVATE_ID,
+    chatMessageId,
+    senderId,
+    reaction,
+    add,
+  };
+}
+
+describe('chat message reactions', () => {
+  afterAll(async () => {
+    await firestore.recursiveDelete(
+      firestore.collection('experiments').doc(EXPERIMENT_ID),
+    );
+  });
+
+  it('records who reacted, and counts them', async () => {
+    const chatMessage = await seedGroupChatMessage();
+
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, true),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'bob', ChatMessageReaction.HEART, true),
+    );
+
+    const updated = await readGroupChatMessage(chatMessage.id);
+    expect(getChatMessageReactors(updated, ChatMessageReaction.HEART)).toEqual([
+      'alice',
+      'bob',
+    ]);
+    expect(
+      getChatMessageReactionCount(updated, ChatMessageReaction.HEART),
+    ).toBe(2);
+    expect(
+      hasChatMessageReaction(updated, ChatMessageReaction.HEART, 'alice'),
+    ).toBe(true);
+  });
+
+  it('keeps reactions independent of each other', async () => {
+    const chatMessage = await seedGroupChatMessage();
+
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, true),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(
+        chatMessage.id,
+        'alice',
+        ChatMessageReaction.THUMBS_UP,
+        true,
+      ),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'bob', ChatMessageReaction.THUMBS_UP, true),
+    );
+
+    const updated = await readGroupChatMessage(chatMessage.id);
+    expect(
+      getChatMessageReactionCount(updated, ChatMessageReaction.HEART),
+    ).toBe(1);
+    expect(
+      getChatMessageReactors(updated, ChatMessageReaction.THUMBS_UP),
+    ).toEqual(['alice', 'bob']);
+  });
+
+  it('removes only the reacting participant when un-reacting', async () => {
+    const chatMessage = await seedGroupChatMessage();
+
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, true),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'bob', ChatMessageReaction.HEART, true),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, false),
+    );
+
+    const updated = await readGroupChatMessage(chatMessage.id);
+    expect(getChatMessageReactors(updated, ChatMessageReaction.HEART)).toEqual([
+      'bob',
+    ]);
+    expect(
+      hasChatMessageReaction(updated, ChatMessageReaction.HEART, 'alice'),
+    ).toBe(false);
+  });
+
+  it('does not double-count a participant who reacts twice', async () => {
+    const chatMessage = await seedGroupChatMessage();
+
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, true),
+    );
+    await updateChatMessageReaction(
+      StageKind.CHAT,
+      reactionData(chatMessage.id, 'alice', ChatMessageReaction.HEART, true),
+    );
+
+    const updated = await readGroupChatMessage(chatMessage.id);
+    expect(
+      getChatMessageReactionCount(updated, ChatMessageReaction.HEART),
+    ).toBe(1);
+  });
+
+  it('does not lose reactions applied at the same time', async () => {
+    const chatMessage = await seedGroupChatMessage();
+    const senderIds = Array.from({length: 8}, (_, index) => `sender-${index}`);
+
+    // Every participant hearts the message simultaneously. A read-modify-write
+    // would drop reactions here; arrayUnion must keep all of them.
+    await Promise.all(
+      senderIds.map((senderId) =>
+        updateChatMessageReaction(
+          StageKind.CHAT,
+          reactionData(
+            chatMessage.id,
+            senderId,
+            ChatMessageReaction.HEART,
+            true,
+          ),
+        ),
+      ),
+    );
+
+    const updated = await readGroupChatMessage(chatMessage.id);
+    expect(
+      getChatMessageReactors(updated, ChatMessageReaction.HEART).sort(),
+    ).toEqual(senderIds.sort());
+  });
+
+  it('rejects a reaction on a message that does not exist', async () => {
+    await expect(
+      updateChatMessageReaction(
+        StageKind.CHAT,
+        reactionData(
+          'no-such-message',
+          'alice',
+          ChatMessageReaction.HEART,
+          true,
+        ),
+      ),
+    ).rejects.toThrow(ChatMessageNotFoundError);
+  });
+
+  it('routes private chat reactions to the participant subcollection', async () => {
+    const chatMessage = createParticipantChatMessage({
+      id: generateId(),
+      message: 'Private message',
+      senderId: 'author-public-id',
+    });
+
+    await getChatMessageRef(
+      StageKind.PRIVATE_CHAT,
+      EXPERIMENT_ID,
+      COHORT_ID,
+      PARTICIPANT_PRIVATE_ID,
+      STAGE_ID,
+      chatMessage.id,
+    ).set(JSON.parse(JSON.stringify(chatMessage)));
+
+    await updateChatMessageReaction(
+      StageKind.PRIVATE_CHAT,
+      reactionData(
+        chatMessage.id,
+        'alice',
+        ChatMessageReaction.THUMBS_UP,
+        true,
+      ),
+    );
+
+    const snapshot = await getChatMessageRef(
+      StageKind.PRIVATE_CHAT,
+      EXPERIMENT_ID,
+      COHORT_ID,
+      PARTICIPANT_PRIVATE_ID,
+      STAGE_ID,
+      chatMessage.id,
+    ).get();
+    expect(
+      getChatMessageReactors(
+        snapshot.data() as ChatMessage,
+        ChatMessageReaction.THUMBS_UP,
+      ),
+    ).toEqual(['alice']);
+  });
+});

--- a/functions/src/stages/chat.endpoints.ts
+++ b/functions/src/stages/chat.endpoints.ts
@@ -3,6 +3,7 @@ import {
   ChatStageConfig,
   ChatStagePublicData,
   StageKind,
+  UpdateChatMessageReactionData,
   UpdateChatStageParticipantAnswerData,
   getTimeElapsed,
 } from '@deliberation-lab/utils';
@@ -10,6 +11,10 @@ import {Timestamp} from 'firebase-admin/firestore';
 import {onCall, HttpsError} from 'firebase-functions/v2/https';
 
 import {app} from '../app';
+import {
+  ChatMessageNotFoundError,
+  updateChatMessageReaction as updateChatMessageReactionInternal,
+} from '../chat/chat.utils';
 import {
   getFirestoreStage,
   getFirestoreStagePublicData,
@@ -101,6 +106,49 @@ export const createChatMessage = onCall(async (request) => {
   });
 
   return {id: ''};
+});
+
+// ************************************************************************* //
+// updateChatMessageReaction endpoint                                        //
+//                                                                           //
+// Input structure: {                                                        //
+//   experimentId, cohortId, stageId, participantId (private), chatMessageId,//
+//   senderId (public), reaction, add                                        //
+// }                                                                         //
+// Validation: utils/src/stages/chat_stage.validation.ts                     //
+// ************************************************************************* //
+
+export const updateChatMessageReaction = onCall(async (request) => {
+  const {data} = request;
+
+  // Validate input
+  const validInput = Value.Check(UpdateChatMessageReactionData, data);
+  if (!validInput) {
+    for (const error of Value.Errors(UpdateChatMessageReactionData, data)) {
+      prettyPrintError(error);
+    }
+    throw new HttpsError('invalid-argument', 'Invalid data');
+  }
+
+  const stage = await getFirestoreStage(data.experimentId, data.stageId);
+
+  if (!stage) {
+    throw new HttpsError(
+      'not-found',
+      `Stage ${data.stageId} not found in experiment ${data.experimentId}`,
+    );
+  }
+
+  try {
+    await updateChatMessageReactionInternal(stage.kind, data);
+  } catch (error) {
+    if (error instanceof ChatMessageNotFoundError) {
+      throw new HttpsError('not-found', error.message);
+    }
+    throw error;
+  }
+
+  return {id: data.chatMessageId};
 });
 
 // ************************************************************************* //

--- a/utils/src/chat_message.test.ts
+++ b/utils/src/chat_message.test.ts
@@ -1,0 +1,125 @@
+import {
+  ChatMessageReaction,
+  MAX_CHAT_QUOTE_LENGTH,
+  createChatMessageReply,
+  createParticipantChatMessage,
+  getChatMessageReactionCount,
+  getChatMessageReactors,
+  hasChatMessageReaction,
+} from './chat_message';
+
+describe('chat message reactions', () => {
+  it('defaults to no reactions and no reply', () => {
+    const chatMessage = createParticipantChatMessage({message: 'Hello'});
+
+    expect(chatMessage.reactionMap).toEqual({});
+    expect(chatMessage.replyTo).toBeNull();
+    expect(
+      getChatMessageReactionCount(chatMessage, ChatMessageReaction.HEART),
+    ).toBe(0);
+  });
+
+  it('reads reactors and counts', () => {
+    const chatMessage = createParticipantChatMessage({
+      message: 'Hello',
+      reactionMap: {
+        [ChatMessageReaction.HEART]: ['alice', 'bob'],
+        [ChatMessageReaction.THUMBS_UP]: ['carol'],
+      },
+    });
+
+    expect(
+      getChatMessageReactors(chatMessage, ChatMessageReaction.HEART),
+    ).toEqual(['alice', 'bob']);
+    expect(
+      getChatMessageReactionCount(chatMessage, ChatMessageReaction.HEART),
+    ).toBe(2);
+    expect(
+      getChatMessageReactionCount(chatMessage, ChatMessageReaction.THUMBS_UP),
+    ).toBe(1);
+    expect(
+      hasChatMessageReaction(chatMessage, ChatMessageReaction.HEART, 'alice'),
+    ).toBe(true);
+    expect(
+      hasChatMessageReaction(chatMessage, ChatMessageReaction.HEART, 'carol'),
+    ).toBe(false);
+  });
+
+  it('treats a message saved before reactions existed as having none', () => {
+    // Messages written before this feature have no reactionMap field at all
+    const chatMessage = createParticipantChatMessage({message: 'Hello'});
+    delete chatMessage.reactionMap;
+
+    expect(
+      getChatMessageReactors(chatMessage, ChatMessageReaction.HEART),
+    ).toEqual([]);
+    expect(
+      getChatMessageReactionCount(chatMessage, ChatMessageReaction.HEART),
+    ).toBe(0);
+    expect(
+      hasChatMessageReaction(chatMessage, ChatMessageReaction.HEART, 'alice'),
+    ).toBe(false);
+  });
+});
+
+describe('chat message replies', () => {
+  it('quotes the sender and message being replied to', () => {
+    const original = createParticipantChatMessage({
+      message: 'The original point',
+      senderId: 'alice-public-id',
+      profile: {name: 'Alice', avatar: '🦊', pronouns: 'she/her'},
+    });
+
+    expect(createChatMessageReply(original)).toEqual({
+      id: original.id,
+      senderId: 'alice-public-id',
+      name: 'Alice',
+      message: 'The original point',
+    });
+  });
+
+  it('truncates a long quote so replies cannot grow without bound', () => {
+    const original = createParticipantChatMessage({
+      message: 'a'.repeat(MAX_CHAT_QUOTE_LENGTH + 100),
+      senderId: 'alice-public-id',
+    });
+
+    const reply = createChatMessageReply(original);
+    expect(reply.message).toHaveLength(MAX_CHAT_QUOTE_LENGTH + 1); // + ellipsis
+    expect(reply.message.endsWith('…')).toBe(true);
+  });
+
+  it('does not truncate a quote at the length limit', () => {
+    const message = 'a'.repeat(MAX_CHAT_QUOTE_LENGTH);
+    const original = createParticipantChatMessage({message});
+
+    expect(createChatMessageReply(original).message).toBe(message);
+  });
+
+  it('falls back to the sender ID when the sender has no name', () => {
+    const original = createParticipantChatMessage({
+      message: 'Anonymous point',
+      senderId: 'alice-public-id',
+    });
+
+    expect(createChatMessageReply(original).name).toBe('alice-public-id');
+  });
+
+  it('carries the quote onto the reply', () => {
+    const original = createParticipantChatMessage({
+      message: 'The original point',
+      senderId: 'alice-public-id',
+      profile: {name: 'Alice', avatar: '🦊', pronouns: 'she/her'},
+    });
+
+    const reply = createParticipantChatMessage({
+      message: 'I disagree',
+      senderId: 'bob-public-id',
+      replyTo: createChatMessageReply(original),
+    });
+
+    expect(reply.replyTo?.id).toBe(original.id);
+    expect(reply.replyTo?.name).toBe('Alice');
+    expect(reply.replyTo?.message).toBe('The original point');
+  });
+});

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -13,6 +13,34 @@ import {StoredFile} from './model_response';
 // TYPES                                                                     //
 // ************************************************************************* //
 
+/** Reaction that can be applied to a chat message. */
+export enum ChatMessageReaction {
+  HEART = 'heart',
+  THUMBS_UP = 'thumbsUp',
+}
+
+/**
+ * Reactions on a chat message: reaction to the IDs of everyone who applied it.
+ *
+ * The sender IDs are the record; a reaction count is the length of its list,
+ * so counts can never drift out of sync with who reacted.
+ */
+export type ChatReactionMap = Partial<Record<ChatMessageReaction, string[]>>;
+
+/**
+ * Snapshot of the message that a reply quotes.
+ *
+ * Copied onto the reply rather than looked up by ID, so that the quote still
+ * renders (and still appears in experiment downloads) if the quoted message is
+ * not part of the loaded history.
+ */
+export interface ChatMessageReply {
+  id: string; // ID of the quoted message
+  senderId: string; // sender of the quoted message
+  name: string; // sender's display name when the reply was written
+  message: string; // quoted text, truncated to MAX_CHAT_QUOTE_LENGTH
+}
+
 /**
  * ChatMessage.
  *
@@ -34,6 +62,12 @@ export interface ChatMessage {
   reasoning?: string; // model's internal chain-of-thought (from thinking/reasoning features)
   isError: boolean; // is error message (used for private chats)
   files?: StoredFile[]; // uploaded files (images, documents, etc.)
+  // Message that this message replies to (with quoted text), if any.
+  // Optional because messages written before replies existed do not have it.
+  replyTo?: ChatMessageReply | null;
+  // Reactions applied to this message, keyed by reaction.
+  // Optional because messages written before reactions existed do not have it.
+  reactionMap?: ChatReactionMap;
 }
 
 // ************************************************************************* //
@@ -43,6 +77,10 @@ export interface ChatMessage {
 // Sender ID for chat messages manually sent by experimenter
 // This should be consistent to ensure same background color for each message
 export const EXPERIMENTER_MANUAL_CHAT_SENDER_ID = 'experimenter';
+
+// Quoted text longer than this is truncated when replying, so that a chain of
+// replies cannot grow each message without bound
+export const MAX_CHAT_QUOTE_LENGTH = 280;
 
 // ************************************************************************* //
 // FUNCTIONS                                                                 //
@@ -65,6 +103,8 @@ export function createChatMessage(
     reasoning: config.reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    replyTo: config.replyTo ?? null,
+    reactionMap: config.reactionMap ?? {},
   };
 }
 
@@ -85,6 +125,8 @@ export function createParticipantChatMessage(
     reasoning: config.reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    replyTo: config.replyTo ?? null,
+    reactionMap: config.reactionMap ?? {},
   };
 }
 
@@ -105,6 +147,8 @@ export function createMediatorChatMessage(
     reasoning: config.reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    replyTo: config.replyTo ?? null,
+    reactionMap: config.reactionMap ?? {},
   };
 }
 
@@ -125,6 +169,49 @@ export function createExperimenterChatMessage(
     reasoning: config.reasoning ?? undefined,
     isError: config.isError ?? false,
     files: config.files ?? undefined,
+    replyTo: config.replyTo ?? null,
+    reactionMap: config.reactionMap ?? {},
+  };
+}
+
+/** Return the IDs of everyone who applied the given reaction to a message. */
+export function getChatMessageReactors(
+  chatMessage: ChatMessage,
+  reaction: ChatMessageReaction,
+): string[] {
+  return chatMessage.reactionMap?.[reaction] ?? [];
+}
+
+/** Return the number of times the given reaction was applied to a message. */
+export function getChatMessageReactionCount(
+  chatMessage: ChatMessage,
+  reaction: ChatMessageReaction,
+): number {
+  return getChatMessageReactors(chatMessage, reaction).length;
+}
+
+/** Whether the given sender applied the given reaction to a message. */
+export function hasChatMessageReaction(
+  chatMessage: ChatMessage,
+  reaction: ChatMessageReaction,
+  senderId: string,
+): boolean {
+  return getChatMessageReactors(chatMessage, reaction).includes(senderId);
+}
+
+/** Build the quote snapshot for a reply to the given message. */
+export function createChatMessageReply(
+  chatMessage: ChatMessage,
+): ChatMessageReply {
+  const message = chatMessage.message;
+  return {
+    id: chatMessage.id,
+    senderId: chatMessage.senderId,
+    name: chatMessage.profile?.name ?? chatMessage.senderId,
+    message:
+      message.length > MAX_CHAT_QUOTE_LENGTH
+        ? `${message.slice(0, MAX_CHAT_QUOTE_LENGTH).trimEnd()}…`
+        : message,
   };
 }
 
@@ -145,5 +232,7 @@ export function createSystemChatMessage(
     reasoning: config.reasoning ?? undefined,
     isError: false,
     files: config.files ?? undefined,
+    replyTo: config.replyTo ?? null,
+    reactionMap: config.reactionMap ?? {},
   };
 }

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -7,6 +7,7 @@ import {
   type StageValidationResult,
 } from './stage.schemas';
 import {UserType} from '../participant';
+import {ChatMessageReaction, MAX_CHAT_QUOTE_LENGTH} from '../chat_message';
 import {ChatStageConfig} from './chat_stage';
 
 /** Shorthand for strict TypeBox object validation */
@@ -108,6 +109,23 @@ export const UserTypeData = Type.Union([
   Type.Literal(UserType.UNKNOWN),
 ]);
 
+/** ChatMessageReaction input validation. */
+export const ChatMessageReactionData = Type.Union([
+  Type.Literal(ChatMessageReaction.HEART),
+  Type.Literal(ChatMessageReaction.THUMBS_UP),
+]);
+
+/** ChatMessageReply input validation. */
+export const ChatMessageReplyData = Type.Object(
+  {
+    id: Type.String({minLength: 1}),
+    senderId: Type.String(),
+    name: Type.String(),
+    message: Type.String({maxLength: MAX_CHAT_QUOTE_LENGTH + 1}),
+  },
+  {$id: 'ChatMessageReply', ...strict},
+);
+
 /** ChatMessage input validation. */
 export const ChatMessageData = Type.Object(
   {
@@ -123,6 +141,7 @@ export const ChatMessageData = Type.Object(
       },
       {$id: 'ChatMessageProfile', ...strict},
     ),
+    replyTo: Type.Optional(Type.Union([Type.Null(), ChatMessageReplyData])),
     // timestamp
   },
   {$id: 'ChatMessage'},
@@ -142,6 +161,32 @@ export const CreateChatMessageData = Type.Object(
 );
 
 export type CreateChatMessageData = Static<typeof CreateChatMessageData>;
+
+// ************************************************************************* //
+// updateChatMessageReaction endpoint                                        //
+// ************************************************************************* //
+
+/** UpdateChatMessageReactionData. */
+export const UpdateChatMessageReactionData = Type.Object(
+  {
+    experimentId: Type.String({minLength: 1}),
+    cohortId: Type.String({minLength: 1}),
+    stageId: Type.String({minLength: 1}),
+    // private participant ID (used in private chat cases)
+    participantId: Type.String({minLength: 1}),
+    chatMessageId: Type.String({minLength: 1}),
+    // public ID of the participant applying/removing the reaction
+    senderId: Type.String({minLength: 1}),
+    reaction: ChatMessageReactionData,
+    // true to apply the reaction, false to remove it
+    add: Type.Boolean(),
+  },
+  strict,
+);
+
+export type UpdateChatMessageReactionData = Static<
+  typeof UpdateChatMessageReactionData
+>;
 
 // ************************************************************************* //
 // updateChatStageParticipantAnswer endpoint                                 //


### PR DESCRIPTION
Participants can reply to a message with a quote of it, and react to messages with a heart or thumbs up. Reactions record **who** reacted, not just how many.

## Data model

Two optional fields on `ChatMessage`, so existing chat documents remain valid:

- `reactionMap: {heart: string[], thumbsUp: string[]}` — each reaction maps to the public IDs of everyone who applied it. The list of reactors *is* the storage and the count is its length, so a count can never drift out of sync with who reacted.
- `replyTo: {id, senderId, name, message}` — a snapshot of the quoted message rather than just a parent ID, so the quote still renders if the original is not in the loaded history, and it survives into experiment downloads. Quotes are truncated (280 chars) so a chain of replies cannot grow each message without bound.

## Writes

A new `updateChatMessageReaction` callable applies reactions with Firestore's `arrayUnion`/`arrayRemove`. These are atomic, so simultaneous reactions from different participants cannot overwrite each other, and idempotent, so a double-click cannot double-count. Chat documents were already client-unwritable in the security rules and stay that way — no rules change.

## Data export

Replies and reactions flow into the JSON experiment download automatically, since `data.ts` passes the raw documents through.

The chat history **CSV** builds its columns explicitly, so it would have silently dropped both — anyone analysing a conversation from the CSV would have concluded nothing was recorded. Added seven columns: `Reply to message ID`, `Reply to sender ID`, `Reply to content`, `Heart count`, `Heart by`, `Thumbs up count`, `Thumbs up by`. Reactor lists are semicolon-separated because `toCSV` strips commas from cells (a comma would shift every following column).

## Drive-by fix

`CohortService.loadChatMessages` appended every changed document to the message list without checking the change type. Only creates happened before, so it went unnoticed — but a reaction *updates* a chat document, which would have rendered that message twice. The listener now rebuilds from the snapshot, as the private chat listener already does.

## Testing

- 7 integration tests against the Firestore emulator covering the reaction write path, including 8 participants reacting simultaneously (a read-modify-write would drop some; `arrayUnion` keeps all), un-reacting removing only the caller, and reacting to a missing message.
- The deployed callable driven over HTTP end-to-end: toggling, reactions staying independent, plus `NOT_FOUND` on a missing message and `INVALID_ARGUMENT` on an unknown reaction or empty sender.
- Unit tests for the quote/reaction helpers, including truncation and the backward-compatibility case (messages saved before this feature have no `reactionMap` and read as zero reactions).
- CSV tests pinning the header row against a real message row so the columns cannot drift out of alignment.
- Verified in the running app with two participants, and confirmed in a real experiment download that reactions and replies appear in both the JSON and the CSV.

Full suites pass on this base: 107 emulator, 219 utils, 134 functions, 30 frontend.