### PR TITLE
Fix/negotiation payout ordering and stage ids

### DIFF
--- a/frontend/src/components/stages/negotiation_payout_participant_view.ts
+++ b/frontend/src/components/stages/negotiation_payout_participant_view.ts
@@ -15,8 +15,10 @@ import {
   SurveyStageConfig,
 } from '@deliberation-lab/utils';
 import {
+  NEGOTIATION_FINAL_DECISION_STAGE_ID,
   calculateNegotiationPayout,
   extractPartySubmission,
+  findNegotiationFinalDecisionStage,
 } from '../../shared/negotiation_payout.utils';
 import {core} from '../../core/core';
 import {CohortService} from '../../services/cohort.service';
@@ -254,35 +256,11 @@ export class NegotiationPayoutParticipantView extends MobxLitElement {
         (s) => s.kind === StageKind.SURVEY,
       ) as SurveyStageConfig[];
 
-      let targetStage = surveyStages.find(
-        (s) =>
-          s.id === 'fa00266d-2987-4dc1-8f30-e8febb63939d' ||
-          s.name?.toLowerCase().includes('final decision'),
-      );
-      if (!targetStage) {
-        targetStage = surveyStages.find((s) =>
-          s.questions?.some(
-            (q) =>
-              'options' in q &&
-              Array.isArray((q as {options?: unknown[]}).options) &&
-              (q as {options: Array<{text?: string}>}).options.some((o) =>
-                ['A+B', 'A+C', 'B+C', 'A+B+C'].includes(
-                  o.text?.trim().toUpperCase() ?? '',
-                ),
-              ),
-          ),
-        );
-      }
-      if (!targetStage) {
-        targetStage = surveyStages.find(
-          (s) =>
-            s.name?.toLowerCase().includes('task 2') &&
-            !s.name?.toLowerCase().includes('pre-negotiation'),
-        );
-      }
-      if (!targetStage && surveyStages.length > 0) {
-        targetStage = surveyStages[surveyStages.length - 1];
-      }
+      // Select the negotiation "Final Decision" survey using negotiation-specific
+      // signals first. A loose "final decision" name match is unsafe here: when a
+      // consensus study precedes the negotiation study, its own "Final Decision"
+      // survey would otherwise be picked and the payout would read wrong answers.
+      const targetStage = findNegotiationFinalDecisionStage(surveyStages);
 
       if (
         targetStage &&
@@ -297,7 +275,7 @@ export class NegotiationPayoutParticipantView extends MobxLitElement {
       }
 
       const fallbackPublicData = this.cohortService.stagePublicDataMap[
-        'fa00266d-2987-4dc1-8f30-e8febb63939d'
+        NEGOTIATION_FINAL_DECISION_STAGE_ID
       ] as SurveyPublicData | undefined;
 
       if (fallbackPublicData) {

--- a/frontend/src/components/stages/negotiation_payout_participant_view.ts
+++ b/frontend/src/components/stages/negotiation_payout_participant_view.ts
@@ -370,8 +370,8 @@ export class NegotiationPayoutParticipantView extends MobxLitElement {
 
         <div class="status-badge ${isSuccess ? 'success' : 'failure'}">
           ${isSuccess
-            ? '✅ Coalition Validated'
-            : '❌ Deal Failed / Amount Mismatch'}
+            ? '✅ The negotiating parties successfully formed a valid coalition.'
+            : '❌ The negotiating parties did not form a valid coalition.'}
         </div>
 
         <div class="explanation"><strong>Result:</strong> ${explanation}</div>

--- a/frontend/src/shared/negotiation_payout.utils.test.ts
+++ b/frontend/src/shared/negotiation_payout.utils.test.ts
@@ -1,6 +1,9 @@
+import {SurveyStageConfig} from '@deliberation-lab/utils';
 import {
+  NEGOTIATION_FINAL_DECISION_STAGE_ID,
   calculateNegotiationPayout,
   extractPartySubmission,
+  findNegotiationFinalDecisionStage,
 } from './negotiation_payout.utils';
 
 describe('calculateNegotiationPayout', () => {
@@ -112,5 +115,133 @@ describe('extractPartySubmission', () => {
     const submission = extractPartySubmission(undefined);
     expect(submission.coalition).toBe('Not submitted');
     expect(submission.money).toBe(0);
+  });
+});
+
+describe('findNegotiationFinalDecisionStage', () => {
+  // Minimal stand-ins for the two survey stages that share the "Final Decision"
+  // name in a combined experiment. Only fields read by the selector are set.
+  const consensusFinalDecision = {
+    id: '122bac65-de76-4556-9e30-5dfef2945089',
+    kind: 'survey',
+    name: '🏠 Task 3: Final Decision',
+    questions: [
+      {
+        id: '92380913-6e2a-4ec4-a0a9-6f49e0fdf29e',
+        kind: 'mc',
+        questionTitle: 'Which charity did you vote for?',
+        options: [
+          {id: 'c1', text: 'Charity One'},
+          {id: 'c2', text: 'Charity Two'},
+          {id: 'c3', text: 'Charity Three'},
+        ],
+      },
+    ],
+  } as unknown as SurveyStageConfig;
+
+  const negotiationFinalDecision = {
+    id: NEGOTIATION_FINAL_DECISION_STAGE_ID,
+    kind: 'survey',
+    name: '💰 Task 2: Final Decision',
+    questions: [
+      {
+        id: '5c95a991-483a-418f-90e3-d3a53e2aa06f',
+        kind: 'mc',
+        questionTitle: 'Which coalition would you like to form?',
+        options: [
+          {id: 'o1', text: 'A+B+C'},
+          {id: 'o2', text: 'A+B'},
+          {id: 'o3', text: 'A+C'},
+          {id: 'o4', text: 'B+C'},
+        ],
+      },
+    ],
+  } as unknown as SurveyStageConfig;
+
+  it('picks the negotiation survey when negotiation comes first', () => {
+    const stages = [negotiationFinalDecision, consensusFinalDecision];
+    const result = findNegotiationFinalDecisionStage(stages);
+    expect(result?.id).toBe(NEGOTIATION_FINAL_DECISION_STAGE_ID);
+  });
+
+  it('picks the negotiation survey even when the consensus study comes first', () => {
+    // Regression: previously the loose "final decision" name match returned the
+    // consensus "Task 3: Final Decision" stage because it appeared first.
+    const stages = [consensusFinalDecision, negotiationFinalDecision];
+    const result = findNegotiationFinalDecisionStage(stages);
+    expect(result?.id).toBe(NEGOTIATION_FINAL_DECISION_STAGE_ID);
+  });
+
+  it('falls back to coalition options when the id differs', () => {
+    const renamedNegotiation = {
+      ...negotiationFinalDecision,
+      id: 'some-other-id',
+      name: '💰 Task 2: Coalition Choice',
+    } as unknown as SurveyStageConfig;
+    const stages = [consensusFinalDecision, renamedNegotiation];
+    const result = findNegotiationFinalDecisionStage(stages);
+    expect(result?.id).toBe('some-other-id');
+  });
+
+  it('never picks the consensus survey (returns undefined when no negotiation survey exists)', () => {
+    const stages = [consensusFinalDecision];
+    const result = findNegotiationFinalDecisionStage(stages);
+    // The consensus "Final Decision" survey must not be mistaken for the
+    // negotiation one, even when it is the only survey present.
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('negotiation payout end-to-end with consensus study ordering', () => {
+  // Hard-coded participant answers for the negotiation "Final Decision" survey.
+  const negotiationAnswers = (choiceId: string, money: string) => ({
+    '5c95a991-483a-418f-90e3-d3a53e2aa06f': {
+      id: '5c95a991-483a-418f-90e3-d3a53e2aa06f',
+      kind: 'mc',
+      choiceId,
+    },
+    '169d8485-bee7-4205-9235-bc3d151df93e': {
+      id: '169d8485-bee7-4205-9235-bc3d151df93e',
+      kind: 'text',
+      answer: money,
+    },
+  });
+
+  // Charity "Final Decision" answers contain no coalition/money data.
+  const consensusAnswers = {
+    '92380913-6e2a-4ec4-a0a9-6f49e0fdf29e': {
+      id: '92380913-6e2a-4ec4-a0a9-6f49e0fdf29e',
+      kind: 'mc',
+      choiceId: 'c2',
+    },
+  };
+
+  it('computes the correct payout from the negotiation survey answers', () => {
+    // A+B choiceId = b0cab089..., B side selects A+B too.
+    const subA = extractPartySubmission(
+      negotiationAnswers('b0cab089-b7b7-4827-a9a4-ebc1dfcc7571', '$3.80'),
+    );
+    const subB = extractPartySubmission(
+      negotiationAnswers('b0cab089-b7b7-4827-a9a4-ebc1dfcc7571', '$3.80'),
+    );
+    const subC = extractPartySubmission(consensusAnswers);
+
+    const result = calculateNegotiationPayout(subA, subB, subC);
+    expect(result.isSuccess).toBe(true);
+    expect(result.payouts['party-a']).toBe(3.8);
+    expect(result.payouts['party-b']).toBe(3.8);
+  });
+
+  it('demonstrates the failure when consensus answers are read instead', () => {
+    // This is what happened when the wrong (consensus) survey was selected:
+    // no coalition/money is extractable, so every party comes back empty and
+    // the payout fails.
+    const subA = extractPartySubmission(consensusAnswers);
+    const subB = extractPartySubmission(consensusAnswers);
+    const subC = extractPartySubmission(consensusAnswers);
+
+    const result = calculateNegotiationPayout(subA, subB, subC);
+    expect(result.isSuccess).toBe(false);
+    expect(result.formedCoalition).toBe('None');
   });
 });

--- a/frontend/src/shared/negotiation_payout.utils.ts
+++ b/frontend/src/shared/negotiation_payout.utils.ts
@@ -23,6 +23,53 @@ export const COALITION_LIMITS: Record<string, number> = {
   'A+B+C': 7.8,
 };
 
+/** Stable id of the negotiation "Final Decision" survey in the GUIDE study. */
+export const NEGOTIATION_FINAL_DECISION_STAGE_ID =
+  'fa00266d-2987-4dc1-8f30-e8febb63939d';
+
+const COALITION_OPTION_TEXTS = ['A+B', 'A+C', 'B+C', 'A+B+C'];
+
+/** True if the survey stage offers the coalition multiple-choice options. */
+function hasCoalitionOptions(stage: SurveyStageConfig): boolean {
+  return (stage.questions ?? []).some(
+    (q) =>
+      'options' in q &&
+      Array.isArray((q as {options?: unknown[]}).options) &&
+      (q as {options: Array<{text?: string}>}).options.some((o) =>
+        COALITION_OPTION_TEXTS.includes(o.text?.trim().toUpperCase() ?? ''),
+      ),
+  );
+}
+
+/**
+ * Selects the negotiation "Final Decision" survey stage from all survey stages.
+ *
+ * The stable stage id is the reliable signal: experiments created from the
+ * template preserve stage ids (only the experiment id is regenerated), so the
+ * negotiation survey keeps this id regardless of how studies are ordered or
+ * concatenated. We deliberately do NOT fall back to a name match — a consensus
+ * study contributes its own "Task 3: Final Decision" survey, and matching on
+ * the name would pick the wrong one when that study is placed first.
+ *
+ * The only fallback is content-based: a survey offering the coalition options
+ * (A+B, A+C, B+C, A+B+C), which cannot be confused with a charity survey. This
+ * covers the case where the survey was rebuilt/duplicated in the editor and
+ * received a fresh id. If neither matches, we return undefined so the caller
+ * can show "not available" rather than silently reading an unrelated survey.
+ */
+export function findNegotiationFinalDecisionStage(
+  surveyStages: SurveyStageConfig[],
+): SurveyStageConfig | undefined {
+  // 1. Exact stage id (preserved from the template — the reliable signal).
+  const byId = surveyStages.find(
+    (s) => s.id === NEGOTIATION_FINAL_DECISION_STAGE_ID,
+  );
+  if (byId) return byId;
+
+  // 2. Fallback: survey offering the coalition options (A+B, A+C, B+C, A+B+C).
+  return surveyStages.find(hasCoalitionOptions);
+}
+
 /**
  * Calculates the negotiation coalition payout for Parties A, B, and C.
  */

--- a/frontend/src/shared/templates/guide_pilot_study.test.ts
+++ b/frontend/src/shared/templates/guide_pilot_study.test.ts
@@ -7,12 +7,7 @@ import {
 import {getGuidePilotStudyTemplate} from './guide_pilot_study';
 
 /** Stages whose id/name marks them as part of the negotiation (Task 2) flow. */
-const NEGOTIATION_MARKERS = [
-  'negotiation',
-  'coalition',
-  'task 2:',
-  'discussion-round-2',
-];
+const NEGOTIATION_MARKERS = ['negotiation', 'coalition', 'task 2:'];
 function isNegotiationStage(stage: StageConfig): boolean {
   const haystack = `${stage.id} ${stage.name}`.toLowerCase();
   return NEGOTIATION_MARKERS.some((marker) => haystack.includes(marker));

--- a/frontend/src/shared/templates/guide_pilot_study.ts
+++ b/frontend/src/shared/templates/guide_pilot_study.ts
@@ -18,12 +18,7 @@ import {
 // negotiation profile set. This coupling is intentionally kept here in the
 // template — not in shared profile utilities — so it cannot affect other
 // experiments. Stages are tagged via their `anonymousProfileSetId` field.
-const NEGOTIATION_STAGE_MARKERS = [
-  'negotiation',
-  'coalition',
-  'task 2:',
-  'discussion-round-2',
-];
+const NEGOTIATION_STAGE_MARKERS = ['negotiation', 'coalition', 'task 2:'];
 
 /** Whether a stage should display participants under the negotiation profile. */
 function usesNegotiationProfile(stage: StageConfig): boolean {
@@ -85,7 +80,7 @@ const GUIDE_DATA = {
       'f6914ebc-769a-41cc-adc8-1fb113972358',
       '920efc24-d396-49ce-9fe1-3f6a95aa8039',
       '3e5f2a96-d115-4702-9d98-6936db6e8197',
-      'discussion-round-1',
+      'open-ended-discussion',
       '0413e80a-da8b-4055-a1d5-3ef412e2db3b',
       '785cb971-93ac-4e44-8eab-2d124cff69ea',
       'bf61994e-937d-4c51-80bc-40cb9e733a41',
@@ -94,7 +89,7 @@ const GUIDE_DATA = {
       '4ea3db67-ef1c-4cc1-8954-64d66d39edf2',
       'negotiation_profile',
       '558e9053-bec9-4177-9bb2-d0d2fa1bb009',
-      'discussion-round-2',
+      'negotiation',
       'fa00266d-2987-4dc1-8f30-e8febb63939d',
       'negotiation_payout_summary',
       '6d620ceb-fe2e-4248-954f-8a0843e14e7c',
@@ -104,7 +99,7 @@ const GUIDE_DATA = {
       'ecd09d91-0c7a-4982-b69a-8cf1575883be',
       'e5121a12-4853-4507-88e9-11ed6baf1074',
       'bf56e614-4749-43fb-94ef-106770dad6b8',
-      'a0b13593-9dc6-4bb7-9034-51d1ae77918e',
+      'consensus-building',
       '122bac65-de76-4556-9e30-5dfef2945089',
       '3f3b9e04-a721-4491-8a76-f20b715d4fbe',
       '59ae8e87-152c-43f0-8013-64a0c5933d3e',
@@ -1238,8 +1233,8 @@ const GUIDE_DATA = {
         },
       ],
     },
-    'a0b13593-9dc6-4bb7-9034-51d1ae77918e': {
-      id: 'a0b13593-9dc6-4bb7-9034-51d1ae77918e',
+    'consensus-building': {
+      id: 'consensus-building',
       kind: 'chat',
       name: '\ud83c\udfe0 Task 3: Discussion',
       descriptions: {
@@ -1512,8 +1507,8 @@ const GUIDE_DATA = {
       ],
       youtubeVideoId: null,
     },
-    'discussion-round-1': {
-      id: 'discussion-round-1',
+    'open-ended-discussion': {
+      id: 'open-ended-discussion',
       kind: 'chat',
       name: '\ud83d\udde3\ufe0f Task 1: Discussion Period',
       descriptions: {
@@ -1533,8 +1528,8 @@ const GUIDE_DATA = {
       enableReactionsAndReplies: true,
       isTurnBased: false,
     },
-    'discussion-round-2': {
-      id: 'discussion-round-2',
+    negotiation: {
+      id: 'negotiation',
       kind: 'chat',
       name: '\ud83d\udcb0 Task 2: Discussion',
       descriptions: {
@@ -2073,8 +2068,8 @@ const GUIDE_DATA = {
         },
       },
       promptMap: {
-        'a0b13593-9dc6-4bb7-9034-51d1ae77918e': {
-          id: 'a0b13593-9dc6-4bb7-9034-51d1ae77918e',
+        'consensus-building': {
+          id: 'consensus-building',
           type: 'chat',
           prompt: [
             {
@@ -2093,7 +2088,7 @@ const GUIDE_DATA = {
             },
             {
               type: 'STAGE_CONTEXT',
-              stageId: 'a0b13593-9dc6-4bb7-9034-51d1ae77918e',
+              stageId: 'consensus-building',
               includePrimaryText: true,
               includeInfoText: false,
               includeHelpText: false,
@@ -2175,8 +2170,8 @@ const GUIDE_DATA = {
             initialMessage: '',
           },
         },
-        'discussion-round-1': {
-          id: 'discussion-round-1',
+        'open-ended-discussion': {
+          id: 'open-ended-discussion',
           type: 'chat',
           prompt: [
             {
@@ -2194,7 +2189,7 @@ const GUIDE_DATA = {
             },
             {
               type: 'STAGE_CONTEXT',
-              stageId: 'discussion-round-1',
+              stageId: 'open-ended-discussion',
               includePrimaryText: true,
               includeInfoText: false,
               includeHelpText: false,
@@ -2276,8 +2271,8 @@ const GUIDE_DATA = {
             initialMessage: '',
           },
         },
-        'discussion-round-2': {
-          id: 'discussion-round-2',
+        negotiation: {
+          id: 'negotiation',
           type: 'chat',
           prompt: [
             {
@@ -2296,7 +2291,7 @@ const GUIDE_DATA = {
             },
             {
               type: 'STAGE_CONTEXT',
-              stageId: 'discussion-round-2',
+              stageId: 'negotiation',
               includePrimaryText: true,
               includeInfoText: false,
               includeHelpText: false,


### PR DESCRIPTION
## Description
Two main changes for GUIDE template:
(1) change the stage id for discussion task into: open-ended, negotiation, consensus, instead of randomized string
(2) fix the bug: https://github.com/PAIR-code/deliberate-lab/issues/1213. The main issue is that there are two final decision stages in the study. The negotiation payout summary look for keyword "final decision" instead of the stage ID. 
(3) polish the text in the negotiation payout summary "Coalition validated" -> "The negotiating parties successfully formed a valid coalition."

## Verification
1. Create a new experiment and load the GUIDE template. 
2. Put Task 3 before Task 2
3. Use agents to run experiments
4. Expected result: when downloading the experiment, the conversation csv files should include new stage id as suffix. The negotiation payout summary should work now. 
