### PR TITLE
build: add one-click local deploy pipeline (#1197)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,86 @@
+# Deploying from local
+
+`npm run deploy:*` is the **local companion to `cloudbuild.yaml`**. It reproduces CI's staged, ordered deploy — validate → build → test → rules → indexes → functions → frontend — from your machine, for when you have locally-developed, bespoke code you just want to deploy *somewhere* others can reach.
+
+> [!CAUTION]
+> These commands deploy to a **real GCP project**. They are real-by-default. Always preview with `DRY_RUN=1` first, and double-check `PROJECT_ID`.
+
+## Prerequisites
+
+The tooling assumes the target project is already provisioned (APIs enabled, App Engine app created, Firebase web app created). It does **not** create resources or manage secrets. You must be logged in locally:
+
+```sh
+npm ci                 # installs firebase-tools (used via npx)
+firebase login         # for firebase deploy / apps:sdkconfig
+gcloud auth login      # for App Engine deploy (frontend surface only)
+```
+
+Node ≥22 is required. `deploy:functions` builds functions via Firebase `predeploy` hooks (lint + build); a Java 21 runtime is **not** needed for deploys (only for `functions` tests).
+
+## Configuration (environment variables)
+
+npm forwards `-- <args>` only to the last command in a chain, so cross-cutting options are **environment variables** (they propagate to every child process).
+
+| Env var | Meaning | Default |
+|---|---|---|
+| `PROJECT_ID` | **Required.** Target GCP project. No fallback to `.firebaserc`/`gcloud config`. | — |
+| `DRY_RUN` | If set, run dry-run equivalents (`firebase … --dry-run`, `gcloud app describe`). | unset (real) |
+| `YES` | If set, skip the typed confirmation. | unset (prompt) |
+| `AUTO_PROMOTE` | Frontend: migrate traffic to the new version (drops `--no-promote`). | unset |
+| `FIREBASE_CONFIG_FILE` | Path to a JSON web-config override file. | auto-fetch |
+
+## Usage
+
+```sh
+# Preview the whole pipeline (no writes to GCP)
+PROJECT_ID=my-proj DRY_RUN=1 npm run deploy:all
+
+# Full deploy (single confirmation prompt up front)
+PROJECT_ID=my-proj npm run deploy:all
+
+# One surface, no prompt
+PROJECT_ID=my-proj YES=1 npm run deploy:functions
+```
+
+Individual surfaces are independently runnable:
+
+| Script | Deploys |
+|---|---|
+| `deploy:rules` | Firestore → Storage → Database rules |
+| `deploy:rules:firestore` / `:storage` / `:database` | a single ruleset |
+| `deploy:indexes` | Firestore composite indexes |
+| `deploy:functions` | Cloud Functions (predeploy: lint + build) |
+| `deploy:frontend` | Production frontend → App Engine |
+| `deploy:all` | the full ordered pipeline |
+
+Supporting build/validate scripts (also used by `deploy:all`): `build`, `build:utils|functions|frontend`, `lint`, `test`.
+
+## Safety model
+
+1. **Explicit target** — `PROJECT_ID` is required every time; the tooling never guesses (avoids "oops, deployed to prod").
+2. **Typed confirmation** — each real deploy asks you to type the project id.  `YES=1` skips it (`deploy:all` confirms once, then sets `YES=1` for children).  `DRY_RUN=1` needs no confirmation.
+3. **Rollback** — this tooling takes **no local backups**.  To revert: Firebase retains **rules** version history (restore via the console); **indexes** change rarely and prior definitions live in git (`firestore/indexes.json`); for any surface, redeploy from an earlier commit. Progress prints to the terminal only — redirect if you want a transcript: `npm run deploy:all > deploy.log 2>&1`.
+
+## Frontend web config resolution
+
+The Firebase web config is **not a secret** (it ships in the client bundle; security is enforced by Rules + App Check), but it **must be correct** for the target project. It is produced authoritatively from, in precedence:
+
+1. `FIREBASE_CONFIG_FILE` — a JSON file containing the `FirebaseOptions` object.
+2. Auto-fetch — `firebase apps:sdkconfig WEB --project $PROJECT_ID`.
+
+The resolved config is then **validated** (mirroring CI: `apiKey`, `appId`, `authDomain`, `measurementId`, `messagingSenderId`, `projectId`, `storageBucket` must all be present as strings, and `projectId` must equal `PROJECT_ID`). `measurementId` comes from a linked Google Analytics stream — if auto-fetch omits it, link GA to the web app or supply a complete `FIREBASE_CONFIG_FILE`.
+
+It is **reconciled** against any existing `frontend/firebase_config.ts`:
+
+| Existing file | Action |
+|---|---|
+| missing | written from the authoritative config |
+| matches the authoritative config | left as-is |
+| the dev demo placeholder (copy of `firebase_config.example.ts` the dev `build` creates) | replaced |
+| **a different real config** | **hard failure** — the file is gitignored and may be intentional, so it is never silently overwritten. Delete it (to regenerate) or correct it to match, then re-run. |
+
+For `deploy:all` this validation + conflict check runs as an **early preflight** (before lint/build/test) so a bad or conflicting config blocks in seconds rather than after minutes of work. On a real deploy the config is then written, `measurementId` is passed to Webpack via `MEASUREMENT_ID`, `index.example.html` is copied to `index.html`, and the bundle is built with `npm run build:prod -w frontend` before `gcloud app deploy`. `DRY_RUN=1` validates/reconciles (including auto-fetch and the conflict check) but does **not** write files or build.
+
+## Relationship to CI
+
+CI (`cloudbuild.yaml`) remains the canonical path for the production project.  This local path favors simplicity over speed (local deploys are rare): it keeps `firebase.json`'s `predeploy` hooks instead of stripping them into a `firebase-prod.json`, so functions are linted/built at deploy time.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ on human + LLM group dynamics.
 
 - 🔎 [Documentation for researchers + developers](https://pair-code.github.io/deliberate-lab/)
 - 👉 [Quick start for developers](https://pair-code.github.io/deliberate-lab/developers/run-locally)
+- 🚀 [Deploying from local](./DEPLOY.md)
 - :📃 [Technical paper](https://arxiv.org/abs/2510.13011)
 
 ## Citation

--- a/package.json
+++ b/package.json
@@ -30,7 +30,21 @@
   "scripts": {
     "doctor": "node scripts/doctor.js",
     "prepare": "husky",
-    "update-schemas": "./scripts/update_schemas.sh"
+    "update-schemas": "./scripts/update_schemas.sh",
+    "build:utils": "npm run build -w utils",
+    "build:functions": "npm run build -w functions",
+    "build:frontend": "node scripts/ensure-frontend-dev-config.js && npm run build -w frontend",
+    "build": "npm run build:utils && npm run build:functions && npm run build:frontend",
+    "lint": "prettier --check \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\" && eslint --quiet \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\"",
+    "test": "npm test -w utils && npm test -w functions && npm test -w frontend",
+    "deploy:rules:firestore": "node scripts/deploy-firestore-rules.js",
+    "deploy:rules:storage": "node scripts/deploy-storage-rules.js",
+    "deploy:rules:database": "node scripts/deploy-database-rules.js",
+    "deploy:rules": "npm run deploy:rules:firestore && npm run deploy:rules:storage && npm run deploy:rules:database",
+    "deploy:indexes": "node scripts/deploy-indexes.js",
+    "deploy:functions": "node scripts/deploy-functions.js",
+    "deploy:frontend": "node scripts/deploy-frontend.js",
+    "deploy:all": "node scripts/deploy-preflight.js && npm run lint && npm run build && npm run test && YES=1 npm run deploy:rules && YES=1 npm run deploy:indexes && YES=1 npm run deploy:functions && YES=1 npm run deploy:frontend"
   },
   "workspaces": [
     "frontend",

--- a/scripts/deploy-database-rules.js
+++ b/scripts/deploy-database-rules.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-database-rules.js — Deploy Realtime Database security rules.
+ *
+ * Local companion to the DeployFirebaseDatabaseRules step in cloudbuild.yaml.
+ * Rollback: redeploy an earlier commit (RTDB rules are defined in
+ * firestore/database.rules.json).
+ */
+
+const {
+  isDryRun,
+  firebase,
+  beginSurface,
+  colors,
+  log,
+} = require('./lib/deploy-common');
+
+async function main() {
+  const {project} = await beginSurface({
+    surface: 'Realtime Database rules',
+    clis: ['firebase'],
+  });
+
+  const args = [
+    'deploy',
+    '--only',
+    'database:rules',
+    '--project',
+    project,
+    '--non-interactive',
+    isDryRun() ? '--dry-run' : '--force',
+  ];
+  log(
+    isDryRun()
+      ? 'Dry-run: deploying Database rules...'
+      : 'Deploying Database rules...',
+  );
+  await firebase(args);
+  log(colors.green('✓ Database rules step complete.'));
+}
+
+main().catch((err) => {
+  process.stderr.write(colors.red(String(err && err.stack ? err.stack : err)) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-firestore-rules.js
+++ b/scripts/deploy-firestore-rules.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-firestore-rules.js — Deploy Firestore security rules.
+ *
+ * Local companion to the DeployFirebaseFirestoreRules step in cloudbuild.yaml.
+ * Rollback: Firebase retains rules version history (restore via the console),
+ * or redeploy an earlier commit.
+ */
+
+const {
+  isDryRun,
+  firebase,
+  beginSurface,
+  colors,
+  log,
+} = require('./lib/deploy-common');
+
+async function main() {
+  const {project} = await beginSurface({
+    surface: 'Firestore rules',
+    clis: ['firebase'],
+  });
+
+  const args = [
+    'deploy',
+    '--only',
+    'firestore:rules',
+    '--project',
+    project,
+    '--non-interactive',
+    isDryRun() ? '--dry-run' : '--force',
+  ];
+  log(
+    isDryRun()
+      ? 'Dry-run: deploying Firestore rules...'
+      : 'Deploying Firestore rules...',
+  );
+  await firebase(args);
+  log(colors.green('✓ Firestore rules step complete.'));
+}
+
+main().catch((err) => {
+  process.stderr.write(colors.red(String(err && err.stack ? err.stack : err)) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-frontend.js
+++ b/scripts/deploy-frontend.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-frontend.js — Build the production frontend and deploy to App Engine.
+ *
+ * Local companion to the BuildProdFrontend + DeployFrontend steps in
+ * cloudbuild.yaml.
+ *
+ * The Firebase web config (frontend/firebase_config.ts) is resolved, validated,
+ * and reconciled by scripts/lib/frontend-config.js (shared with the deploy:all
+ * preflight): it is written from FIREBASE_CONFIG_FILE or auto-fetch, an existing
+ * matching file is reused as-is, and a conflicting real config fails loudly. The
+ * config is NOT a secret (it ships in the client bundle; security is enforced by
+ * Rules + App Check). measurementId is passed to Webpack via MEASUREMENT_ID (see
+ * frontend/webpack.config.mts). App Engine deploy uses --no-promote unless
+ * AUTO_PROMOTE is set. DRY_RUN validates/reconciles the config (without writing
+ * or building) and verifies App Engine state.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  isDryRun,
+  run,
+  beginSurface,
+  colors,
+  log,
+  ROOT,
+} = require('./lib/deploy-common');
+const {reconcileConfig} = require('./lib/frontend-config');
+
+const FRONTEND_DIR = path.join(ROOT, 'frontend');
+const INDEX_EXAMPLE = path.join(FRONTEND_DIR, 'index.example.html');
+const INDEX_HTML = path.join(FRONTEND_DIR, 'index.html');
+
+async function main() {
+  const promote =
+    Boolean(process.env.AUTO_PROMOTE && process.env.AUTO_PROMOTE !== '');
+  const {project} = await beginSurface({
+    surface: 'Frontend (App Engine)',
+    extra: promote
+      ? 'Auto-promote: traffic WILL migrate to the new version'
+      : 'Auto-promote: OFF (deploys with --no-promote)',
+  });
+
+  // Resolve + validate + write the authoritative web config (or reuse a matching
+  // existing file; a conflicting real config fails loudly). No writes on dry-run.
+  const {source, projectId, measurementId} = reconcileConfig({
+    project,
+    write: !isDryRun(),
+    log,
+  });
+  log(`Resolved web config projectId: ${projectId} (source: ${source}).`);
+
+  if (isDryRun()) {
+    log('Dry-run: verifying App Engine state instead of deploying...');
+    await run('gcloud', ['app', 'describe', '--project', project]);
+    log(
+      colors.green(`✓ Frontend dry-run complete (config source: ${source}).`),
+    );
+    return;
+  }
+
+  log('Copying index.example.html -> index.html...');
+  fs.copyFileSync(INDEX_EXAMPLE, INDEX_HTML);
+
+  log('Building production frontend (build:prod)...');
+  await run('npm', ['run', 'build:prod', '-w', 'frontend'], {
+    env: measurementId ? {MEASUREMENT_ID: measurementId} : {},
+  });
+
+  const deployArgs = [
+    'app',
+    'deploy',
+    'app.yaml',
+    '--project',
+    project,
+    '--quiet',
+  ];
+  if (!promote) {
+    deployArgs.push('--no-promote');
+  }
+  log(
+    promote
+      ? 'Deploying frontend to App Engine (auto-promote)...'
+      : 'Deploying frontend to App Engine (--no-promote)...',
+  );
+  await run('gcloud', deployArgs, {
+    cwd: FRONTEND_DIR,
+  });
+  log(colors.green(`✓ Frontend step complete (config source: ${source}).`));
+}
+
+main().catch((err) => {
+  const text = err && err.userFacing ? err.message : String(err && err.stack ? err.stack : err);
+  process.stderr.write(colors.red(text) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-functions.js
+++ b/scripts/deploy-functions.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-functions.js — Deploy Cloud Functions.
+ *
+ * Local companion to the DeployFirebaseFunctions step in cloudbuild.yaml.
+ *
+ * Unlike CI (which strips predeploy into firebase-prod.json), this path keeps
+ * firebase.json as-is, so `firebase deploy --only functions` runs the
+ * functions predeploy hooks (lint + build) automatically. We build `utils`
+ * first because functions depend on utils/dist (AGENTS.md "utils first" rule).
+ *
+ * No live backup is taken (there is no simple "prior definition" to snapshot);
+ * rollback is a redeploy of prior source. This matches CI behavior.
+ */
+
+const {
+  isDryRun,
+  run,
+  firebase,
+  beginSurface,
+  colors,
+  log,
+} = require('./lib/deploy-common');
+
+async function main() {
+  const {project} = await beginSurface({
+    surface: 'Cloud Functions',
+    clis: ['firebase'],
+  });
+
+  log('Building utils (functions depend on utils/dist)...');
+  await run('npm', ['run', 'build:utils']);
+
+  const args = [
+    'deploy',
+    '--only',
+    'functions',
+    '--project',
+    project,
+    '--non-interactive',
+    isDryRun() ? '--dry-run' : '--force',
+  ];
+  log(
+    isDryRun()
+      ? 'Dry-run: deploying Functions (predeploy runs lint + build)...'
+      : 'Deploying Functions (predeploy runs lint + build)...',
+  );
+  await firebase(args);
+  log(colors.green('✓ Functions step complete.'));
+}
+
+main().catch((err) => {
+  process.stderr.write(colors.red(String(err && err.stack ? err.stack : err)) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-indexes.js
+++ b/scripts/deploy-indexes.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-indexes.js — Deploy Firestore indexes.
+ *
+ * Local companion to the DeployFirebaseIndexes step in cloudbuild.yaml.
+ * Rollback: indexes change rarely; prior definitions live in git history
+ * (firestore/indexes.json) and Cloud Build logs. Redeploy an earlier commit.
+ */
+
+const {
+  isDryRun,
+  firebase,
+  beginSurface,
+  colors,
+  log,
+} = require('./lib/deploy-common');
+
+async function main() {
+  const {project} = await beginSurface({
+    surface: 'Firestore indexes',
+    clis: ['firebase'],
+  });
+
+  const args = [
+    'deploy',
+    '--only',
+    'firestore:indexes',
+    '--project',
+    project,
+    '--non-interactive',
+    isDryRun() ? '--dry-run' : '--force',
+  ];
+  log(
+    isDryRun()
+      ? 'Dry-run: deploying Firestore indexes...'
+      : 'Deploying Firestore indexes...',
+  );
+  await firebase(args);
+  log(colors.green('✓ Firestore indexes step complete.'));
+}
+
+main().catch((err) => {
+  process.stderr.write(colors.red(String(err && err.stack ? err.stack : err)) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-preflight.js
+++ b/scripts/deploy-preflight.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-preflight.js — Up-front gate for `npm run deploy:all`.
+ *
+ * Runs BEFORE the long lint/build/test pipeline so blockers surface in seconds
+ * instead of after several minutes of work:
+ *   1. Assert PROJECT_ID and required CLIs.
+ *   2. Reconcile the frontend web config (validate it + detect a conflicting
+ *      existing frontend/firebase_config.ts) WITHOUT mutating the working tree.
+ *      deploy-frontend.js performs the real write later in the pipeline.
+ *   3. Perform the SINGLE typed confirmation for the whole pipeline.
+ *
+ * All human-facing text is written to stderr. Any failure (unresolvable/invalid
+ * config, a conflicting real config, or a declined confirmation) exits non-zero,
+ * aborting the && chain in `deploy:all`.
+ */
+
+const {
+  assertProjectId,
+  checkClis,
+  isDryRun,
+  confirm,
+  note,
+  colors,
+} = require('./lib/deploy-common');
+const {reconcileConfig} = require('./lib/frontend-config');
+
+async function main() {
+  const project = assertProjectId();
+  checkClis(['firebase', 'gcloud']);
+
+  // Preview-only: never writes, but a conflicting real config fails loudly here.
+  note(colors.bold('\n=== Preflight: frontend web config ==='));
+  reconcileConfig({project, write: false, log: note});
+
+  await confirm({
+    project,
+    surface: 'ALL surfaces (rules → indexes → functions → frontend)',
+    extra: isDryRun() ? 'DRY RUN (no writes to GCP)' : 'REAL DEPLOY',
+  });
+}
+
+main().catch((err) => {
+  const text = err && err.userFacing ? err.message : String(err && err.stack ? err.stack : err);
+  process.stderr.write(colors.red(text) + '\n');
+  process.exit(1);
+});

--- a/scripts/deploy-storage-rules.js
+++ b/scripts/deploy-storage-rules.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * deploy-storage-rules.js — Deploy Cloud Storage security rules.
+ *
+ * Local companion to the DeployFirebaseStorageRules step in cloudbuild.yaml.
+ * Rollback: Firebase retains rules version history (restore via the console),
+ * or redeploy an earlier commit.
+ */
+
+const {
+  isDryRun,
+  firebase,
+  beginSurface,
+  colors,
+  log,
+} = require('./lib/deploy-common');
+
+async function main() {
+  const {project} = await beginSurface({
+    surface: 'Storage rules',
+    clis: ['firebase'],
+  });
+
+  const args = [
+    'deploy',
+    '--only',
+    'storage',
+    '--project',
+    project,
+    '--non-interactive',
+    isDryRun() ? '--dry-run' : '--force',
+  ];
+  log(
+    isDryRun()
+      ? 'Dry-run: deploying Storage rules...'
+      : 'Deploying Storage rules...',
+  );
+  await firebase(args);
+  log(colors.green('✓ Storage rules step complete.'));
+}
+
+main().catch((err) => {
+  process.stderr.write(colors.red(String(err && err.stack ? err.stack : err)) + '\n');
+  process.exit(1);
+});

--- a/scripts/ensure-frontend-dev-config.js
+++ b/scripts/ensure-frontend-dev-config.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * ensure-frontend-dev-config.js — Make the frontend dev build self-sufficient.
+ *
+ * The frontend imports `frontend/firebase_config.ts` and html-webpack-plugin
+ * needs `frontend/index.html`; neither is committed (both are gitignored,
+ * generated files). run_locally.sh and the BuildDevFrontend step in
+ * cloudbuild.yaml copy the committed *.example.* files before building.
+ *
+ * This mirrors that behavior for `npm run build` / `build:frontend`, copying an
+ * example only when the target is MISSING so an operator's real files (or the
+ * production config written by deploy-frontend.js) are preserved.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FRONTEND_DIR = path.join(__dirname, '..', 'frontend');
+
+const files = [
+  ['firebase_config.example.ts', 'firebase_config.ts'],
+  ['index.example.html', 'index.html'],
+];
+
+for (const [example, target] of files) {
+  const targetPath = path.join(FRONTEND_DIR, target);
+  const examplePath = path.join(FRONTEND_DIR, example);
+  if (fs.existsSync(targetPath)) {
+    console.log(`\x1b[32m✓\x1b[0m frontend/${target} already exists`);
+  } else if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, targetPath);
+    console.log(`Copied frontend/${example} -> frontend/${target}`);
+  } else {
+    console.error(
+      `\x1b[31m✗\x1b[0m frontend/${target} missing and no example (${example}) found`,
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/lib/deploy-common.js
+++ b/scripts/lib/deploy-common.js
@@ -1,0 +1,187 @@
+/**
+ * deploy-common.js — Shared helpers for the local deploy pipeline.
+ *
+ * Local companion to cloudbuild.yaml. See issue #1197 and
+ * <repo>/scripts/AGENTS.md for the design. These are plain-Node (CommonJS)
+ * operational scripts following the scripts/doctor.js idiom.
+ *
+ * Cross-cutting configuration is read from environment variables (npm forwards
+ * `-- <args>` only to the last command in a chain, so flags can't propagate):
+ *
+ *   PROJECT_ID            (required) Target GCP project. No fallback.
+ *   DRY_RUN               If set, run dry-run equivalents instead of real deploys.
+ *   YES                   If set, skip the interactive typed confirmation.
+ *   AUTO_PROMOTE          Frontend: migrate traffic (drop --no-promote).
+ *   FIREBASE_CONFIG_FILE  Path to a JSON web-config override file.
+ */
+
+const path = require('path');
+const readline = require('readline');
+const {spawn, spawnSync} = require('child_process');
+
+// Repo root: scripts/lib/ -> scripts/ -> <root>
+const ROOT = path.join(__dirname, '..', '..');
+
+const colors = {
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+};
+
+/** Write a line to stderr (used for human-facing messages that must NOT be
+ * captured by `$(...)` command substitution). */
+function note(msg = '') {
+  process.stderr.write(msg + '\n');
+}
+
+/** Print a progress line to stdout. */
+function log(msg = '') {
+  process.stdout.write(msg + '\n');
+}
+
+/** Return PROJECT_ID or exit(1) with actionable guidance. Never falls back to
+ * .firebaserc or `gcloud config` (Decision 1: explicit target every time). */
+function assertProjectId() {
+  const id = process.env.PROJECT_ID;
+  if (!id || !id.trim()) {
+    note(colors.red('✗ PROJECT_ID is required.'));
+    note('  This tooling never guesses the target project (safety).');
+    note('  Example:');
+    note('    PROJECT_ID=my-project npm run deploy:functions');
+    process.exit(1);
+  }
+  return id.trim();
+}
+
+/** True when DRY_RUN is set to any non-empty value. */
+function isDryRun() {
+  return Boolean(process.env.DRY_RUN && process.env.DRY_RUN !== '');
+}
+
+/** True when YES is set to any non-empty value. */
+function skipConfirm() {
+  return Boolean(process.env.YES && process.env.YES !== '');
+}
+
+/** Verify required CLIs are available; fail fast with guidance otherwise.
+ * `firebase` is checked via the local devDependency (npx --no-install). */
+function checkClis(names) {
+  const missing = [];
+  for (const name of names) {
+    if (name === 'firebase') {
+      const r = spawnSync(
+        'npx',
+        ['--no-install', 'firebase', '--version'],
+        {stdio: 'ignore', cwd: ROOT},
+      );
+      if (r.status !== 0) {
+        missing.push({
+          name: 'firebase',
+          hint: 'Run `npm ci` (firebase-tools is a devDependency), then `npx firebase login`.',
+        });
+      }
+    } else {
+      const which = process.platform === 'win32' ? 'where' : 'which';
+      const r = spawnSync(which, [name], {stdio: 'ignore'});
+      if (r.status !== 0) {
+        const hint =
+          name === 'gcloud'
+            ? 'Install the Google Cloud SDK and run `gcloud auth login`.'
+            : `Install '${name}' and ensure it is on your PATH.`;
+        missing.push({name, hint});
+      }
+    }
+  }
+  if (missing.length) {
+    note(colors.red('✗ Missing required command(s):'));
+    for (const m of missing) {
+      note(`  - ${m.name}: ${m.hint}`);
+    }
+    process.exit(1);
+  }
+}
+
+/** Interactive typed confirmation. Skipped when YES is set. Requires the
+ * operator to type the exact PROJECT_ID. All prompt text goes to stderr. */
+function confirm({surface, project, extra}) {
+  if (skipConfirm()) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stderr,
+    });
+    note('');
+    note(colors.bold('⚠  You are about to DEPLOY to a real GCP project.'));
+    note(`   Project: ${colors.bold(project)}`);
+    note(`   Surface: ${surface}`);
+    if (extra) note(`   ${extra}`);
+    note('');
+    rl.question(
+      `Type the project id (${project}) to proceed: `,
+      (answer) => {
+        rl.close();
+        if (answer.trim() === project) {
+          resolve();
+        } else {
+          note(colors.red('✗ Confirmation did not match. Aborting.'));
+          process.exit(1);
+        }
+      },
+    );
+  });
+}
+
+/** Run a command with inherited stdio (live output straight to the terminal).
+ * Returns a promise that resolves on exit code 0 and rejects otherwise. */
+function run(cmd, args, {cwd, env} = {}) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(colors.dim(`$ ${cmd} ${args.join(' ')}`) + '\n');
+    const child = spawn(cmd, args, {
+      cwd: cwd || ROOT,
+      env: {...process.env, ...(env || {})},
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0
+        ? resolve(0)
+        : reject(new Error(`${cmd} exited with code ${code}`)),
+    );
+  });
+}
+
+/** Convenience: invoke the local firebase-tools CLI via npx --no-install. */
+function firebase(args, opts) {
+  return run('npx', ['--no-install', 'firebase', ...args], opts);
+}
+
+/** Standard preamble for a single-surface deploy helper. Asserts PROJECT_ID,
+ * checks CLIs, prints a header, and (unless YES) confirms. */
+async function beginSurface({surface, extra, clis = ['firebase', 'gcloud']}) {
+  const project = assertProjectId();
+  checkClis(clis);
+  log(colors.bold(`\n=== Deploy: ${surface} ===`));
+  log(`Project:   ${project}`);
+  log(`Mode:      ${isDryRun() ? 'DRY RUN (no writes)' : 'REAL DEPLOY'}`);
+  await confirm({surface, project, extra});
+  return {project};
+}
+
+module.exports = {
+  ROOT,
+  colors,
+  note,
+  log,
+  assertProjectId,
+  isDryRun,
+  skipConfirm,
+  checkClis,
+  confirm,
+  run,
+  firebase,
+  beginSurface,
+};

--- a/scripts/lib/frontend-config.js
+++ b/scripts/lib/frontend-config.js
@@ -1,0 +1,285 @@
+/**
+ * frontend-config.js — Resolve, validate, and reconcile frontend/firebase_config.ts.
+ *
+ * The Firebase web config is NOT a secret (it ships in the client bundle;
+ * security is enforced by Rules + App Check). But it MUST be correct for the
+ * target project, so this module produces it and is run as an EARLY preflight
+ * (see deploy-preflight.js) so a bad config blocks `deploy:all` before the long
+ * lint/build/test pipeline.
+ *
+ * Authoritative sources (precedence):
+ *   1. FIREBASE_CONFIG_FILE — a JSON file with the FirebaseOptions object.
+ *   2. Auto-fetch — `firebase apps:sdkconfig WEB --project <id> --json`.
+ *
+ * Reconciliation against an existing frontend/firebase_config.ts:
+ *   - missing                       → write the authoritative config (or, in
+ *                                     preview/dry-run mode, report it would be).
+ *   - matches the authoritative one → nothing to do.
+ *   - equals the committed demo example (the dev-build sentinel written by
+ *     ensure-frontend-dev-config.js) → treated as absent and replaced.
+ *   - otherwise (a real, DIFFERENT config) → FAIL LOUDLY. The file is gitignored
+ *     and may be the operator's own, so we never silently overwrite it; they
+ *     must delete it (to regenerate) or correct it to match.
+ *
+ * Validation mirrors cloudbuild.yaml's frontend validation step: every
+ * REQUIRED_FIELD must be present as a non-empty string, and projectId must equal
+ * the target PROJECT_ID.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {execSync} = require('child_process');
+const {colors} = require('./deploy-common');
+
+const ROOT = path.join(__dirname, '..', '..');
+const FRONTEND_DIR = path.join(ROOT, 'frontend');
+const CONFIG_TS = path.join(FRONTEND_DIR, 'firebase_config.ts');
+const CONFIG_EXAMPLE = path.join(FRONTEND_DIR, 'firebase_config.example.ts');
+
+// Mirrors the required-field check in cloudbuild.yaml's validation step.
+const REQUIRED_FIELDS = [
+  'apiKey',
+  'appId',
+  'authDomain',
+  'measurementId',
+  'messagingSenderId',
+  'projectId',
+  'storageBucket',
+];
+
+// Optional fields we compare when present (never required).
+const OPTIONAL_FIELDS = ['databaseURL'];
+const ALL_FIELDS = [...REQUIRED_FIELDS, ...OPTIONAL_FIELDS];
+
+/** A blocking, user-facing error (clean message, no stack trace for callers). */
+function blockingError(msg) {
+  const err = new Error(msg);
+  err.userFacing = true;
+  return err;
+}
+
+/** Render a firebase_config.ts file from a config object (repo format).
+ *
+ * Emits the repo's Prettier style (bare keys, single-quoted values, trailing
+ * comma, 2-space indent) so the generated file passes `prettier --check` — the
+ * deploy `lint` step globs frontend/**\/*.ts and Prettier does NOT honor
+ * .gitignore, so this gitignored file would otherwise be flagged. Firebase web
+ * config values (api keys, domains, ids, urls) never contain quotes, so simple
+ * single-quoting is safe and matches firebase_config.example.ts. */
+function renderConfigTs(config) {
+  const body = Object.entries(config)
+    .map(([key, value]) => `  ${key}: '${String(value)}',`)
+    .join('\n');
+  return (
+    "import {FirebaseOptions} from 'firebase/app';\n\n" +
+    `export const FIREBASE_CONFIG: FirebaseOptions = {\n${body}\n};\n`
+  );
+}
+
+/** Read a single string field from a firebase_config.ts via a simple regex.
+ * Handles both quoted keys ("projectId", as JSON.stringify emits) and bare keys
+ * (projectId, as the committed example uses); the value may be single/double
+ * quoted. */
+function readField(contents, key) {
+  const m = contents.match(
+    new RegExp(`["']?${key}["']?\\s*:\\s*['"]([^'"]+)['"]`),
+  );
+  return m ? m[1] : undefined;
+}
+
+/** Parse the known FirebaseOptions fields out of a firebase_config.ts. */
+function parseConfigTs(contents) {
+  const obj = {};
+  for (const key of ALL_FIELDS) {
+    const v = readField(contents, key);
+    if (v !== undefined) obj[key] = v;
+  }
+  return obj;
+}
+
+/** Keep only valid FirebaseOptions fields. `apps:sdkconfig` (and possibly a
+ * user-supplied override file) can include extras like projectNumber/version
+ * that are NOT part of FirebaseOptions and break the frontend TypeScript build
+ * (TS2353). We normalize to the allowlist before writing/validating. */
+function pickKnownFields(config) {
+  const clean = {};
+  if (config && typeof config === 'object') {
+    for (const key of ALL_FIELDS) {
+      if (config[key] !== undefined) clean[key] = config[key];
+    }
+  }
+  return clean;
+}
+
+/** Validate a config object against the target project. Throws on failure. */
+function validateConfig(config, project, sourceLabel) {
+  if (!config || typeof config !== 'object') {
+    throw blockingError(`${sourceLabel}: config is not an object.`);
+  }
+  const missing = REQUIRED_FIELDS.filter(
+    (f) => !config[f] || typeof config[f] !== 'string',
+  );
+  if (missing.length) {
+    let msg = `${sourceLabel}: missing/invalid required field(s): ${missing.join(', ')}.`;
+    if (missing.includes('measurementId')) {
+      msg +=
+        '\n  measurementId comes from a linked Google Analytics stream. Link GA to ' +
+        'the\n  Firebase web app, or supply a complete config via FIREBASE_CONFIG_FILE.';
+    }
+    throw blockingError(msg);
+  }
+  if (config.projectId !== project) {
+    throw blockingError(
+      `${sourceLabel}: projectId '${config.projectId}' does not match ` +
+        `target PROJECT_ID '${project}'.`,
+    );
+  }
+}
+
+/** Auto-fetch the web SDK config from the target project. */
+function autoFetchConfig(project) {
+  const out = execSync(
+    `npx --no-install firebase apps:sdkconfig WEB --project ${project} --json`,
+    {cwd: ROOT, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe']},
+  );
+  const parsed = JSON.parse(out);
+  // Firebase CLI --json shape: { status, result: { sdkConfig: {...} } }
+  return (
+    (parsed.result && parsed.result.sdkConfig) ||
+    parsed.sdkConfig ||
+    parsed.result ||
+    parsed
+  );
+}
+
+/** Produce the authoritative, validated config from file or auto-fetch. */
+function resolveAuthoritative(project, log) {
+  if (process.env.FIREBASE_CONFIG_FILE) {
+    const file = process.env.FIREBASE_CONFIG_FILE;
+    log(`Web config: using FIREBASE_CONFIG_FILE (${file}).`);
+    const config = pickKnownFields(JSON.parse(fs.readFileSync(file, 'utf-8')));
+    validateConfig(config, project, `FIREBASE_CONFIG_FILE (${file})`);
+    return {source: 'FIREBASE_CONFIG_FILE', config};
+  }
+  log(`Web config: auto-fetching from project '${project}'...`);
+  const config = pickKnownFields(autoFetchConfig(project));
+  validateConfig(config, project, `auto-fetch (apps:sdkconfig for '${project}')`);
+  return {source: 'auto-fetch', config};
+}
+
+/** True when the existing file is the committed demo example verbatim (i.e. the
+ * sentinel ensure-frontend-dev-config.js writes to satisfy the dev build). */
+function existingIsDemoSentinel(existingContents) {
+  if (!fs.existsSync(CONFIG_EXAMPLE)) return false;
+  return existingContents.trim() === fs.readFileSync(CONFIG_EXAMPLE, 'utf-8').trim();
+}
+
+/** Fields present in the existing file whose value CONFLICTS with authoritative
+ * (a genuinely different value the operator may have set on purpose). Absent
+ * fields are not conflicts — they just mean the file is incomplete/stale. */
+function conflictingFields(authoritative, existingObj) {
+  return ALL_FIELDS.filter(
+    (f) => existingObj[f] !== undefined && existingObj[f] !== authoritative[f],
+  );
+}
+
+/** Human-readable field-level diff for the loud-failure message. */
+function describeDiff(authoritative, existingObj, fields = ALL_FIELDS) {
+  const lines = [];
+  for (const f of fields) {
+    if (authoritative[f] !== existingObj[f]) {
+      lines.push(
+        `    - ${f}: existing '${existingObj[f] ?? '(absent)'}' != ` +
+          `expected '${authoritative[f] ?? '(absent)'}'`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+function writeOrPreview(config, write, log) {
+  if (write) {
+    fs.writeFileSync(CONFIG_TS, renderConfigTs(config));
+    log(colors.green('  ✓ Wrote frontend/firebase_config.ts'));
+    return 'wrote';
+  }
+  log(colors.dim('  (preview) would write frontend/firebase_config.ts'));
+  return 'would-write';
+}
+
+/**
+ * Reconcile frontend/firebase_config.ts with the authoritative config.
+ *
+ * @param {{project: string, write: boolean, log: Function}} opts - when `write`
+ *   is false (preview/dry-run) the working tree is never mutated, but a
+ *   conflicting real config still fails loudly.
+ * @returns {{source, config, projectId, measurementId, action}}
+ */
+function reconcileConfig({project, write, log}) {
+  const {source, config} = resolveAuthoritative(project, log);
+
+  let action;
+  if (fs.existsSync(CONFIG_TS)) {
+    const existingContents = fs.readFileSync(CONFIG_TS, 'utf-8');
+
+    if (existingIsDemoSentinel(existingContents)) {
+      log(
+        'Web config: existing frontend/firebase_config.ts is the dev demo ' +
+          'placeholder; it will be replaced.',
+      );
+      action = writeOrPreview(config, write, log);
+    } else {
+      const existingObj = parseConfigTs(existingContents);
+      const conflicts = conflictingFields(config, existingObj);
+      if (conflicts.length) {
+        throw blockingError(
+          `frontend/firebase_config.ts already exists and DIFFERS from the ` +
+            `authoritative config for '${project}':\n` +
+            describeDiff(config, existingObj, conflicts) +
+            `\n  This file is gitignored and may be intentional, so it will NOT be ` +
+            `overwritten automatically.\n  Resolve it by deleting the file (to let ` +
+            `the deploy regenerate it) or correcting it to match, then re-run.`,
+        );
+      } else if (existingContents.trim() === renderConfigTs(config).trim()) {
+        log(
+          colors.green(
+            '  ✓ Existing frontend/firebase_config.ts matches the authoritative config.',
+          ),
+        );
+        action = 'matches';
+      } else {
+        // Same known values, but the file isn't normalized (e.g. stale extra
+        // fields like projectNumber/version, or different formatting/key order).
+        // Safe to regenerate: no known field conflicts, so no operator intent
+        // is lost, and this repairs a config that would fail the TS build.
+        log(
+          'Web config: existing frontend/firebase_config.ts has matching values ' +
+            'but is not normalized; regenerating.',
+        );
+        action = writeOrPreview(config, write, log);
+      }
+    }
+  } else {
+    action = writeOrPreview(config, write, log);
+  }
+
+  return {
+    source,
+    config,
+    projectId: config.projectId,
+    measurementId: config.measurementId,
+    action,
+  };
+}
+
+module.exports = {
+  FRONTEND_DIR,
+  CONFIG_TS,
+  REQUIRED_FIELDS,
+  renderConfigTs,
+  parseConfigTs,
+  validateConfig,
+  autoFetchConfig,
+  resolveAuthoritative,
+  reconcileConfig,
+};


### PR DESCRIPTION
Local companion to cloudbuild.yaml: staged, ordered `npm run deploy:*` commands (rules → indexes → functions → frontend) driven by env vars (PROJECT_ID required, DRY_RUN, YES, AUTO_PROMOTE, FIREBASE_CONFIG_FILE), so collaborators can deploy bespoke local code to GCP without wiring up a Cloud Build ↔ GitHub connection.

- npm orchestrates the pipeline; scripts/ holds per-surface helpers
- real-by-default with a typed PROJECT_ID confirmation; DRY_RUN previews
- frontend web config auto-fetched (or FIREBASE_CONFIG_FILE), validated, and reconciled against any existing firebase_config.ts
- no local backups: the CI-style live-snapshot HTTP calls don't work with corp credentials, so rollback relies on Firebase version history + git
- docs in DEPLOY.md, linked from README

Closes #1197