### PR TITLE
feat: chat setting to prevent agents ending or declining to respond

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -735,6 +735,9 @@
         },
         "isTurnBased": {
           "type": "boolean"
+        },
+        "preventAgentEnd": {
+          "type": "boolean"
         }
       }
     },
@@ -1370,6 +1373,9 @@
           "type": ["number", "null"]
         },
         "preventCancellation": {
+          "type": "boolean"
+        },
+        "preventAgentEnd": {
           "type": "boolean"
         }
       }

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -31,6 +31,7 @@ export class ChatEditor extends MobxLitElement {
     return html`
       <div class="title">Conversation settings</div>
       ${this.renderTimeLimit()} ${this.renderTurnBasedSetting()}
+      ${this.renderPreventAgentEndSetting()}
       <div class="divider"></div>
       <div class="title">Agent mediators</div>
       <div class="description">
@@ -61,6 +62,29 @@ export class ChatEditor extends MobxLitElement {
             Turn-based conversation: Each participant speaks in a random order,
             beginning with the mediators if at least one is present.
           </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPreventAgentEndSetting() {
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${this.stage?.preventAgentEnd ?? false}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @change=${(e: Event) => {
+              const checked = (e.target as HTMLInputElement).checked;
+              this.experimentEditor.updateStage({
+                ...this.stage!,
+                preventAgentEnd: checked,
+              });
+            }}
+          >
+          </md-checkbox>
+          <div>Prevent agents from ending chat</div>
         </div>
       </div>
     `;

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -29,8 +29,8 @@ export class ChatEditor extends MobxLitElement {
       ${this.renderTimeLimit()} ${this.renderPreventCancellation()}
       <div class="divider"></div>
       <div class="title">Message limits</div>
-      ${this.renderTurnBasedChat()} ${this.renderMinNumberOfTurns()}
-      ${this.renderMaxNumberOfTurns()}
+      ${this.renderTurnBasedChat()} ${this.renderPreventAgentEndSetting()}
+      ${this.renderMinNumberOfTurns()} ${this.renderMaxNumberOfTurns()}
       <div class="divider"></div>
       <div class="title">Agent mediators</div>
       <div class="description">
@@ -181,6 +181,36 @@ export class ChatEditor extends MobxLitElement {
           </md-checkbox>
           <div>
             Turn-based chat (participant and mediator alternate messages)
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPreventAgentEndSetting() {
+    const preventAgentEnd = this.stage?.preventAgentEnd ?? false;
+
+    const updateCheck = () => {
+      if (!this.stage) return;
+      this.experimentEditor.updateStage({
+        ...this.stage,
+        preventAgentEnd: !preventAgentEnd,
+      });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${preventAgentEnd}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateCheck}
+          >
+          </md-checkbox>
+          <div>
+            Prevent agents from ending chat (agents always reply and cannot end
+            the conversation)
           </div>
         </div>
       </div>

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -4,6 +4,7 @@ import {
   ChatMessage,
   ChatPromptConfig,
   ChatStageConfig,
+  PrivateChatStageConfig,
   ChatStagePublicData,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
@@ -393,21 +394,54 @@ export async function getAgentChatMessage(
   // field whose "stay silent" path would freeze the turn. The prompt text is
   // already filtered in structured_prompt.utils.ts; this keeps the two in sync.
   const effectiveStructuredOutputConfig = (() => {
-    const config = promptConfig.structuredOutputConfig as
+    let config = promptConfig.structuredOutputConfig as
       | ChatMediatorStructuredOutputConfig
       | undefined;
-    if (!isTurnBasedGroupChat || !config?.schema?.properties) return config;
-    const shouldRespondFieldName = config.shouldRespondField || 'shouldRespond';
-    return {
-      ...config,
-      schema: {
-        ...config.schema,
-        properties: config.schema.properties.filter(
-          (p) => p.name !== shouldRespondFieldName,
-        ),
-      },
-      shouldRespondField: '',
-    } as ChatMediatorStructuredOutputConfig;
+    if (isTurnBasedGroupChat && config?.schema?.properties) {
+      const shouldRespondFieldName =
+        config.shouldRespondField || 'shouldRespond';
+      config = {
+        ...config,
+        schema: {
+          ...config.schema,
+          properties: config.schema.properties.filter(
+            (p) => p.name !== shouldRespondFieldName,
+          ),
+        },
+        shouldRespondField: '',
+      } as ChatMediatorStructuredOutputConfig;
+    }
+    // When the stage prevents agents from ending the chat, drop the end-chat
+    // field for every agent; in turn-based private chats also drop the
+    // respond decision so the agent always replies.
+    const stagePreventsAgentEnd =
+      (stage.kind === StageKind.CHAT ||
+        stage.kind === StageKind.PRIVATE_CHAT) &&
+      (stage as ChatStageConfig | PrivateChatStageConfig).preventAgentEnd ===
+        true;
+    if (stagePreventsAgentEnd && config?.schema?.properties) {
+      const dropFields = [config.readyToEndField || 'readyToEndChat'];
+      let shouldRespondField = config.shouldRespondField;
+      if (
+        stage.kind === StageKind.PRIVATE_CHAT &&
+        (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true
+      ) {
+        dropFields.push(config.shouldRespondField || 'shouldRespond');
+        shouldRespondField = '';
+      }
+      config = {
+        ...config,
+        schema: {
+          ...config.schema,
+          properties: config.schema.properties.filter(
+            (p) => !dropFields.includes(p.name),
+          ),
+        },
+        shouldRespondField,
+        readyToEndField: '',
+      } as ChatMediatorStructuredOutputConfig;
+    }
+    return config;
   })();
 
   const {response, logId, retryTimedOut} = await processModelResponse(
@@ -486,8 +520,17 @@ export async function getAgentChatMessage(
     // Logic for not responding (handled below)
   }
 
-  // Only if agent participant is ready to end chat
-  if (readyToEndChat && user.type === UserType.PARTICIPANT) {
+  // Only if agent participant is ready to end chat. The experimenter can
+  // suppress this entirely via the preventAgentEnd setting.
+  const stageBlocksAgentEnd =
+    (stage.kind === StageKind.CHAT || stage.kind === StageKind.PRIVATE_CHAT) &&
+    (stage as ChatStageConfig | PrivateChatStageConfig).preventAgentEnd ===
+      true;
+  if (
+    readyToEndChat &&
+    user.type === UserType.PARTICIPANT &&
+    !stageBlocksAgentEnd
+  ) {
     // Ensure we don't end chat on the very first message
     if (chatMessages.length > 0) {
       // Call ready to end chat update to stage public data

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -20,6 +20,7 @@ import {
   createSystemChatMessage,
   sanitizeRawResponseForLogging,
   shuffleWithSeed,
+  rewriteDescriptionsForRequiredResponse,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 import {processModelResponse} from '../agent.utils';
@@ -422,20 +423,28 @@ export async function getAgentChatMessage(
     if (stagePreventsAgentEnd && config?.schema?.properties) {
       const dropFields = [config.readyToEndField || 'readyToEndChat'];
       let shouldRespondField = config.shouldRespondField;
+      let respondRequired = false;
       if (
         stage.kind === StageKind.PRIVATE_CHAT &&
         (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true
       ) {
         dropFields.push(config.shouldRespondField || 'shouldRespond');
         shouldRespondField = '';
+        respondRequired = true;
       }
+      const properties = config.schema.properties.filter(
+        (p) => !dropFields.includes(p.name),
+      );
       config = {
         ...config,
         schema: {
           ...config.schema,
-          properties: config.schema.properties.filter(
-            (p) => !dropFields.includes(p.name),
-          ),
+          properties: respondRequired
+            ? rewriteDescriptionsForRequiredResponse(
+                properties,
+                user.type === UserType.MEDIATOR,
+              )
+            : properties,
         },
         shouldRespondField,
         readyToEndField: '',

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_PROMPT_INSTRUCTIONS,
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
+  PrivateChatStageConfig,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -359,6 +360,34 @@ export async function getPromptFromConfig(
       schema: {
         ...structuredOutputConfig.schema,
         properties: sanitizedProperties,
+      },
+    };
+  }
+
+  // When the stage prevents agents from ending the chat, no agent is asked
+  // for the end-chat field at all. In turn-based private chats the agent is
+  // also not asked whether to respond: it always replies (declining would
+  // stall the turn; in free-form private chats it just means no reply).
+  const stagePreventsAgentEnd =
+    (stage?.kind === StageKind.CHAT ||
+      stage?.kind === StageKind.PRIVATE_CHAT) &&
+    (stage as ChatStageConfig | PrivateChatStageConfig).preventAgentEnd ===
+      true;
+  if (stagePreventsAgentEnd && structuredOutputConfig?.schema?.properties) {
+    const dropFields = [structuredOutputConfig.readyToEndField];
+    if (
+      stage?.kind === StageKind.PRIVATE_CHAT &&
+      (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true
+    ) {
+      dropFields.push(structuredOutputConfig.shouldRespondField);
+    }
+    structuredOutputConfig = {
+      ...structuredOutputConfig,
+      schema: {
+        ...structuredOutputConfig.schema,
+        properties: structuredOutputConfig.schema.properties.filter(
+          (prop) => !dropFields.includes(prop.name),
+        ),
       },
     };
   }

--- a/functions/src/structured_prompt.utils.ts
+++ b/functions/src/structured_prompt.utils.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_MEDIATOR_GROUP_CHAT_TURN_TAKING_PROMPT_INSTRUCTIONS,
   ChatStageConfig,
   PrivateChatStageConfig,
+  rewriteDescriptionsForRequiredResponse,
 } from '@deliberation-lab/utils';
 import {
   getAgentMediatorPrompt,
@@ -375,19 +376,27 @@ export async function getPromptFromConfig(
       true;
   if (stagePreventsAgentEnd && structuredOutputConfig?.schema?.properties) {
     const dropFields = [structuredOutputConfig.readyToEndField];
+    let respondRequired = false;
     if (
       stage?.kind === StageKind.PRIVATE_CHAT &&
       (stage as PrivateChatStageConfig).isTurnBasedChatGroupStyle === true
     ) {
       dropFields.push(structuredOutputConfig.shouldRespondField);
+      respondRequired = true;
     }
+    const remainingProperties = structuredOutputConfig.schema.properties.filter(
+      (prop) => !dropFields.includes(prop.name),
+    );
     structuredOutputConfig = {
       ...structuredOutputConfig,
       schema: {
         ...structuredOutputConfig.schema,
-        properties: structuredOutputConfig.schema.properties.filter(
-          (prop) => !dropFields.includes(prop.name),
-        ),
+        properties: respondRequired
+          ? rewriteDescriptionsForRequiredResponse(
+              remainingProperties,
+              userProfile.type === UserType.MEDIATOR,
+            )
+          : remainingProperties,
       },
     };
   }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -360,6 +360,7 @@ class PrivateChatStageConfig(BaseModel):
     minNumberOfTurns: float | None = None
     maxNumberOfTurns: float | None = None
     preventCancellation: bool | None = None
+    preventAgentEnd: bool | None = None
 
 
 class ProfileType(StrEnum):
@@ -979,6 +980,7 @@ class ChatStageConfig(BaseModel):
     timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
     isTurnBased: bool | None = None
+    preventAgentEnd: bool | None = None
 
 
 class RankingStageConfig(

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -27,6 +27,9 @@ export interface ChatStageConfig extends BaseStageConfig {
   timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
   timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
   isTurnBased?: boolean; // Whether the conversation is turn-based
+  // If true, agent participants cannot end the chat by setting readyToEndChat
+  // in their structured output. The backend ignores the field for agents.
+  preventAgentEnd?: boolean;
 }
 
 /** Chat discussion. */
@@ -120,6 +123,7 @@ export function createChatStage(
     timeLimitInMinutes: config.timeLimitInMinutes ?? null,
     timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
     isTurnBased: config.isTurnBased ?? false,
+    preventAgentEnd: config.preventAgentEnd ?? false,
   };
 }
 

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -70,6 +70,7 @@ export const ChatStageConfigData = Type.Composite(
         ),
         discussions: Type.Array(ChatDiscussionData),
         isTurnBased: Type.Optional(Type.Boolean()),
+        preventAgentEnd: Type.Optional(Type.Boolean()),
       },
       strict,
     ),

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -42,6 +42,9 @@ export interface PrivateChatStageConfig extends BaseStageConfig {
   // If true, prevents participants from cancelling pending requests
   // while waiting for a response (to prevent gaming minimum message counts)
   preventCancellation: boolean;
+  // If true, agents in this chat are not asked whether to respond or end
+  // the chat: they always reply, and end-chat signals are ignored.
+  preventAgentEnd?: boolean;
 }
 
 // ************************************************************************* //
@@ -64,5 +67,6 @@ export function createPrivateChatStage(
     minNumberOfTurns: config.minNumberOfTurns ?? 0,
     maxNumberOfTurns: config.maxNumberOfTurns ?? null,
     preventCancellation: config.preventCancellation ?? false,
+    preventAgentEnd: config.preventAgentEnd ?? false,
   };
 }

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -38,6 +38,7 @@ export const PrivateChatStageConfigData = Type.Composite(
         // If true, prevents participants from cancelling pending requests
         // while waiting for a response (to prevent gaming minimum message counts)
         preventCancellation: Type.Optional(Type.Boolean()),
+        preventAgentEnd: Type.Optional(Type.Boolean()),
       },
       strict,
     ),

--- a/utils/src/structured_output.ts
+++ b/utils/src/structured_output.ts
@@ -19,6 +19,46 @@ export enum StructuredOutputDataType {
   ENUM = 'ENUM',
 }
 
+const OPTIONAL_RESPONSE_DESCRIPTION =
+  'Your chat message (empty if you prefer to stay silent).';
+const REQUIRED_RESPONSE_DESCRIPTION = 'Your chat message.';
+const OPTIONAL_EXPLANATION_DESCRIPTION =
+  '1-2 sentences explaining why you are sending this message, or why you are staying silent, based on your persona and the chat context.';
+const REQUIRED_EXPLANATION_DESCRIPTION =
+  '1-2 sentences explaining why you are sending this message, based on your persona and the chat context.';
+const REQUIRED_EXPLANATION_MEDIATOR_DESCRIPTION =
+  '1-2 sentences explaining why you are sending this message, based on the chat context.';
+
+/**
+ * Rewords the default explanation and response descriptions once the respond
+ * decision is stripped and a response is required; custom text is unchanged.
+ */
+export function rewriteDescriptionsForRequiredResponse(
+  properties: {name: string; schema: StructuredOutputSchema}[],
+  isMediator: boolean,
+): {name: string; schema: StructuredOutputSchema}[] {
+  return properties.map((prop) => {
+    if (prop.schema.description === OPTIONAL_RESPONSE_DESCRIPTION) {
+      return {
+        ...prop,
+        schema: {...prop.schema, description: REQUIRED_RESPONSE_DESCRIPTION},
+      };
+    }
+    if (prop.schema.description === OPTIONAL_EXPLANATION_DESCRIPTION) {
+      return {
+        ...prop,
+        schema: {
+          ...prop.schema,
+          description: isMediator
+            ? REQUIRED_EXPLANATION_MEDIATOR_DESCRIPTION
+            : REQUIRED_EXPLANATION_DESCRIPTION,
+        },
+      };
+    }
+    return prop;
+  });
+}
+
 export interface StructuredOutputSchema {
   type: StructuredOutputDataType;
   description?: string;
@@ -127,8 +167,7 @@ export function createStructuredOutputConfig(
         name: DEFAULT_EXPLANATION_FIELD,
         schema: {
           type: StructuredOutputDataType.STRING,
-          description:
-            '1-2 sentences explaining why you are sending this message, or why you are staying silent, based on your persona and the chat context.',
+          description: OPTIONAL_EXPLANATION_DESCRIPTION,
         },
       },
       {
@@ -143,8 +182,7 @@ export function createStructuredOutputConfig(
         name: DEFAULT_RESPONSE_FIELD,
         schema: {
           type: StructuredOutputDataType.STRING,
-          description:
-            'Your chat message (empty if you prefer to stay silent).',
+          description: OPTIONAL_RESPONSE_DESCRIPTION,
         },
       },
       {


### PR DESCRIPTION
# Description

This setting prevents LLM agents from ending the chat. When on, agents are not asked for `readyToEndChat` (the field is dropped from their structured output), and the backend ignores it if a model returns it anyway. In a turn-based private chat, the agent is also not asked for `shouldRespond` because responding `false` to that would end the chat.

# Manual testing as per template

Set up an experiment with (i) a chat stage with `Prevent agents from ending chat` checked and (ii) an agent mediator. Ask the mediator to end the chat (e.g., "We are done now. Please end the chat.").

- 1 human participant
- No agent participants
- Expected behavior: The chat does not end, and the API log for the mediator message shows no `readyToEndChat` field.