### PR TITLE
fix: api accepts experiments with agent mediators that it exports

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -2855,6 +2855,24 @@
         "name": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "const": "participant",
+              "type": "string"
+            },
+            {
+              "const": "mediator",
+              "type": "string"
+            }
+          ]
+        },
+        "isDefaultAddToCohort": {
+          "type": "boolean"
+        },
         "defaultModelSettings": {
           "$ref": "#/$defs/AgentModelSettings"
         },

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -630,6 +630,11 @@ class SurveyAutoTransferConfig(BaseModel):
     participantCounts: Annotated[dict[str, int], Field(title="ParticipantCounts")]
 
 
+class Type(StrEnum):
+    participant = "participant"
+    mediator = "mediator"
+
+
 class ApiKeyType(StrEnum):
     GEMINI = "GEMINI"
     VERTEX_AI = "VERTEX_AI"
@@ -997,6 +1002,9 @@ class Persona(BaseModel):
     )
     id: Annotated[str, Field(min_length=1)]
     name: str
+    description: str | None = None
+    type: Type | None = None
+    isDefaultAddToCohort: bool | None = None
     defaultModelSettings: AgentModelSettings | None = None
     defaultProfile: ParticipantProfileBase | None = None
 

--- a/utils/src/agent.validation.ts
+++ b/utils/src/agent.validation.ts
@@ -5,6 +5,7 @@
  * for JSON Schema export and Python type generation.
  */
 import {Type, type Static} from '@sinclair/typebox';
+import {AgentPersonaType} from './agent';
 import {PromptConfigData} from './prompt.validation';
 import {ApiKeyTypeData} from './providers.validation';
 import {ParticipantProfileBaseData} from './participant.validation';
@@ -34,6 +35,9 @@ export const AgentConfigData = Type.Object(
   {
     id: Type.String({minLength: 1}),
     name: Type.String(),
+    description: Type.Optional(Type.String()),
+    type: Type.Optional(Type.Enum(AgentPersonaType)),
+    isDefaultAddToCohort: Type.Optional(Type.Boolean()),
     defaultModelSettings: Type.Optional(AgentModelSettingsData),
     defaultProfile: Type.Optional(ParticipantProfileBaseData),
   },


### PR DESCRIPTION
# Description

The experiment template API (`POST`/`PUT /experiments`) validates agent personas against `AgentConfigData`, but three required fields are missing, so attempts to upload a valid exported experiment with agent personas are being rejected as `400 Invalid request body`.

This fix adds those three fields to `AgentConfigData` as optional (mirroring how it already treats `defaultModelSettings` / `defaultProfile`) so uploads are no longer rejected.

# Manual testing

You can try uploading an experiment with an agent mediator persona before and after the fix.