### PR TITLE
fix: ends study if the API reaches a timeout in turn-based mode

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -735,6 +735,10 @@
         },
         "isTurnBased": {
           "type": "boolean"
+        },
+        "agentTimeoutSeconds": {
+          "minimum": 1,
+          "type": "integer"
         }
       }
     },
@@ -1371,6 +1375,10 @@
         },
         "preventCancellation": {
           "type": "boolean"
+        },
+        "agentTimeoutSeconds": {
+          "minimum": 1,
+          "type": "integer"
         }
       }
     },
@@ -4341,6 +4349,12 @@
                   "items": {
                     "$ref": "#/$defs/CohortDefinition"
                   }
+                },
+                "timeoutMessageLimit": {
+                  "type": ["number", "null"]
+                },
+                "useNeutralTimeoutResponses": {
+                  "type": "boolean"
                 }
               },
               "title": "Experiment"

--- a/frontend/src/components/participant_view/participant_view.scss
+++ b/frontend/src/components/participant_view/participant_view.scss
@@ -13,6 +13,10 @@
   flex-grow: 1;
   max-height: calc(100vh - common.$header-height);
   overflow: auto;
+  // Positioning context for the API-failure overlay (position:absolute;
+  // inset:0): it fills this pane, which is the full viewport in the
+  // participant view and only the preview pane in the experimenter view.
+  position: relative;
 
   &.full-view {
     max-height: 100vh;

--- a/frontend/src/components/participant_view/participant_view.ts
+++ b/frontend/src/components/participant_view/participant_view.ts
@@ -1,4 +1,5 @@
 import '../popup/accept_transfer_popup';
+import '../popup/api_failure_popup';
 import '../popup/attention_check_popup';
 import '../popup/booted_popup';
 import '../progress/progress_stage_waiting';
@@ -123,7 +124,7 @@ export class ParticipantView extends MobxLitElement {
           ? 'full-view'
           : ''}"
       >
-        ${renderContent()}
+        ${renderContent()} ${this.renderApiFailurePopup()}
       </div>
       ${this.participantService.showHelpPanel
         ? html`<help-panel></help-panel>`
@@ -137,6 +138,31 @@ export class ParticipantView extends MobxLitElement {
       ${this.renderTransferPopup()} ${this.renderAttentionPopup()}
       ${this.renderBootedPopup()}
     `;
+  }
+
+  private renderApiFailurePopup() {
+    // Blocking overlay whenever the viewed participant is in API_FAILURE,
+    // in the participant view and the experimenter preview alike.
+    if (
+      this.participantService.profile?.currentStatus !==
+      ParticipantStatus.API_FAILURE
+    ) {
+      return nothing;
+    }
+    // When the last stage is named "Debrief", show its text in the pop-up
+    // (descriptions.infoText when set, else descriptions.primaryText).
+    const stageIds = this.experimentService.stageIds;
+    const lastStage = this.experimentService.getStage(
+      stageIds[stageIds.length - 1] ?? '',
+    );
+    const debriefText =
+      lastStage?.name?.trim().toLowerCase() === 'debrief'
+        ? lastStage.descriptions?.infoText?.trim() ||
+          (lastStage.descriptions?.primaryText ?? '')
+        : '';
+    return html`<api-failure-popup
+      .debriefText=${debriefText}
+    ></api-failure-popup>`;
   }
 
   private renderLanding() {

--- a/frontend/src/components/popup/api_failure_popup.ts
+++ b/frontend/src/components/popup/api_failure_popup.ts
@@ -1,0 +1,46 @@
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './popup.scss';
+
+/**
+ * Blocking pop-up shown when a turn-based chat agent's model call fails to
+ * return within the stage's response deadline. Tells the participant the
+ * error was recorded and compensation is unaffected, and shows the study's
+ * debrief when the experiment's last stage is named "Debrief".
+ */
+@customElement('api-failure-popup')
+class ApiFailurePopup extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  // Markdown of the experiment's debrief stage (empty = no debrief to show).
+  @property() debriefText = '';
+
+  render() {
+    return html`
+      <div class="overlay">
+        <div class="popup constrained">
+          <div class="title">
+            The chatbot is not currently working due to technical issues. The
+            error has been recorded, and you will receive full compensation for
+            the study. You can exit the study and return to the platform (e.g.,
+            Prolific).
+          </div>
+          ${this.debriefText
+            ? html`<div class="body">
+                ${unsafeHTML(convertMarkdownToHTML(this.debriefText))}
+              </div>`
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-failure-popup': ApiFailurePopup;
+  }
+}

--- a/frontend/src/components/popup/api_failure_popup.ts
+++ b/frontend/src/components/popup/api_failure_popup.ts
@@ -8,7 +8,7 @@ import {styles} from './popup.scss';
 /**
  * Blocking pop-up shown when a turn-based chat agent's model call fails to
  * return within the stage's response deadline. Tells the participant the
- * error was recorded and compensation is unaffected, and shows the study's
+ * error was recorded and they will be compensated, and shows the study's
  * debrief when the experiment's last stage is named "Debrief".
  */
 @customElement('api-failure-popup')
@@ -24,9 +24,8 @@ class ApiFailurePopup extends MobxLitElement {
         <div class="popup constrained">
           <div class="title">
             The chatbot is not currently working due to technical issues. The
-            error has been recorded, and you will receive full compensation for
-            the study. You can exit the study and return to the platform (e.g.,
-            Prolific).
+            error has been recorded, and you will be compensated for your time.
+            You can exit the study and return to the platform (e.g., Prolific).
           </div>
           ${this.debriefText
             ? html`<div class="body">

--- a/frontend/src/components/popup/popup.scss
+++ b/frontend/src/components/popup/popup.scss
@@ -56,3 +56,14 @@
   font-style: italic;
   margin: 0;
 }
+
+.popup.constrained {
+  max-width: min(640px, 90vw);
+  width: auto;
+}
+
+.body {
+  @include typescale.body-medium;
+  max-height: 50vh;
+  overflow-y: auto;
+}

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -9,7 +9,10 @@ import {AuthService} from '../../services/auth.service';
 
 import {ExperimentEditor} from '../../services/experiment.editor';
 
-import {ChatStageConfig} from '@deliberation-lab/utils';
+import {
+  ChatStageConfig,
+  DEFAULT_AGENT_TIMEOUT_SECONDS,
+} from '@deliberation-lab/utils';
 
 import {styles} from './group_chat_editor.scss';
 
@@ -62,6 +65,40 @@ export class ChatEditor extends MobxLitElement {
             beginning with the mediators if at least one is present.
           </div>
         </div>
+        ${this.renderAgentTimeout()}
+      </div>
+    `;
+  }
+
+  private renderAgentTimeout() {
+    if (!this.stage?.isTurnBased) return nothing;
+
+    const updateTimeout = (e: InputEvent) => {
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      this.experimentEditor.updateStage({
+        ...this.stage!,
+        agentTimeoutSeconds:
+          val > 0 ? Math.floor(val) : DEFAULT_AGENT_TIMEOUT_SECONDS,
+      });
+    };
+
+    return html`
+      <div class="number-input tab">
+        <label for="agentTimeout">
+          Agent response timeout in seconds. If an agent's response does not
+          arrive in time, the participant is shown an error pop-up and the
+          study's debrief.
+        </label>
+        <input
+          type="number"
+          id="agentTimeout"
+          name="agentTimeout"
+          min="1"
+          .value=${this.stage?.agentTimeoutSeconds ??
+          DEFAULT_AGENT_TIMEOUT_SECONDS}
+          ?disabled=${!this.experimentEditor.canEditStages}
+          @input=${updateTimeout}
+        />
       </div>
     `;
   }

--- a/frontend/src/components/stages/group_chat_participant_view.scss
+++ b/frontend/src/components/stages/group_chat_participant_view.scss
@@ -3,6 +3,41 @@
 
 :host {
   @include common.flex-column;
+  // Containing block for the absolutely positioned overlay below.
+  position: relative;
+}
+
+.response-timeout-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: common.$spacing-xl;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.response-timeout-dialog {
+  @include common.flex-column;
+  gap: common.$spacing-medium;
+  max-width: 420px;
+  padding: common.$spacing-xl;
+  border-radius: common.$spacing-medium;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.response-timeout-title {
+  @include typescale.title-medium;
+  color: var(--md-sys-color-error);
+  font-weight: 600;
+}
+
+.response-timeout-body {
+  @include typescale.body-medium;
 }
 
 chat-interface {

--- a/frontend/src/components/stages/private_chat_participant_view.ts
+++ b/frontend/src/components/stages/private_chat_participant_view.ts
@@ -81,6 +81,13 @@ export class PrivateChatView extends MobxLitElement {
       chatMessages[chatMessages.length - 1].senderId === publicId &&
       !this.responseTimeout.timedOut;
 
+    // True once the participant's last message has gone unanswered past the
+    // response timeout.
+    const hasTimedOut =
+      chatMessages.length > 0 &&
+      chatMessages[chatMessages.length - 1].senderId === publicId &&
+      this.responseTimeout.timedOut;
+
     // Check if max number of turns reached (but only after response received)
     const maxTurnsReached =
       this.stage.maxNumberOfTurns !== null &&
@@ -114,7 +121,7 @@ export class PrivateChatView extends MobxLitElement {
     // Disable input if turn-taking is set and latest message
     // is from participant OR if conversation is over
     const isDisabledInput = () => {
-      if (isConversationOver) {
+      if (hasTimedOut || isConversationOver) {
         return true;
       }
       if (!this.stage?.isTurnBasedChat) {
@@ -159,6 +166,24 @@ export class PrivateChatView extends MobxLitElement {
           ? this.renderMinTimeMessage(elapsedMinutes)
           : nothing}
       </stage-footer>
+      ${hasTimedOut ? this.renderResponseTimeoutOverlay() : nothing}
+    `;
+  }
+
+  // Blocking overlay shown when the response timeout is reached.
+  private renderResponseTimeoutOverlay() {
+    return html`
+      <div class="response-timeout-overlay">
+        <div class="response-timeout-dialog">
+          <div class="response-timeout-title">
+            The chatbot message failed after trying for 2 minutes.
+          </div>
+          <div class="response-timeout-body">
+            Something went wrong and the discussion cannot continue. Please
+            restart the study or contact the researcher.
+          </div>
+        </div>
+      </div>
     `;
   }
 

--- a/frontend/src/shared/callables.ts
+++ b/frontend/src/shared/callables.ts
@@ -278,13 +278,12 @@ export const updateParticipantToNextStageCallable = async (
   functions: Functions,
   config: BaseParticipantData,
 ) => {
+  // Entering a turn-based stage generates the opening agent messages before
+  // the call returns, so allow the backend's full response deadline.
   const {data} = await httpsCallable<
     BaseParticipantData,
     ParticipantNextStageResponse
-  >(
-    functions,
-    'updateParticipantToNextStage',
-  )(config);
+  >(functions, 'updateParticipantToNextStage', {timeout: 300_000})(config);
   return data;
 };
 
@@ -359,9 +358,11 @@ export const acceptParticipantExperimentStartCallable = async (
   functions: Functions,
   config: BaseParticipantData,
 ) => {
+  // The first stage can be turn-based, generating agent messages inline.
   const {data} = await httpsCallable<BaseParticipantData, SuccessResponse>(
     functions,
     'acceptParticipantExperimentStart',
+    {timeout: 300_000},
   )(config);
   return data;
 };

--- a/functions/src/agent.utils.test.ts
+++ b/functions/src/agent.utils.test.ts
@@ -1,0 +1,135 @@
+import {ModelResponse, ModelResponseStatus} from '@deliberation-lab/utils';
+
+jest.mock('firebase-admin/firestore', () => ({
+  Timestamp: {now: () => ({seconds: 0, nanoseconds: 0})},
+}));
+jest.mock('./log.utils', () => ({
+  writeModelLogEntry: jest.fn(),
+  formatPromptForLog: jest.fn(() => 'prompt'),
+}));
+jest.mock('./api/ai-sdk.api', () => ({
+  generateAIResponse: jest.fn(),
+}));
+
+import {processModelResponse} from './agent.utils';
+import {generateAIResponse} from './api/ai-sdk.api';
+
+const mockCall = generateAIResponse as jest.Mock;
+
+// Tracks how many mocked calls are in flight at once (concurrency), and resolves
+// each call after a scripted delay with a scripted response.
+let inFlight = 0;
+let maxInFlight = 0;
+
+function script(entries: Array<{delayMs: number; response: ModelResponse}>) {
+  let i = 0;
+  mockCall.mockImplementation(() => {
+    const entry = entries[Math.min(i, entries.length - 1)];
+    i++;
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    return new Promise<ModelResponse>((resolve) => {
+      setTimeout(() => {
+        inFlight--;
+        resolve(entry.response);
+      }, entry.delayMs);
+    });
+  });
+}
+
+const ok = (text: string): ModelResponse => ({
+  status: ModelResponseStatus.OK,
+  text,
+});
+const err = (): ModelResponse => ({
+  status: ModelResponseStatus.UNKNOWN_ERROR,
+  errorMessage: 'boom',
+});
+
+function run(numRetries: number | null, maxRetryDurationMs: number | null) {
+  return processModelResponse(
+    'exp',
+    'cohort',
+    'pid',
+    'stage',
+    {} as never,
+    'public',
+    'private',
+    '',
+    {} as never,
+    'prompt',
+    {} as never,
+    {} as never,
+    undefined,
+    numRetries,
+    maxRetryDurationMs,
+  );
+}
+
+describe('processModelResponse', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    inFlight = 0;
+    maxInFlight = 0;
+    mockCall.mockReset();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('turn-based (hedged)', () => {
+    it('returns a fast response without hedging', async () => {
+      script([{delayMs: 5000, response: ok('fast')}]);
+      const p = run(null, 120000);
+      await jest.advanceTimersByTimeAsync(5000);
+      const {response, retryTimedOut} = await p;
+      expect(response.text).toBe('fast');
+      expect(retryTimedOut).toBe(false);
+      expect(mockCall).toHaveBeenCalledTimes(1);
+      expect(maxInFlight).toBe(1);
+    });
+
+    it('keeps the first call in flight and takes whichever resolves first', async () => {
+      // First call resolves at 40s (10s after the 30s window starts the 2nd).
+      script([
+        {delayMs: 40000, response: ok('first')},
+        {delayMs: 40000, response: ok('second')},
+      ]);
+      const p = run(null, 120000);
+      await jest.advanceTimersByTimeAsync(30000); // window elapses -> 2nd starts
+      expect(mockCall).toHaveBeenCalledTimes(2);
+      expect(maxInFlight).toBe(2); // both in flight (first not abandoned)
+      await jest.advanceTimersByTimeAsync(10000); // first resolves at 40s
+      const {response, retryTimedOut} = await p;
+      expect(response.text).toBe('first');
+      expect(retryTimedOut).toBe(false);
+    });
+
+    it('times out at the overall deadline when nothing resolves in time', async () => {
+      script([{delayMs: 1000000, response: ok('never')}]);
+      const p = run(null, 120000);
+      await jest.advanceTimersByTimeAsync(120000);
+      const {retryTimedOut} = await p;
+      expect(retryTimedOut).toBe(true);
+    });
+  });
+
+  describe('non-turn-based (sequential, unaffected)', () => {
+    it('retries sequentially with no overlapping calls', async () => {
+      script([
+        {delayMs: 1000, response: err()},
+        {delayMs: 1000, response: err()},
+        {delayMs: 1000, response: ok('done')},
+      ]);
+      const p = run(2, null);
+      // Flush the calls and the exponential inter-attempt backoff.
+      for (let i = 0; i < 20; i++) {
+        await jest.advanceTimersByTimeAsync(1000);
+      }
+      const {response} = await p;
+      expect(response.text).toBe('done');
+      expect(mockCall).toHaveBeenCalledTimes(3);
+      expect(maxInFlight).toBe(1); // never hedges: at most one call at a time
+    });
+  });
+});

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -20,13 +20,35 @@ class RetryTimeoutError extends Error {
   }
 }
 
+/**
+ * A single model call exceeded the per-attempt timeout. Unlike
+ * RetryTimeoutError (the overall deadline, which gives up), this is
+ * retryable, so one hung call is retried within the budget instead of
+ * consuming all of it.
+ */
+class AttemptTimeoutError extends Error {
+  constructor() {
+    super('Model call exceeded per-attempt timeout');
+    this.name = 'AttemptTimeoutError';
+  }
+}
+
+// Per-attempt timeout for turn-based model calls. Sized so roughly six
+// attempts fit the overall turn-based deadline while still giving a single
+// call enough time to return.
+const TURN_BASED_PER_ATTEMPT_TIMEOUT_MS = 30000;
+// Max times an OK-but-rejected (e.g. empty) response is re-rolled before giving
+// up, so a persistently empty response can't loop until the overall deadline.
+const MAX_EMPTY_RETRIES = 2;
+
 async function withRetryTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
+  makeError: () => Error = () => new RetryTimeoutError(),
 ): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<T>((_, reject) => {
-    timeout = setTimeout(() => reject(new RetryTimeoutError()), timeoutMs);
+    timeout = setTimeout(() => reject(makeError()), timeoutMs);
   });
 
   return Promise.race([promise, timeoutPromise]).finally(() => {
@@ -51,6 +73,12 @@ export async function processModelResponse(
   structuredOutputConfig?: StructuredOutputConfig,
   numRetries: number | null = 0,
   maxRetryDurationMs: number | null = null,
+  // Optional gate: when provided, an OK response for which this returns false is
+  // treated like a (retryable) API failure rather than a usable result. Used in
+  // must-respond contexts (e.g. turn-based group chat, where it is always the
+  // agent's turn) to reject empty/contentless responses so the agent retries
+  // instead of ever emitting an empty message.
+  isResponseAcceptable?: (response: ModelResponse) => boolean,
 ): Promise<{
   response: ModelResponse;
   logId: string;
@@ -59,6 +87,7 @@ export async function processModelResponse(
   let response = {status: ModelResponseStatus.NONE};
   let lastError: Error | undefined;
   let retryTimedOut = false;
+  let emptyRetries = 0;
   const maxRetries = numRetries;
   const initialDelay = 1000; // 1 second initial delay
   let logId = '';
@@ -71,6 +100,7 @@ export async function processModelResponse(
     maxRetries === null || attempt <= maxRetries;
     attempt++
   ) {
+    let responseRejected = false;
     // Create a new log entry for each attempt
     const log = createModelLogEntry({
       experimentId,
@@ -105,14 +135,41 @@ export async function processModelResponse(
         generationConfig,
         structuredOutputConfig,
       );
-      response = (await (remainingRetryMs === null
-        ? request
-        : withRetryTimeout(request, remainingRetryMs))) as ModelResponse;
+      // Turn-based calls cap each attempt (a retryable AttemptTimeoutError)
+      // so a single hung call is retried within the overall deadline.
+      // Non-turn-based calls are bounded only by an overall retry deadline
+      // when one was given (RetryTimeoutError on timeout) and are otherwise
+      // uncapped, with no per-attempt timeout.
+      if (maxRetries === null) {
+        const cap =
+          remainingRetryMs === null
+            ? TURN_BASED_PER_ATTEMPT_TIMEOUT_MS
+            : Math.min(remainingRetryMs, TURN_BASED_PER_ATTEMPT_TIMEOUT_MS);
+        response = (await withRetryTimeout(
+          request,
+          cap,
+          () => new AttemptTimeoutError(),
+        )) as ModelResponse;
+      } else {
+        response = (await (remainingRetryMs === null
+          ? request
+          : withRetryTimeout(request, remainingRetryMs))) as ModelResponse;
+      }
       const responseTimestamp = Timestamp.now();
 
       log.response = response;
       log.queryTimestamp = queryTimestamp;
       log.responseTimestamp = responseTimestamp;
+
+      // A successful API call can still be unusable (e.g. empty content when
+      // the caller requires a real message): treat it like a failure and retry.
+      if (
+        response.status === ModelResponseStatus.OK &&
+        isResponseAcceptable &&
+        !isResponseAcceptable(response)
+      ) {
+        responseRejected = true;
+      }
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       console.log(error);
@@ -127,21 +184,48 @@ export async function processModelResponse(
       };
       log.queryTimestamp = Timestamp.now();
       log.responseTimestamp = Timestamp.now();
+
+      // A per-attempt timeout is retryable: reflect a retryable status on
+      // `response` (which the retry check below reads) so the agent re-rolls
+      // within the overall deadline. A thrown error otherwise leaves `response`
+      // as the non-retryable NONE, which would give up after one attempt and
+      // stall the turn (it is not a RetryTimeoutError, so the caller will not
+      // skip it). On the eventual deadline a RetryTimeoutError ends and
+      // skips.
+      if (error instanceof AttemptTimeoutError) {
+        response = {status: ModelResponseStatus.UNKNOWN_ERROR};
+      }
     }
 
     // Write log entry for every attempt
     writeModelLogEntry(experimentId, log);
 
     // Check if we should retry
+    // In turn-based mode a give-up stalls the whole turn cycle instead of
+    // just skipping one speaker, so also retry errors that can differ on a
+    // re-roll (safety refusals, length caps, unparseable output, rate-limited
+    // quota) until they succeed or the deadline is reached. A bad key or
+    // invalid config is deterministic, so those still fail fast.
+    const turnBasedRetryableStatus =
+      maxRetries === null &&
+      (response.status === ModelResponseStatus.REFUSAL_ERROR ||
+        response.status === ModelResponseStatus.LENGTH_ERROR ||
+        response.status === ModelResponseStatus.STRUCTURED_OUTPUT_PARSE_ERROR ||
+        response.status === ModelResponseStatus.QUOTA_ERROR);
     const shouldRetry =
       !retryTimedOut &&
       (maxRetries === null || attempt < maxRetries) &&
-      (response.status === ModelResponseStatus.PROVIDER_UNAVAILABLE_ERROR ||
+      ((responseRejected && emptyRetries < MAX_EMPTY_RETRIES) ||
+        response.status === ModelResponseStatus.PROVIDER_UNAVAILABLE_ERROR ||
         response.status === ModelResponseStatus.INTERNAL_ERROR ||
-        response.status === ModelResponseStatus.UNKNOWN_ERROR);
+        response.status === ModelResponseStatus.UNKNOWN_ERROR ||
+        turnBasedRetryableStatus);
 
     if (shouldRetry) {
-      const baseDelay = initialDelay * Math.pow(2, attempt);
+      if (responseRejected) emptyRetries++;
+      // No inter-attempt delay for turn-based retries.
+      const baseDelay =
+        maxRetries === null ? 0 : initialDelay * Math.pow(2, attempt);
       // Clamp to remaining budget so the next attempt fires before the deadline.
       const delay =
         maxRetryDurationMs === null
@@ -156,7 +240,9 @@ export async function processModelResponse(
       const retryCount =
         maxRetries === null ? `${attempt + 1}` : `${attempt + 1}/${maxRetries}`;
       console.log(
-        `API error (${response.status}), retrying after ${delay}ms (attempt ${retryCount})`,
+        responseRejected
+          ? `Empty/unacceptable response, retrying after ${delay}ms (attempt ${retryCount})`
+          : `API error (${response.status}), retrying after ${delay}ms (attempt ${retryCount})`,
       );
       await new Promise((resolve) => setTimeout(resolve, delay));
     } else {

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -26,17 +26,13 @@ class RetryTimeoutError extends Error {
  * retryable, so one hung call is retried within the budget instead of
  * consuming all of it.
  */
-class AttemptTimeoutError extends Error {
-  constructor() {
-    super('Model call exceeded per-attempt timeout');
-    this.name = 'AttemptTimeoutError';
-  }
-}
-
-// Per-attempt timeout for turn-based model calls. Sized so roughly six
-// attempts fit the overall turn-based deadline while still giving a single
-// call enough time to return.
+// Per-attempt window for a turn-based model call. If a call is still pending
+// after this, another is hedged alongside it, bounded by the overall deadline.
 const TURN_BASED_PER_ATTEMPT_TIMEOUT_MS = 30000;
+// Minimum time between successive turn-based calls, so a rejected call is
+// re-issued no sooner than this after the prior one was sent instead of
+// immediately. Lets a rate-limited quota recover within the deadline.
+const TURN_BASED_MIN_RETRY_INTERVAL_MS = 1000;
 // Max times an OK-but-rejected (e.g. empty) response is re-rolled before giving
 // up, so a persistently empty response can't loop until the overall deadline.
 const MAX_EMPTY_RETRIES = 2;
@@ -95,6 +91,160 @@ export async function processModelResponse(
 
   // Convert prompt to string for logging (reused across retries)
   const promptForLog = formatPromptForLog(prompt);
+
+  // Turn-based path: hedge instead of abandoning a slow call. When the
+  // per-attempt window elapses without an acceptable response, start another
+  // request but keep the earlier ones in flight, and take whichever returns an
+  // acceptable response first. Cuts the occasional long tail where one call is
+  // merely slow. Bounded by the overall retry deadline.
+  if (maxRetries === null) {
+    interface Hedge {
+      logId: string;
+      settled: boolean;
+      consumed: boolean;
+      response?: ModelResponse;
+      promise: Promise<void>;
+    }
+    const hedges: Hedge[] = [];
+    let lastLogId = '';
+    let lastResponse: ModelResponse = {status: ModelResponseStatus.NONE};
+    // When the most recent call was sent, to space out re-issued calls.
+    let lastHedgeSentMs = 0;
+
+    const startHedge = () => {
+      const index = hedges.length;
+      const log = createModelLogEntry({
+        experimentId,
+        cohortId,
+        participantId,
+        stageId,
+        userProfile,
+        publicId,
+        privateId,
+        description:
+          index > 0 ? `${description} (hedge ${index})` : description,
+        prompt: promptForLog,
+        createdTimestamp: Timestamp.now(),
+      });
+      lastLogId = log.id;
+      const queryTimestamp = Timestamp.now();
+      lastHedgeSentMs = Date.now();
+      const hedge: Hedge = {
+        logId: log.id,
+        settled: false,
+        consumed: false,
+      } as Hedge;
+      hedge.promise = (async () => {
+        try {
+          const response = (await getAgentResponse(
+            apiKeyConfig,
+            prompt,
+            modelSettings,
+            generationConfig,
+            structuredOutputConfig,
+          )) as ModelResponse;
+          log.response = response;
+          log.queryTimestamp = queryTimestamp;
+          log.responseTimestamp = Timestamp.now();
+          hedge.response = response;
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          console.log(err);
+          log.response = {
+            status: ModelResponseStatus.UNKNOWN_ERROR,
+            errorMessage: err.message,
+          };
+          log.queryTimestamp = queryTimestamp;
+          log.responseTimestamp = Timestamp.now();
+          hedge.response = {
+            status: ModelResponseStatus.UNKNOWN_ERROR,
+            errorMessage: err.message,
+          };
+        } finally {
+          writeModelLogEntry(experimentId, log);
+          hedge.settled = true;
+        }
+      })();
+      hedges.push(hedge);
+    };
+
+    const isAcceptable = (r: ModelResponse) =>
+      r.status === ModelResponseStatus.OK &&
+      (!isResponseAcceptable || isResponseAcceptable(r));
+    // Deterministic, non-retryable statuses (e.g. bad key, invalid config):
+    // hedging cannot help, so return immediately.
+    const isRetryable = (r: ModelResponse) =>
+      r.status === ModelResponseStatus.PROVIDER_UNAVAILABLE_ERROR ||
+      r.status === ModelResponseStatus.INTERNAL_ERROR ||
+      r.status === ModelResponseStatus.UNKNOWN_ERROR ||
+      r.status === ModelResponseStatus.REFUSAL_ERROR ||
+      r.status === ModelResponseStatus.LENGTH_ERROR ||
+      r.status === ModelResponseStatus.STRUCTURED_OUTPUT_PARSE_ERROR ||
+      r.status === ModelResponseStatus.QUOTA_ERROR;
+
+    startHedge();
+    for (;;) {
+      const remaining =
+        maxRetryDurationMs === null
+          ? TURN_BASED_PER_ATTEMPT_TIMEOUT_MS
+          : maxRetryDurationMs - (Date.now() - retryStartMs);
+      if (remaining <= 0) {
+        return {response: lastResponse, logId: lastLogId, retryTimedOut: true};
+      }
+      const windowMs = Math.min(remaining, TURN_BASED_PER_ATTEMPT_TIMEOUT_MS);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const windowElapsed = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, windowMs);
+      });
+      const pending = hedges.filter((h) => !h.settled).map((h) => h.promise);
+      await Promise.race(
+        pending.length
+          ? [Promise.race(pending), windowElapsed]
+          : [windowElapsed],
+      );
+      if (timer) clearTimeout(timer);
+
+      for (const hedge of hedges) {
+        if (hedge.settled && !hedge.consumed) {
+          hedge.consumed = true;
+          lastResponse = hedge.response as ModelResponse;
+          if (isAcceptable(lastResponse) || !isRetryable(lastResponse)) {
+            return {
+              response: lastResponse,
+              logId: hedge.logId,
+              retryTimedOut: false,
+            };
+          }
+        }
+      }
+
+      const budgetLeft =
+        maxRetryDurationMs === null
+          ? true
+          : maxRetryDurationMs - (Date.now() - retryStartMs) > 0;
+      if (budgetLeft) {
+        // Hold off until the minimum interval since the last call has passed.
+        // A slow call already outlasts this, so only fast failures wait here.
+        const sinceLastSent = Date.now() - lastHedgeSentMs;
+        if (sinceLastSent < TURN_BASED_MIN_RETRY_INTERVAL_MS) {
+          await new Promise((resolve) =>
+            setTimeout(
+              resolve,
+              TURN_BASED_MIN_RETRY_INTERVAL_MS - sinceLastSent,
+            ),
+          );
+        }
+        startHedge();
+      } else if (hedges.every((h) => h.settled)) {
+        // Budget exhausted (the deadline was reached while the last call was in
+        // flight) with nothing acceptable: report a timeout, like the deadline
+        // check above, so the caller posts the timeout message rather than the
+        // pop-up meant for unrecoverable errors.
+        return {response: lastResponse, logId: lastLogId, retryTimedOut: true};
+      }
+    }
+  }
+
   for (
     let attempt = 0;
     maxRetries === null || attempt <= maxRetries;
@@ -135,26 +285,13 @@ export async function processModelResponse(
         generationConfig,
         structuredOutputConfig,
       );
-      // Turn-based calls cap each attempt (a retryable AttemptTimeoutError)
-      // so a single hung call is retried within the overall deadline.
-      // Non-turn-based calls are bounded only by an overall retry deadline
-      // when one was given (RetryTimeoutError on timeout) and are otherwise
-      // uncapped, with no per-attempt timeout.
-      if (maxRetries === null) {
-        const cap =
-          remainingRetryMs === null
-            ? TURN_BASED_PER_ATTEMPT_TIMEOUT_MS
-            : Math.min(remainingRetryMs, TURN_BASED_PER_ATTEMPT_TIMEOUT_MS);
-        response = (await withRetryTimeout(
-          request,
-          cap,
-          () => new AttemptTimeoutError(),
-        )) as ModelResponse;
-      } else {
-        response = (await (remainingRetryMs === null
-          ? request
-          : withRetryTimeout(request, remainingRetryMs))) as ModelResponse;
-      }
+      // This loop only runs for fixed-retry (non-turn-based) calls; the
+      // turn-based path is hedged above and returns before here. The call is
+      // bounded by an overall retry deadline when one was given, otherwise
+      // unbounded.
+      response = (await (remainingRetryMs === null
+        ? request
+        : withRetryTimeout(request, remainingRetryMs))) as ModelResponse;
       const responseTimestamp = Timestamp.now();
 
       log.response = response;
@@ -184,17 +321,6 @@ export async function processModelResponse(
       };
       log.queryTimestamp = Timestamp.now();
       log.responseTimestamp = Timestamp.now();
-
-      // A per-attempt timeout is retryable: reflect a retryable status on
-      // `response` (which the retry check below reads) so the agent re-rolls
-      // within the overall deadline. A thrown error otherwise leaves `response`
-      // as the non-retryable NONE, which would give up after one attempt and
-      // stall the turn (it is not a RetryTimeoutError, so the caller will not
-      // skip it). On the eventual deadline a RetryTimeoutError ends and
-      // skips.
-      if (error instanceof AttemptTimeoutError) {
-        response = {status: ModelResponseStatus.UNKNOWN_ERROR};
-      }
     }
 
     // Write log entry for every attempt

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -6,7 +6,9 @@ import {setGlobalOptions} from 'firebase-functions/v2';
 // This MUST be in this file (not index.ts) because the bundler resolves
 // dependency modules before executing index.ts top-level code.
 // Since all endpoint files import app.ts, this runs before any onCall() calls.
-setGlobalOptions({memory: '512MiB'});
+// Turn-based agent calls retry inside request handlers for up to the stage's
+// response deadline, so the execution limit must exceed it.
+setGlobalOptions({memory: '512MiB', timeoutSeconds: 300});
 
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -4,21 +4,26 @@ import {
   ChatMessage,
   ChatPromptConfig,
   ChatStageConfig,
+  DEFAULT_AGENT_TIMEOUT_SECONDS,
   ChatStagePublicData,
   extractChatMediatorStructuredFields,
   getStructuredOutput,
   MediatorProfileExtended,
   ModelResponseStatus,
   ParticipantProfileExtended,
+  ParticipantStatus,
   StageConfig,
   StageKind,
   UserType,
   awaitTypingDelay,
   createChatMessage,
+  NEUTRAL_TIMEOUT_RESPONSES,
+  TIMEOUT_ERROR_RESPONSE,
   createParticipantProfileBase,
   createSystemChatMessage,
   sanitizeRawResponseForLogging,
   shuffleWithSeed,
+  Experiment,
 } from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase-admin/firestore';
 import {processModelResponse} from '../agent.utils';
@@ -36,12 +41,14 @@ import {
 import {updateParticipantReadyToEndChat} from '../chat/chat.utils';
 import {
   getExperimenterDataFromExperiment,
+  getFirestoreExperiment,
   getFirestorePublicStageChatMessages,
   getFirestorePrivateChatMessages,
   getFirestoreStage,
   getFirestoreStagePublicData,
   getFirestoreActiveMediators,
   getFirestoreActiveParticipants,
+  getFirestoreParticipantRef,
   getGroupChatTriggerLogRef,
   getPrivateChatTriggerLogRef,
   getFirestoreParticipantAnswerRef,
@@ -56,9 +63,6 @@ import {updateModelLogFiles} from '../log.utils';
 // ****************************************************************************
 // Functions for preparing, querying, and organizing agent chat responses.
 // ****************************************************************************
-
-// 300s cloud function timeout minus 10s buffer for skip handler.
-const TURN_BASED_AGENT_RETRY_TIMEOUT_MS = 290000;
 
 /** Use persona chat prompt to create and send agent chat message. */
 export async function createAgentChatMessageFromPrompt(
@@ -100,173 +104,341 @@ export async function createAgentChatMessageFromPrompt(
   const isPrivateChat = stage.kind === StageKind.PRIVATE_CHAT;
   const isTurnBasedGroupChat =
     stage.kind === StageKind.CHAT && (stage as ChatStageConfig).isTurnBased;
+  // Group-style turn-based private chats retry transient model errors until
+  // the deadline too: the participant is blocked waiting on the mediator, so
+  // we mirror the group-chat turn-based behavior rather than erroring out.
+  const isTurnBasedPrivateChat =
+    stage.kind === StageKind.PRIVATE_CHAT &&
+    (stage as {isTurnBasedChatGroupStyle?: boolean}).isTurnBasedChatGroupStyle;
+  const agentTimeoutMs =
+    ((stage as {agentTimeoutSeconds?: number}).agentTimeoutSeconds ??
+      DEFAULT_AGENT_TIMEOUT_SECONDS) * 1000;
   const retryDeadlineMs =
     turnBasedRetryDeadlineMs ??
-    (isTurnBasedGroupChat
-      ? Date.now() + TURN_BASED_AGENT_RETRY_TIMEOUT_MS
+    (isTurnBasedGroupChat || isTurnBasedPrivateChat
+      ? Date.now() + agentTimeoutMs
       : undefined);
 
-  // Check if this is an initial message request (empty triggerChatId)
-  if (triggerChatId === '') {
-    // Check if we've already sent an initial message for this user
-
-    // Build the appropriate trigger log reference based on chat type
-    const triggerLogId = `initial-${user.publicId}`;
-    const triggerLogRef = isPrivateChat
-      ? getPrivateChatTriggerLogRef(
-          experimentId,
-          participantIds[0], // Use the first participant ID as the storage location
-          stageId,
-          triggerLogId,
-        )
-      : getGroupChatTriggerLogRef(
-          experimentId,
-          cohortId,
-          stageId,
-          triggerLogId,
-        );
-
-    const shouldSendInitialMessage = await app
-      .firestore()
-      .runTransaction(async (transaction) => {
-        const triggerLog = await transaction.get(triggerLogRef);
-        if (triggerLog.exists) return false;
-
-        transaction.create(triggerLogRef, {timestamp: Timestamp.now()});
-        return true;
-      });
-
-    if (!shouldSendInitialMessage) {
-      return false; // Already sent initial message
-    }
-  }
-
-  // Get the chat message (either initial or response)
-  let message: ChatMessage | null = null;
-
-  // For initial messages, check if there's a configured initial message
-  if (triggerChatId === '') {
-    const initialMessage = promptConfig.chatSettings?.initialMessage;
-    if (initialMessage && initialMessage.trim() !== '') {
-      // Resolve template variables in the initial message.
-      // Only use participant variables for private chats.
-      const resolvedMessage = await resolveStringWithVariables(
-        initialMessage,
-        experimentId,
-        cohortId,
-        isPrivateChat ? participantIds[0] : undefined,
-      );
-
-      message = createChatMessage({
-        message: resolvedMessage,
-        senderId: user.publicId,
-        type: user.type,
-        profile: createParticipantProfileBase(user),
-        timestamp: Timestamp.now(),
-      });
-    }
-  }
-
-  // If no configured initial message or this is a regular response, query the API
-  if (!message) {
-    const response = await getAgentChatMessage(
-      experimentId,
-      cohortId,
-      participantIds,
-      stage,
-      user,
-      promptConfig,
-      retryDeadlineMs,
-    );
-    message = response.message;
-    if (!message) {
-      if (isTurnBasedGroupChat && response.retryTimedOut) {
-        // Clean up the initial trigger log lock if it timed out and we are skipping the agent
-        if (triggerChatId === '') {
-          const triggerLogId = `initial-${user.publicId}`;
-          const triggerLogRef = getGroupChatTriggerLogRef(
-            experimentId,
-            cohortId,
-            stageId,
-            triggerLogId,
-          );
-          await triggerLogRef.delete();
-        }
-
-        await skipTimedOutTurnBasedAgentTurn(
-          experimentId,
-          cohortId,
-          stage,
-          triggerChatId,
-          user,
-        );
-        return true;
+  // An unexpected error on the turn-based path would otherwise kill the
+  // trigger silently (nothing re-fires it). Retry the pipeline until the
+  // stage's response deadline, like model errors; only once the deadline has
+  // elapsed fall through to the fallback message/pop-up.
+  const throwRetryDelayMs = 5000;
+  for (;;) {
+    try {
+      return await runAgentChatMessagePipeline();
+    } catch (error) {
+      if (!isTurnBasedGroupChat && !isTurnBasedPrivateChat) {
+        throw error;
       }
-
+      console.error(
+        `[chat.agent] Turn-based message pipeline failed for ${user.publicId}:`,
+        error,
+      );
+      // Release the initial-message lock so a retry can re-enter.
       if (triggerChatId === '') {
         const triggerLogId = `initial-${user.publicId}`;
-        console.log(
-          `[chat.agent] getAgentChatMessage failed for initial message. Deleting trigger log: ${triggerLogId}`,
-        );
-        const isTurnBased =
-          stage?.kind === StageKind.CHAT &&
-          (stage as ChatStageConfig).isTurnBased;
+        const triggerLogRef = isPrivateChat
+          ? getPrivateChatTriggerLogRef(
+              experimentId,
+              participantIds[0],
+              stageId,
+              triggerLogId,
+            )
+          : getGroupChatTriggerLogRef(
+              experimentId,
+              cohortId,
+              stageId,
+              triggerLogId,
+            );
+        await triggerLogRef.delete().catch(() => {});
+      }
+      if (retryDeadlineMs !== undefined && Date.now() < retryDeadlineMs) {
+        await new Promise((resolve) => setTimeout(resolve, throwRetryDelayMs));
+        continue;
+      }
+    }
+    break;
+  }
+  {
+    const outcome = await handleTurnBasedDeadEnd(
+      experimentId,
+      cohortId,
+      stage,
+      participantIds,
+      user,
+      triggerChatId,
+    );
+    if (outcome === null) {
+      return true;
+    }
+    if (stage.kind === StageKind.PRIVATE_CHAT) {
+      const privateChatParticipantId = participantIds[0];
+      if (!privateChatParticipantId) {
+        return false;
+      }
+      await sendAgentPrivateChatMessage(
+        experimentId,
+        privateChatParticipantId,
+        stageId,
+        triggerChatId,
+        outcome,
+        promptConfig.chatSettings,
+      );
+    } else {
+      await sendAgentGroupChatMessage(
+        experimentId,
+        cohortId,
+        stageId,
+        triggerChatId,
+        outcome,
+        promptConfig.chatSettings,
+      );
+    }
+    return true;
+  }
 
-        let triggerLogRef;
-        if (isTurnBased) {
-          triggerLogRef = getGroupChatTriggerLogRef(
+  // Unreachable: every path above returns.
+
+  async function runAgentChatMessagePipeline(): Promise<boolean> {
+    // Check if this is an initial message request (empty triggerChatId)
+    if (triggerChatId === '') {
+      // Check if we've already sent an initial message for this user
+
+      // Build the appropriate trigger log reference based on chat type
+      const triggerLogId = `initial-${user.publicId}`;
+      const triggerLogRef = isPrivateChat
+        ? getPrivateChatTriggerLogRef(
+            experimentId,
+            participantIds[0], // Use the first participant ID as the storage location
+            stageId,
+            triggerLogId,
+          )
+        : getGroupChatTriggerLogRef(
             experimentId,
             cohortId,
             stageId,
             triggerLogId,
           );
-        } else {
-          triggerLogRef = app
-            .firestore()
-            .collection('experiments')
-            .doc(experimentId)
-            .collection('cohorts')
-            .doc(cohortId)
-            .collection('publicStageData')
-            .doc(stageId)
-            .collection('agentInitialTriggerLog')
-            .doc(triggerLogId);
-        }
-        await triggerLogRef.delete();
-      }
-      return response.success;
-    }
-  }
 
-  if (stage.kind === StageKind.PRIVATE_CHAT) {
-    // For private chat, use the first participant's ID for storage location
-    const privateChatParticipantId = participantIds[0];
-    if (!privateChatParticipantId) {
-      console.error(
-        'No participant ID provided for private chat message storage',
-      );
-      return false;
+      const shouldSendInitialMessage = await app
+        .firestore()
+        .runTransaction(async (transaction) => {
+          const triggerLog = await transaction.get(triggerLogRef);
+          if (triggerLog.exists) return false;
+
+          transaction.create(triggerLogRef, {timestamp: Timestamp.now()});
+          return true;
+        });
+
+      if (!shouldSendInitialMessage) {
+        return false; // Already sent initial message
+      }
     }
-    await sendAgentPrivateChatMessage(
-      experimentId,
-      privateChatParticipantId,
-      stageId,
-      triggerChatId,
-      message,
-      promptConfig.chatSettings,
-    );
-  } else {
-    await sendAgentGroupChatMessage(
+
+    // Get the chat message (either initial or response)
+    let message: ChatMessage | null = null;
+
+    // For initial messages, check if there's a configured initial message
+    if (triggerChatId === '') {
+      const initialMessage = promptConfig.chatSettings?.initialMessage;
+      if (initialMessage && initialMessage.trim() !== '') {
+        // Resolve template variables in the initial message.
+        // Only use participant variables for private chats.
+        const resolvedMessage = await resolveStringWithVariables(
+          initialMessage,
+          experimentId,
+          cohortId,
+          isPrivateChat ? participantIds[0] : undefined,
+        );
+
+        message = createChatMessage({
+          message: resolvedMessage,
+          senderId: user.publicId,
+          type: user.type,
+          profile: createParticipantProfileBase(user),
+          timestamp: Timestamp.now(),
+        });
+      }
+    }
+
+    // If no configured initial message or this is a regular response, query the API
+    if (!message) {
+      const response = await getAgentChatMessage(
+        experimentId,
+        cohortId,
+        participantIds,
+        stage,
+        user,
+        promptConfig,
+        retryDeadlineMs,
+      );
+      message = response.message;
+      if (!message) {
+        // `deadlineReached` is set only when the model call hit the stage's
+        // response deadline (see getAgentChatMessage / processModelResponse).
+        // It is not set for other "no message" outcomes (empty response,
+        // non-OK status, shouldRespond=false); those keep retrying as before.
+        const deadlineReached = response.deadlineReached;
+        // An empty/unusable response that exhausted its retry budget is, on the
+        // turn-based path, also a dead end that must surface the restart pop-up:
+        // otherwise the turn-holder stays set, no message re-fires the trigger,
+        // and the chat freezes silently with no pop-up. Treat it like the
+        // deadline here (the human can then restart).
+        const emptyResponse = response.emptyResponse;
+        // A permanent failure (no API key, no agent config) is the same dead
+        // end: raise the pop-up immediately (no fallback message would help).
+        const permanentFailure = response.permanentFailure;
+        if (
+          (isTurnBasedGroupChat || isTurnBasedPrivateChat) &&
+          (deadlineReached || emptyResponse || permanentFailure)
+        ) {
+          const outcome = await handleTurnBasedDeadEnd(
+            experimentId,
+            cohortId,
+            stage,
+            participantIds,
+            user,
+            triggerChatId,
+            permanentFailure === true,
+          );
+          if (outcome === null) {
+            return true;
+          }
+          message = outcome;
+        }
+
+        if (!message && triggerChatId === '') {
+          const triggerLogId = `initial-${user.publicId}`;
+          console.log(
+            `[chat.agent] getAgentChatMessage failed for initial message. Deleting trigger log: ${triggerLogId}`,
+          );
+          const isTurnBased =
+            stage?.kind === StageKind.CHAT &&
+            (stage as ChatStageConfig).isTurnBased;
+
+          let triggerLogRef;
+          if (isTurnBased) {
+            triggerLogRef = getGroupChatTriggerLogRef(
+              experimentId,
+              cohortId,
+              stageId,
+              triggerLogId,
+            );
+          } else {
+            triggerLogRef = app
+              .firestore()
+              .collection('experiments')
+              .doc(experimentId)
+              .collection('cohorts')
+              .doc(cohortId)
+              .collection('publicStageData')
+              .doc(stageId)
+              .collection('agentInitialTriggerLog')
+              .doc(triggerLogId);
+          }
+          await triggerLogRef.delete();
+        }
+        if (!message) {
+          return response.success;
+        }
+      }
+    }
+
+    if (stage.kind === StageKind.PRIVATE_CHAT) {
+      // For private chat, use the first participant's ID for storage location
+      const privateChatParticipantId = participantIds[0];
+      if (!privateChatParticipantId) {
+        console.error(
+          'No participant ID provided for private chat message storage',
+        );
+        return false;
+      }
+      await sendAgentPrivateChatMessage(
+        experimentId,
+        privateChatParticipantId,
+        stageId,
+        triggerChatId,
+        message,
+        promptConfig.chatSettings,
+      );
+    } else {
+      await sendAgentGroupChatMessage(
+        experimentId,
+        cohortId,
+        stageId,
+        triggerChatId,
+        message,
+        promptConfig.chatSettings,
+      );
+    }
+
+    return true;
+  }
+}
+
+/** On the turn-based path, a dead end (deadline, empty response, permanent
+ * failure, or unexpected error) must not leave the turn silently stuck.
+ * Claims a timeout response and returns it as the fallback chat message; when
+ * none remains, raises the blocking API-failure pop-up (cleaning up the
+ * initial trigger-log lock so a restart can retry) and returns null. */
+async function handleTurnBasedDeadEnd(
+  experimentId: string,
+  cohortId: string,
+  stage: StageConfig,
+  participantIds: string[],
+  user: ParticipantProfileExtended | MediatorProfileExtended,
+  triggerChatId: string,
+  // Permanent failures (bad key, invalid config) cannot improve on later
+  // turns, so no fallback message is posted: raise the pop-up right away.
+  permanent = false,
+): Promise<ChatMessage | null> {
+  const isTurnBasedGroupChat =
+    stage.kind === StageKind.CHAT && (stage as ChatStageConfig).isTurnBased;
+  const experiment = await getFirestoreExperiment(experimentId);
+  const timeoutResponse = permanent
+    ? null
+    : await claimTimeoutResponse(
+        experimentId,
+        cohortId,
+        stage,
+        participantIds,
+        experiment ?? undefined,
+      );
+  if (timeoutResponse === null) {
+    // Clean up the initial trigger log lock so the agent can be retried
+    // if the study is restarted (group chat owns this lock).
+    if (isTurnBasedGroupChat && triggerChatId === '') {
+      const triggerLogId = `initial-${user.publicId}`;
+      const triggerLogRef = getGroupChatTriggerLogRef(
+        experimentId,
+        cohortId,
+        stage.id,
+        triggerLogId,
+      );
+      await triggerLogRef.delete();
+    }
+
+    // Do not skip or advance the turn. Surface a blocking pop-up to the
+    // human participant(s) so they can restart the study.
+    await markTurnBasedApiFailure(
       experimentId,
       cohortId,
-      stageId,
-      triggerChatId,
-      message,
-      promptConfig.chatSettings,
+      stage,
+      participantIds,
     );
+    return null;
   }
 
-  return true;
+  // The agent sends the timeout message, so the turn completes and the
+  // conversation continues.
+  return createChatMessage({
+    message: timeoutResponse,
+    senderId: user.publicId,
+    type: user.type,
+    profile: createParticipantProfileBase(user),
+    timestamp: Timestamp.now(),
+  });
 }
 
 /** Query for and return chat message for given agent and chat prompt configs. */
@@ -283,6 +455,20 @@ export async function getAgentChatMessage(
   message: ChatMessage | null;
   success: boolean;
   retryTimedOut: boolean;
+  // True ONLY when the genuine 120s RetryTimeoutError deadline was reached
+  // (model never returned a usable response in time). Used to trigger the
+  // turn-based "restart the study" pop-up. Not set for other null-message
+  // outcomes (empty response, non-OK status, shouldRespond=false).
+  deadlineReached: boolean;
+  // True when the model returned an empty/unusable response after exhausting
+  // its retry budget. On the turn-based path the caller treats this like the
+  // deadline (surfaces the restart pop-up); other (non-turn-based) callers
+  // ignore it.
+  emptyResponse?: boolean;
+  // True when the call can never succeed (no API key configured, no agent
+  // config). On the turn-based path the caller treats this like the deadline,
+  // immediately: waiting out the timeout would add no information.
+  permanentFailure?: boolean;
 }> {
   const stageId = stage.id;
 
@@ -290,7 +476,13 @@ export async function getAgentChatMessage(
   const experimenterData =
     await getExperimenterDataFromExperiment(experimentId);
   if (!experimenterData) {
-    return {message: null, success: false, retryTimedOut: false};
+    return {
+      message: null,
+      success: false,
+      retryTimedOut: false,
+      deadlineReached: false,
+      permanentFailure: true,
+    };
   }
 
   // Get chat messages from private/public data based on stage kind
@@ -310,6 +502,9 @@ export async function getAgentChatMessage(
   // For turn-based conversation, ensure it is the agent's turn
   const isTurnBasedGroupChat =
     stage.kind === StageKind.CHAT && (stage as ChatStageConfig).isTurnBased;
+  const isTurnBasedPrivateChat =
+    stage.kind === StageKind.PRIVATE_CHAT &&
+    (stage as {isTurnBasedChatGroupStyle?: boolean}).isTurnBasedChatGroupStyle;
   if (isTurnBasedGroupChat) {
     const publicStageData = await getFirestoreStagePublicData(
       experimentId,
@@ -321,19 +516,35 @@ export async function getAgentChatMessage(
       chatPublicData &&
       chatPublicData.currentTurnParticipantId !== user.publicId
     ) {
-      return {message: null, success: true, retryTimedOut: false};
+      return {
+        message: null,
+        success: true,
+        retryTimedOut: false,
+        deadlineReached: false,
+      };
     }
   }
 
   // Confirm that agent can send chat messages based on prompt config
   const chatSettings = promptConfig.chatSettings;
   if (!canSendAgentChatMessage(user.publicId, chatSettings, chatMessages)) {
-    return {message: null, success: true, retryTimedOut: false};
+    return {
+      message: null,
+      success: true,
+      retryTimedOut: false,
+      deadlineReached: false,
+    };
   }
 
   // Ensure user has agent config
   if (!user.agentConfig) {
-    return {message: null, success: false, retryTimedOut: false};
+    return {
+      message: null,
+      success: false,
+      retryTimedOut: false,
+      deadlineReached: false,
+      permanentFailure: true,
+    };
   }
 
   // Use provided participant IDs for prompt context
@@ -384,7 +595,8 @@ export async function getAgentChatMessage(
   }
 
   const retryDurationMs =
-    isTurnBasedGroupChat && turnBasedRetryDeadlineMs !== undefined
+    (isTurnBasedGroupChat || isTurnBasedPrivateChat) &&
+    turnBasedRetryDeadlineMs !== undefined
       ? Math.max(0, turnBasedRetryDeadlineMs - Date.now())
       : null;
 
@@ -424,7 +636,9 @@ export async function getAgentChatMessage(
     user.agentConfig.modelSettings,
     promptConfig.generationConfig,
     effectiveStructuredOutputConfig,
-    isTurnBasedGroupChat ? null : (promptConfig.numRetries ?? 0),
+    isTurnBasedGroupChat || isTurnBasedPrivateChat
+      ? null
+      : (promptConfig.numRetries ?? 0),
     retryDurationMs,
   );
 
@@ -448,7 +662,19 @@ export async function getAgentChatMessage(
 
   // Process response
   if (response.status !== ModelResponseStatus.OK) {
-    return {message: null, success: false, retryTimedOut};
+    // A non-OK status after exhausting the retry budget. If the retry
+    // deadline was hit, flag it for the turn-based caller. Any other non-OK
+    // escape is a status the retry loop deliberately fails fast on (e.g. a
+    // bad API key or invalid config): deterministic, so nothing will improve
+    // without intervention. Flag it as permanent so the turn-based caller
+    // falls back immediately instead of leaving the turn silently stuck.
+    return {
+      message: null,
+      success: false,
+      retryTimedOut,
+      deadlineReached: retryTimedOut,
+      permanentFailure: !retryTimedOut,
+    };
   }
 
   const structured = effectiveStructuredOutputConfig as
@@ -477,9 +703,21 @@ export async function getAgentChatMessage(
     }
   }
 
-  // No text and no files = failure
+  // No text and no files = an empty/unusable response (status was OK) after
+  // the empty-retry budget was already exhausted. This is NOT the genuine
+  // 120s deadline, but on the turn-based path it is still a dead end: the
+  // trigger does not re-fire on its own, so returning here silently freezes
+  // the chat with no pop-up. Flag it so the turn-based caller surfaces the
+  // restart pop-up instead of stalling. Non-turn-based callers ignore
+  // emptyResponse.
   if (!response.text && (!response.files || response.files.length === 0)) {
-    return {message: null, success: false, retryTimedOut};
+    return {
+      message: null,
+      success: false,
+      retryTimedOut,
+      deadlineReached: false,
+      emptyResponse: true,
+    };
   }
 
   if (!shouldRespond) {
@@ -518,7 +756,12 @@ export async function getAgentChatMessage(
       );
       await participantAnswerDoc.set({readyToEndChat: true}, {merge: true});
     }
-    return {message: null, success: true, retryTimedOut};
+    return {
+      message: null,
+      success: true,
+      retryTimedOut,
+      deadlineReached: false,
+    };
   }
 
   // If stage includes discussions, figure out what discussion ID should be
@@ -569,7 +812,12 @@ export async function getAgentChatMessage(
     }
   }
 
-  return {message: chatMessage, success: true, retryTimedOut};
+  return {
+    message: chatMessage,
+    success: true,
+    retryTimedOut,
+    deadlineReached: false,
+  };
 }
 
 async function getNextTurnBasedSpeakerAfterSkippedAgent(
@@ -686,6 +934,179 @@ async function getNextTurnBasedSpeakerAfterSkippedAgent(
   }
 
   return null;
+}
+
+/**
+ * Surfaces the blocking "restart the study" pop-up to the relevant HUMAN
+ * (non-agent) participant(s) when a turn-based agent's model call reaches the
+ * genuine 120s retry deadline still failing.
+ *
+ * Sets ParticipantStatus.API_FAILURE on:
+ *   - group chat (StageKind.CHAT): all active non-agent participants in the cohort.
+ *   - group-chat-style private chat (StageKind.PRIVATE_CHAT): participantIds[0].
+ *
+ * Only transitions participants whose currentStatus is an active/in-progress
+ * state (IN_PROGRESS); never overwrites terminal/transfer states such as
+ * BOOTED_OUT, SUCCESS, DELETED, or TRANSFER_*.
+ */
+/**
+ * Reserve the next timeout message for the human participants in the failing
+ * chat. Returns the error message, or a neutral response drawn without
+ * replacement when the experiment opts into those. Once a participant has
+ * reached the experiment's timeout message limit, returns null so the caller
+ * ends the study instead. Unset limit means the chat continues indefinitely.
+ */
+async function claimTimeoutResponse(
+  experimentId: string,
+  cohortId: string,
+  stage: StageConfig,
+  participantIds: string[], // private participant IDs (private chat uses [0])
+  experiment?: Experiment,
+): Promise<string | null> {
+  const targetPrivateIds = await resolveTimeoutTargetPrivateIds(
+    experimentId,
+    cohortId,
+    stage,
+    participantIds,
+  );
+  if (targetPrivateIds.length === 0) {
+    console.error(
+      `[chat.agent] Timeout message: no human targets resolved in stage ${stage.id}; ending the study instead.`,
+    );
+    return null;
+  }
+  // Undefined defaults to 2; an explicit null means no limit.
+  const limit =
+    experiment?.timeoutMessageLimit === undefined
+      ? 2
+      : experiment.timeoutMessageLimit;
+  const useNeutral = experiment?.useNeutralTimeoutResponses === true;
+
+  const refs = targetPrivateIds.map((privateId) =>
+    getFirestoreParticipantRef(experimentId, privateId),
+  );
+  // Read, pick, and record atomically so concurrent claims for the same
+  // failure cannot double-spend or overwrite each other's records.
+  const pick = await app.firestore().runTransaction(async (transaction) => {
+    const snapshots = await transaction.getAll(...refs);
+    const participants = snapshots.map(
+      (snapshot) => snapshot.data() as ParticipantProfileExtended | undefined,
+    );
+    const count = Math.max(
+      0,
+      ...participants.map((p) => p?.timeoutMessageCount ?? 0),
+    );
+    if (limit !== null && count >= limit) return null;
+
+    let choice = TIMEOUT_ERROR_RESPONSE;
+    let usedNeutral: Set<string> | null = null;
+    if (useNeutral) {
+      usedNeutral = new Set<string>();
+      for (const participant of participants) {
+        for (const response of participant?.neutralTimeoutResponses ?? []) {
+          usedNeutral.add(response);
+        }
+      }
+      const remaining = NEUTRAL_TIMEOUT_RESPONSES.filter(
+        (r) => !usedNeutral!.has(r),
+      );
+      if (remaining.length > 0) {
+        choice = remaining[Math.floor(Math.random() * remaining.length)];
+        usedNeutral.add(choice);
+      }
+    }
+    for (const [i, ref] of refs.entries()) {
+      const update: Record<string, unknown> = {
+        timeoutMessageCount: (participants[i]?.timeoutMessageCount ?? 0) + 1,
+      };
+      if (usedNeutral && choice !== TIMEOUT_ERROR_RESPONSE) {
+        update.neutralTimeoutResponses = [...usedNeutral];
+      }
+      transaction.set(ref, update, {merge: true});
+    }
+    return choice;
+  });
+  console.log(
+    `[chat.agent] Timeout message in stage ${stage.id}: ` +
+      (pick === null ? 'limit reached, ending the study' : `posting "${pick}"`),
+  );
+  return pick;
+}
+
+/**
+ * Resolve the human participants a turn-based failure should address:
+ * the private chat participant, or every active human in the cohort for a
+ * group chat. Observers count; they experience the failure like any other
+ * human in the chat.
+ */
+async function resolveTimeoutTargetPrivateIds(
+  experimentId: string,
+  cohortId: string,
+  stage: StageConfig,
+  participantIds: string[],
+): Promise<string[]> {
+  if (stage.kind === StageKind.PRIVATE_CHAT) {
+    const privateId = participantIds[0];
+    return privateId ? [privateId] : [];
+  }
+  const activeParticipants = await getFirestoreActiveParticipants(
+    experimentId,
+    cohortId,
+    stage.id,
+    false,
+    true, // include observers
+  );
+  return activeParticipants
+    .filter((p) => !p.agentConfig)
+    .map((p) => p.privateId);
+}
+
+export async function markTurnBasedApiFailure(
+  experimentId: string,
+  cohortId: string,
+  stage: StageConfig,
+  participantIds: string[], // private participant IDs (private chat uses [0])
+) {
+  const targetPrivateIds = await resolveTimeoutTargetPrivateIds(
+    experimentId,
+    cohortId,
+    stage,
+    participantIds,
+  );
+
+  if (targetPrivateIds.length === 0) return;
+
+  await Promise.all(
+    targetPrivateIds.map(async (privateId) => {
+      const participantRef = getFirestoreParticipantRef(
+        experimentId,
+        privateId,
+      );
+      // Guard against overwriting terminal/transfer states inside a transaction.
+      await app.firestore().runTransaction(async (transaction) => {
+        const snapshot = await transaction.get(participantRef);
+        const participant = snapshot.data() as
+          | ParticipantProfileExtended
+          | undefined;
+        if (!participant) return;
+        // Only transition active/in-progress participants.
+        if (participant.currentStatus !== ParticipantStatus.IN_PROGRESS) {
+          return;
+        }
+        // Don't touch agent participants.
+        if (participant.agentConfig) return;
+        transaction.set(
+          participantRef,
+          {currentStatus: ParticipantStatus.API_FAILURE},
+          {merge: true},
+        );
+      });
+    }),
+  );
+
+  console.error(
+    `[chat.agent] Turn-based model call hit its response deadline in stage ${stage.id}; surfaced API_FAILURE restart pop-up to ${targetPrivateIds.length} participant(s).`,
+  );
 }
 
 export async function skipTimedOutTurnBasedAgentTurn(

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -236,6 +236,38 @@ export async function createAgentChatMessageFromPrompt(
       }
     }
 
+    // Turn-based private chats: guard against a re-delivered creation event
+    // producing a duplicate reply. Event delivery is at-least-once, so the
+    // private-chat message trigger can fire more than once for the same
+    // participant message; each firing would otherwise generate its own
+    // independent reply. This covers the private turn-based path only, so a
+    // given responder answers a given trigger message at most once there. The
+    // public turn-based path has a claim of its own further down this file,
+    // keyed on the trigger message and the sender's type, which stops a second
+    // reply being posted, though only after the model call has been paid for.
+    // Non-turn-based chats keep their existing behavior.
+    if (triggerChatId !== '' && isTurnBasedPrivateChat) {
+      const replyLogRef = getPrivateChatTriggerLogRef(
+        experimentId,
+        participantIds[0],
+        stageId,
+        `reply-${user.publicId}-${triggerChatId}`,
+      );
+      const shouldReply = await app
+        .firestore()
+        .runTransaction(async (transaction) => {
+          const replyLog = await transaction.get(replyLogRef);
+          if (replyLog.exists) return false;
+
+          transaction.create(replyLogRef, {timestamp: Timestamp.now()});
+          return true;
+        });
+
+      if (!shouldReply) {
+        return false; // Duplicate delivery: already replied to this trigger
+      }
+    }
+
     // Get the chat message (either initial or response)
     let message: ChatMessage | null = null;
 

--- a/functions/src/chat/chat.agent.ts
+++ b/functions/src/chat/chat.agent.ts
@@ -236,6 +236,36 @@ export async function createAgentChatMessageFromPrompt(
       }
     }
 
+    // Turn-based private chats: guard against a re-delivered creation event
+    // producing a duplicate reply. Event delivery is at-least-once, so the
+    // private-chat message trigger can fire more than once for the same
+    // participant message; each firing would otherwise generate its own
+    // independent reply. The public turn-based path is already guarded upstream
+    // by turnProcessedMessageId; this covers the private turn-based path the
+    // same way, so a given responder answers a given trigger message at most
+    // once. Non-turn-based chats keep their existing behavior.
+    if (triggerChatId !== '' && isTurnBasedPrivateChat) {
+      const replyLogRef = getPrivateChatTriggerLogRef(
+        experimentId,
+        participantIds[0],
+        stageId,
+        `reply-${user.publicId}-${triggerChatId}`,
+      );
+      const shouldReply = await app
+        .firestore()
+        .runTransaction(async (transaction) => {
+          const replyLog = await transaction.get(replyLogRef);
+          if (replyLog.exists) return false;
+
+          transaction.create(replyLogRef, {timestamp: Timestamp.now()});
+          return true;
+        });
+
+      if (!shouldReply) {
+        return false; // Duplicate delivery: already replied to this trigger
+      }
+    }
+
     // Get the chat message (either initial or response)
     let message: ChatMessage | null = null;
 

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -360,6 +360,7 @@ class PrivateChatStageConfig(BaseModel):
     minNumberOfTurns: float | None = None
     maxNumberOfTurns: float | None = None
     preventCancellation: bool | None = None
+    agentTimeoutSeconds: Annotated[int | None, Field(ge=1)] = None
 
 
 class ProfileType(StrEnum):
@@ -979,6 +980,7 @@ class ChatStageConfig(BaseModel):
     timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     discussions: list[DefaultChatDiscussion | CompareChatDiscussion]
     isTurnBased: bool | None = None
+    agentTimeoutSeconds: Annotated[int | None, Field(ge=1)] = None
 
 
 class RankingStageConfig(
@@ -1046,6 +1048,8 @@ class Experiment(BaseModel):
     ) = None
     variableMap: Annotated[dict[str, str] | None, Field(title="VariableMap")] = None
     cohortDefinitions: list[CohortDefinition] | None = None
+    timeoutMessageLimit: float | None = None
+    useNeutralTimeoutResponses: bool | None = None
 
 
 class ExperimentTemplate(BaseModel):

--- a/utils/src/chat_message.ts
+++ b/utils/src/chat_message.ts
@@ -147,3 +147,25 @@ export function createSystemChatMessage(
     files: config.files ?? undefined,
   };
 }
+
+/**
+ * Neutral chat responses an agent sends when its model call fails past the
+ * retry deadline and the experiment keeps the conversation going instead of
+ * ending the study.
+ */
+/**
+ * Message a turn-based agent sends when its model call fails past the retry
+ * deadline, unless the experiment opts into neutral responses.
+ */
+export const TIMEOUT_ERROR_RESPONSE =
+  '*Error: Could not generate a message at this time. Please try again.*';
+
+export const NEUTRAL_TIMEOUT_RESPONSES = [
+  'Not sure.',
+  'Not sure yet.',
+  "I'm not sure about that.",
+  "I'm thinking.",
+  "I'm just thinking.",
+  "I'm thinking about it.",
+  "Let's consider that.",
+];

--- a/utils/src/experiment.test.ts
+++ b/utils/src/experiment.test.ts
@@ -1,0 +1,23 @@
+import {createExperimentConfig} from './experiment';
+
+describe('createExperimentConfig', () => {
+  it('should keep the turn-based timeout settings that were passed in', () => {
+    const experiment = createExperimentConfig([], {
+      timeoutMessageLimit: 3,
+      useNeutralTimeoutResponses: true,
+    });
+    expect(experiment.timeoutMessageLimit).toBe(3);
+    expect(experiment.useNeutralTimeoutResponses).toBe(true);
+  });
+
+  it('should keep an explicit null limit, which means no limit', () => {
+    const experiment = createExperimentConfig([], {timeoutMessageLimit: null});
+    expect(experiment.timeoutMessageLimit).toBeNull();
+  });
+
+  it('should leave both unset when they were not passed in', () => {
+    const experiment = createExperimentConfig([]);
+    expect(experiment.timeoutMessageLimit).toBeUndefined();
+    expect(experiment.useNeutralTimeoutResponses).toBeUndefined();
+  });
+});

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -80,6 +80,16 @@ export interface Experiment {
   variableConfigs?: VariableConfig[]; // list of variable configs used in experiment
   variableMap?: Record<string, string>; // variable to assigned value
   cohortDefinitions?: CohortDefinition[]; // pre-defined cohorts for individual routing
+  // Maximum number of timeout messages a participant may receive from
+  // turn-based agents before a further timeout ends the study with the
+  // restart pop-up. Defaults to 2 when unset; null means no limit. Set on
+  // the experiment document directly; not shown in the editor.
+  timeoutMessageLimit?: number | null;
+  // When true, timeout messages are drawn without replacement from the
+  // neutral responses instead of the error message; once all have been
+  // used, the error message is sent. Set on the experiment document
+  // directly; not shown in the editor.
+  useNeutralTimeoutResponses?: boolean;
 }
 
 /** Experiment template (used to load experiments). */

--- a/utils/src/experiment.ts
+++ b/utils/src/experiment.ts
@@ -147,6 +147,8 @@ export function createExperimentConfig(
     variableConfigs: config.variableConfigs ?? [],
     variableMap: config.variableMap ?? {},
     cohortDefinitions: config.cohortDefinitions,
+    timeoutMessageLimit: config.timeoutMessageLimit,
+    useNeutralTimeoutResponses: config.useNeutralTimeoutResponses,
   };
 }
 

--- a/utils/src/experiment.validation.ts
+++ b/utils/src/experiment.validation.ts
@@ -89,6 +89,10 @@ export const ExperimentTemplateSchema = Type.Object(
         variableConfigs: Type.Optional(Type.Array(VariableConfigData)),
         variableMap: Type.Optional(Type.Record(Type.String(), Type.String())),
         cohortDefinitions: Type.Optional(Type.Array(CohortDefinitionSchema)),
+        timeoutMessageLimit: Type.Optional(
+          Type.Union([Type.Number(), Type.Null()]),
+        ),
+        useNeutralTimeoutResponses: Type.Optional(Type.Boolean()),
       },
       strict,
     ),

--- a/utils/src/participant.ts
+++ b/utils/src/participant.ts
@@ -58,6 +58,12 @@ export interface ParticipantProfile extends UserProfileBase {
   timestamps: ProgressTimestamps;
   anonymousProfiles: Record<string, AnonymousProfileMetadata>;
   connected: boolean | null;
+  // Neutral responses already used in this participant's chats after model
+  // timeouts, drawn without replacement. After three, a further timeout ends
+  // the study with the restart pop-up.
+  neutralTimeoutResponses?: string[];
+  // Number of timeout messages sent to this participant by turn-based agents.
+  timeoutMessageCount?: number;
   // Maps variable name to value assigned specifically for this participant
   // This overrides any variable values set at the cohort/experiment levels.
   variableMap?: Record<string, string>;
@@ -117,6 +123,9 @@ export enum ParticipantStatus {
   // Deleted (e.g., if cohort was deleted).
   // The participant will not be part of dashboard, data download, etc.
   DELETED = 'DELETED',
+  // Turn-based chat agent's model call failed to return within the stage's
+  // response deadline; a blocking pop-up debriefs the participant.
+  API_FAILURE = 'API_FAILURE',
 }
 
 // ************************************************************************* //

--- a/utils/src/participant.validation.ts
+++ b/utils/src/participant.validation.ts
@@ -194,6 +194,7 @@ export const ParticipantStatusData = Type.Union([
   Type.Literal(ParticipantStatus.ATTENTION_TIMEOUT),
   Type.Literal(ParticipantStatus.BOOTED_OUT),
   Type.Literal(ParticipantStatus.DELETED),
+  Type.Literal(ParticipantStatus.API_FAILURE),
 ]);
 
 export const ProgressTimestampsSchema = Type.Object({

--- a/utils/src/stages/chat_stage.ts
+++ b/utils/src/stages/chat_stage.ts
@@ -27,7 +27,13 @@ export interface ChatStageConfig extends BaseStageConfig {
   timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
   timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
   isTurnBased?: boolean; // Whether the conversation is turn-based
+  // Seconds a turn-based agent response may take (including retries) before
+  // the participant is shown the error pop-up. Unset = default (120).
+  agentTimeoutSeconds?: number;
 }
+
+/** Default agent response timeout for turn-based chats, in seconds. */
+export const DEFAULT_AGENT_TIMEOUT_SECONDS = 120;
 
 /** Chat discussion. */
 export interface BaseChatDiscussion {

--- a/utils/src/stages/chat_stage.validation.ts
+++ b/utils/src/stages/chat_stage.validation.ts
@@ -70,6 +70,7 @@ export const ChatStageConfigData = Type.Composite(
         ),
         discussions: Type.Array(ChatDiscussionData),
         isTurnBased: Type.Optional(Type.Boolean()),
+        agentTimeoutSeconds: Type.Optional(Type.Integer({minimum: 1})),
       },
       strict,
     ),

--- a/utils/src/stages/private_chat_stage.ts
+++ b/utils/src/stages/private_chat_stage.ts
@@ -42,6 +42,9 @@ export interface PrivateChatStageConfig extends BaseStageConfig {
   // If true, prevents participants from cancelling pending requests
   // while waiting for a response (to prevent gaming minimum message counts)
   preventCancellation: boolean;
+  // Seconds a turn-based agent response may take (including retries) before
+  // the participant is shown the error pop-up. Unset = default (120).
+  agentTimeoutSeconds?: number;
 }
 
 // ************************************************************************* //

--- a/utils/src/stages/private_chat_stage.validation.ts
+++ b/utils/src/stages/private_chat_stage.validation.ts
@@ -38,6 +38,7 @@ export const PrivateChatStageConfigData = Type.Composite(
         // If true, prevents participants from cancelling pending requests
         // while waiting for a response (to prevent gaming minimum message counts)
         preventCancellation: Type.Optional(Type.Boolean()),
+        agentTimeoutSeconds: Type.Optional(Type.Integer({minimum: 1})),
       },
       strict,
     ),


### PR DESCRIPTION
# Description

In turn-based mode, errors can make it impossible to move forward in a study when it is the AI agent's turn to speak, such as if the API fails to respond after several retries. This fix PR provides two ways to handle these:

1. the AI agent can produce a hard-coded message, such as `Error: Could not generate a message at this time. Please try again.` and advance the turn or
2. the human participant can be shown a pop-up ending the study with information, such as telling them that there has been a technical error so they should exit the study.

By default, the agent sends the error message and advances the turn if there are errors after failing to produce a valid message for 120 seconds of retries. This can be changed from an error message to a neutral response (e.g., `Not sure yet.`) with `useNeutralTimeoutResponses`.

By default, if this turn advance occurs a set number of times (default: 2; `null` for never), the pop-up is shown instead. In particular cases where the error in the API pipeline is not going to be resolved with retries (e.g., invalid API key), the pop-up is shown immediately.

This has no effect on non-turn-based functionality.

# Manual testing as per template

Set up an experiment with (i) a turn-based group chat stage with an agent mediator and a human participant and (ii) disconnect the internet or fail to insert a valid API key.

- 1 human participant needed
- No agent participants needed
- Expected behavior: The timeout error with retries can reliably show if you disconnect from the internet, and the system will retry as if you might just be having a quick drop in connection. If the API key is invalid, then when the participant enters the chat stage, the pop-up will immediately appear, instructing the participant to exit the study because an invalid API key can’t be fixed with retries.

# Screenshot

<img width="1524" height="1214" alt="image" src="https://github.com/user-attachments/assets/35452696-a32a-4689-839f-40c80d4daf3c" />