### PR TITLE
feat: add optional min and max timer to survey stage

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -2539,6 +2539,14 @@
         "anonymousProfileSetId": {
           "type": "string"
         },
+        "timeLimitInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "timeMinimumInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
         "questions": {
           "type": "array",
           "items": {

--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -2539,14 +2539,6 @@
         "anonymousProfileSetId": {
           "type": "string"
         },
-        "timeLimitInMinutes": {
-          "minimum": 1,
-          "type": ["integer", "null"]
-        },
-        "timeMinimumInMinutes": {
-          "minimum": 1,
-          "type": ["integer", "null"]
-        },
         "questions": {
           "type": "array",
           "items": {
@@ -2565,6 +2557,14 @@
               }
             ]
           }
+        },
+        "timeLimitInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "timeMinimumInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
         }
       }
     },

--- a/frontend/src/components/participant_view/participant_header.ts
+++ b/frontend/src/components/participant_view/participant_header.ts
@@ -53,10 +53,11 @@ export class Header extends MobxLitElement {
   private updateTimer() {
     if (!this.stage) return;
 
-    // Check if stage is chat (or other stage with time limit)
+    // Check if stage is chat or survey (or other stage with time limit)
     if (
       this.stage.kind === StageKind.CHAT ||
-      this.stage.kind === StageKind.PRIVATE_CHAT
+      this.stage.kind === StageKind.PRIVATE_CHAT ||
+      this.stage.kind === StageKind.SURVEY
     ) {
       if (this.stage.timeLimitInMinutes) {
         const publicStageData = this.cohortService.stagePublicDataMap[
@@ -69,11 +70,11 @@ export class Header extends MobxLitElement {
             : this.cohortService.chatMap;
 
         const startTimestamp =
-          this.stage.kind === StageKind.PRIVATE_CHAT
-            ? this.participantService.profile?.timestamps.readyStages[
+          this.stage.kind === StageKind.CHAT
+            ? publicStageData?.discussionStartTimestamp
+            : this.participantService.profile?.timestamps.readyStages[
                 this.stage.id
-              ]
-            : publicStageData?.discussionStartTimestamp;
+              ];
 
         this.timeRemaining = getChatTimeRemainingInSeconds(
           this.stage,

--- a/frontend/src/components/stages/group_chat_editor.ts
+++ b/frontend/src/components/stages/group_chat_editor.ts
@@ -6,8 +6,8 @@ import '@material/web/checkbox/checkbox.js';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';
-
 import {ExperimentEditor} from '../../services/experiment.editor';
+import {renderTimeLimit} from '../../shared/stage.utils';
 
 import {ChatStageConfig} from '@deliberation-lab/utils';
 
@@ -30,8 +30,12 @@ export class ChatEditor extends MobxLitElement {
 
     return html`
       <div class="title">Conversation settings</div>
-      ${this.renderTimeLimit()} ${this.renderTurnBasedSetting()}
-      ${this.renderReactionsSetting()}
+      ${renderTimeLimit({
+        stage: this.stage,
+        canEdit: this.experimentEditor.canEditStages,
+        onStageChange: (stage) => this.experimentEditor.updateStage(stage),
+      })}
+      ${this.renderTurnBasedSetting()} ${this.renderReactionsSetting()}
       <div class="divider"></div>
       <div class="title">Agent mediators</div>
       <div class="description">
@@ -118,94 +122,6 @@ export class ChatEditor extends MobxLitElement {
             </div>
           `,
         )}
-      </div>
-    `;
-  }
-
-  private renderTimeLimit() {
-    const timeLimit = this.stage?.timeLimitInMinutes;
-
-    const updateCheck = () => {
-      const isSet = this.stage?.timeLimitInMinutes != null;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeLimitInMinutes: isSet ? null : 20,
-        timeMinimumInMinutes: null,
-      });
-    };
-
-    const updateMaxTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeLimitInMinutes,
-      });
-    };
-
-    const updateMinTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const minTime = val > 0 ? Math.floor(val) : null;
-      const max = this.stage?.timeLimitInMinutes;
-      const timeMinimumInMinutes =
-        minTime != null && max != null ? Math.min(minTime, max) : minTime;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeMinimumInMinutes,
-      });
-    };
-
-    return html`
-      <div class="config-item">
-        <div class="checkbox-wrapper">
-          <md-checkbox
-            touch-target="wrapper"
-            ?checked=${timeLimit != null}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @click=${updateCheck}
-          >
-          </md-checkbox>
-          <div>Disable conversation after a fixed amount of time</div>
-        </div>
-        ${timeLimit != null
-          ? html`
-              <div class="number-input tab">
-                <label for="timeLimit">
-                  Maximum time in minutes (starting at first message).
-                  Participant will remain in chat until minimum messages
-                  requirement is met, even if maximum time has passed.
-                </label>
-                <input
-                  type="number"
-                  id="timeLimit"
-                  name="timeLimit"
-                  min="1"
-                  step="1"
-                  .value=${timeLimit}
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMaxTime}
-                />
-              </div>
-              <div class="number-input tab tab-bottom">
-                <label for="timeMinimum">
-                  Minimum time participants must stay (in minutes). Takes
-                  precedence over maximum number of messages.
-                </label>
-                <input
-                  type="number"
-                  id="timeMinimum"
-                  name="timeMinimum"
-                  min="1"
-                  step="1"
-                  .max=${timeLimit ?? ''}
-                  .value=${this.stage?.timeMinimumInMinutes ?? ''}
-                  placeholder="No minimum"
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMinTime}
-                />
-              </div>
-            `
-          : nothing}
       </div>
     `;
   }

--- a/frontend/src/components/stages/private_chat_editor.ts
+++ b/frontend/src/components/stages/private_chat_editor.ts
@@ -6,6 +6,7 @@ import '@material/web/checkbox/checkbox.js';
 
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
+import {renderTimeLimit} from '../../shared/stage.utils';
 
 import {PrivateChatStageConfig} from '@deliberation-lab/utils';
 
@@ -26,7 +27,12 @@ export class ChatEditor extends MobxLitElement {
 
     return html`
       <div class="title">Conversation settings</div>
-      ${this.renderTimeLimit()} ${this.renderPreventCancellation()}
+      ${renderTimeLimit({
+        stage: this.stage,
+        canEdit: this.experimentEditor.canEditStages,
+        onStageChange: (stage) => this.experimentEditor.updateStage(stage),
+      })}
+      ${this.renderPreventCancellation()}
       <div class="divider"></div>
       <div class="title">Message limits</div>
       ${this.renderTurnBasedChat()} ${this.renderMinNumberOfTurns()}
@@ -37,94 +43,6 @@ export class ChatEditor extends MobxLitElement {
         Navigate to "Agent mediators" tab to add or edit mediators
       </div>
       ${this.renderMediators()}
-    `;
-  }
-
-  private renderTimeLimit() {
-    const timeLimit = this.stage?.timeLimitInMinutes;
-
-    const updateCheck = () => {
-      const isSet = this.stage?.timeLimitInMinutes != null;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeLimitInMinutes: isSet ? null : 20,
-        timeMinimumInMinutes: null,
-      });
-    };
-
-    const updateMaxTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeLimitInMinutes,
-      });
-    };
-
-    const updateMinTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const minTime = val > 0 ? Math.floor(val) : null;
-      const max = this.stage?.timeLimitInMinutes;
-      const timeMinimumInMinutes =
-        minTime != null && max != null ? Math.min(minTime, max) : minTime;
-      this.experimentEditor.updateStage({
-        ...this.stage!,
-        timeMinimumInMinutes,
-      });
-    };
-
-    return html`
-      <div class="config-item">
-        <div class="checkbox-wrapper">
-          <md-checkbox
-            touch-target="wrapper"
-            ?checked=${timeLimit != null}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @click=${updateCheck}
-          >
-          </md-checkbox>
-          <div>Disable conversation after a fixed amount of time</div>
-        </div>
-        ${timeLimit != null
-          ? html`
-              <div class="number-input tab">
-                <label for="timeLimit">
-                  Maximum time in minutes (starting at first message).
-                  Participant will remain in chat until minimum messages
-                  requirement is met, even if maximum time has passed.
-                </label>
-                <input
-                  type="number"
-                  id="timeLimit"
-                  name="timeLimit"
-                  min="1"
-                  step="1"
-                  .value=${timeLimit}
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMaxTime}
-                />
-              </div>
-              <div class="number-input tab tab-bottom">
-                <label for="timeMinimum">
-                  Minimum time participants must stay (in minutes). Takes
-                  precedence over maximum number of messages.
-                </label>
-                <input
-                  type="number"
-                  id="timeMinimum"
-                  name="timeMinimum"
-                  min="1"
-                  step="1"
-                  .max=${timeLimit ?? ''}
-                  .value=${this.stage?.timeMinimumInMinutes ?? ''}
-                  placeholder="No minimum"
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMinTime}
-                />
-              </div>
-            `
-          : nothing}
-      </div>
     `;
   }
 

--- a/frontend/src/components/stages/survey_editor.scss
+++ b/frontend/src/components/stages/survey_editor.scss
@@ -133,3 +133,13 @@ pr-textarea-template {
   flex: 1;
   gap: common.$spacing-small;
 }
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}
+
+.tab {
+  margin-top: 0px;
+  margin-left: calc(48px + common.$spacing-medium);
+}

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -8,6 +8,7 @@ import '../../pair-components/textarea_template';
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
 import {renderConditionEditor} from '../../shared/condition_editor.utils';
+import {renderTimeLimit} from '../../shared/stage.utils';
 import {
   CheckSurveyQuestion,
   Condition,
@@ -47,7 +48,17 @@ export class SurveyEditor extends MobxLitElement {
     }
 
     return html`
-      ${this.renderTimeLimit()}
+      ${this.stage.kind === StageKind.SURVEY
+        ? renderTimeLimit({
+            stage: this.stage,
+            canEdit: this.experimentEditor.canEditStages,
+            onStageChange: (stage) => this.experimentEditor.updateStage(stage),
+            checkboxTitle: 'Set time limit for survey',
+            maxTimeLabel:
+              'Maximum time in minutes (starting when participant enters stage).',
+            minTimeLabel: 'Minimum time participants must stay (in minutes).',
+          })
+        : nothing}
       <div class="section">
         <div class="header">
           <div class="title">Survey questions</div>
@@ -56,96 +67,6 @@ export class SurveyEditor extends MobxLitElement {
         ${this.stage.questions.map((question, index) =>
           this.renderQuestion(question, index),
         )}
-      </div>
-    `;
-  }
-
-  private renderTimeLimit() {
-    if (this.stage?.kind !== StageKind.SURVEY) {
-      return nothing;
-    }
-    const stage = this.stage;
-    const timeLimit = stage.timeLimitInMinutes;
-
-    const updateCheck = () => {
-      const isSet = stage.timeLimitInMinutes != null;
-      this.experimentEditor.updateStage({
-        ...stage,
-        timeLimitInMinutes: isSet ? null : 20,
-        timeMinimumInMinutes: null,
-      });
-    };
-
-    const updateMaxTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
-      this.experimentEditor.updateStage({
-        ...stage,
-        timeLimitInMinutes,
-      });
-    };
-
-    const updateMinTime = (e: InputEvent) => {
-      const val = (e.target as HTMLInputElement).valueAsNumber;
-      const minTime = val > 0 ? Math.floor(val) : null;
-      const max = stage.timeLimitInMinutes;
-      const timeMinimumInMinutes =
-        minTime != null && max != null ? Math.min(minTime, max) : minTime;
-      this.experimentEditor.updateStage({
-        ...stage,
-        timeMinimumInMinutes,
-      });
-    };
-
-    return html`
-      <div class="config-item">
-        <div class="checkbox-wrapper">
-          <md-checkbox
-            touch-target="wrapper"
-            ?checked=${timeLimit != null}
-            ?disabled=${!this.experimentEditor.canEditStages}
-            @click=${updateCheck}
-          >
-          </md-checkbox>
-          <div>Set time limit for survey</div>
-        </div>
-        ${timeLimit != null
-          ? html`
-              <div class="number-input tab">
-                <label for="timeLimit">
-                  Maximum time in minutes (starting when participant enters
-                  stage).
-                </label>
-                <input
-                  type="number"
-                  id="timeLimit"
-                  name="timeLimit"
-                  min="1"
-                  step="1"
-                  .value=${timeLimit}
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMaxTime}
-                />
-              </div>
-              <div class="number-input tab tab-bottom">
-                <label for="timeMinimum">
-                  Minimum time participants must stay (in minutes).
-                </label>
-                <input
-                  type="number"
-                  id="timeMinimum"
-                  name="timeMinimum"
-                  min="1"
-                  step="1"
-                  .max=${timeLimit ?? ''}
-                  .value=${stage.timeMinimumInMinutes ?? ''}
-                  placeholder="No minimum"
-                  ?disabled=${!this.experimentEditor.canEditStages}
-                  @input=${updateMinTime}
-                />
-              </div>
-            `
-          : nothing}
       </div>
     `;
   }

--- a/frontend/src/components/stages/survey_editor.ts
+++ b/frontend/src/components/stages/survey_editor.ts
@@ -18,6 +18,7 @@ import {
   isMultipleChoiceImageQuestion,
   sanitizeSurveyQuestionConditions,
   ScaleSurveyQuestion,
+  StageKind,
   SurveyPerParticipantStageConfig,
   SurveyStageConfig,
   SurveyQuestion,
@@ -46,6 +47,7 @@ export class SurveyEditor extends MobxLitElement {
     }
 
     return html`
+      ${this.renderTimeLimit()}
       <div class="section">
         <div class="header">
           <div class="title">Survey questions</div>
@@ -54,6 +56,96 @@ export class SurveyEditor extends MobxLitElement {
         ${this.stage.questions.map((question, index) =>
           this.renderQuestion(question, index),
         )}
+      </div>
+    `;
+  }
+
+  private renderTimeLimit() {
+    if (this.stage?.kind !== StageKind.SURVEY) {
+      return nothing;
+    }
+    const stage = this.stage;
+    const timeLimit = stage.timeLimitInMinutes;
+
+    const updateCheck = () => {
+      const isSet = stage.timeLimitInMinutes != null;
+      this.experimentEditor.updateStage({
+        ...stage,
+        timeLimitInMinutes: isSet ? null : 20,
+        timeMinimumInMinutes: null,
+      });
+    };
+
+    const updateMaxTime = (e: InputEvent) => {
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
+      this.experimentEditor.updateStage({
+        ...stage,
+        timeLimitInMinutes,
+      });
+    };
+
+    const updateMinTime = (e: InputEvent) => {
+      const val = (e.target as HTMLInputElement).valueAsNumber;
+      const minTime = val > 0 ? Math.floor(val) : null;
+      const max = stage.timeLimitInMinutes;
+      const timeMinimumInMinutes =
+        minTime != null && max != null ? Math.min(minTime, max) : minTime;
+      this.experimentEditor.updateStage({
+        ...stage,
+        timeMinimumInMinutes,
+      });
+    };
+
+    return html`
+      <div class="config-item">
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${timeLimit != null}
+            ?disabled=${!this.experimentEditor.canEditStages}
+            @click=${updateCheck}
+          >
+          </md-checkbox>
+          <div>Set time limit for survey</div>
+        </div>
+        ${timeLimit != null
+          ? html`
+              <div class="number-input tab">
+                <label for="timeLimit">
+                  Maximum time in minutes (starting when participant enters
+                  stage).
+                </label>
+                <input
+                  type="number"
+                  id="timeLimit"
+                  name="timeLimit"
+                  min="1"
+                  step="1"
+                  .value=${timeLimit}
+                  ?disabled=${!this.experimentEditor.canEditStages}
+                  @input=${updateMaxTime}
+                />
+              </div>
+              <div class="number-input tab tab-bottom">
+                <label for="timeMinimum">
+                  Minimum time participants must stay (in minutes).
+                </label>
+                <input
+                  type="number"
+                  id="timeMinimum"
+                  name="timeMinimum"
+                  min="1"
+                  step="1"
+                  .max=${timeLimit ?? ''}
+                  .value=${stage.timeMinimumInMinutes ?? ''}
+                  placeholder="No minimum"
+                  ?disabled=${!this.experimentEditor.canEditStages}
+                  @input=${updateMinTime}
+                />
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/frontend/src/components/stages/survey_editor_menu.scss
+++ b/frontend/src/components/stages/survey_editor_menu.scss
@@ -1,6 +1,6 @@
-@use "../../sass/colors";
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/colors';
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -34,6 +34,7 @@ import {
   isQuestionVisible,
   isSurveyComplete,
   isSurveyAnswerComplete,
+  getTimeElapsed,
 } from '@deliberation-lab/utils';
 
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
@@ -56,6 +57,22 @@ export class SurveyView extends MobxLitElement {
 
   @property() stage: SurveyStageConfig | undefined = undefined;
 
+  private timerInterval: number | undefined;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.timerInterval = window.setInterval(() => {
+      if (this.stage?.timeMinimumInMinutes || this.stage?.timeLimitInMinutes) {
+        this.requestUpdate();
+      }
+    }, 1000);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.clearInterval(this.timerInterval);
+  }
+
   override render() {
     if (!this.stage) {
       return nothing;
@@ -77,6 +94,20 @@ export class SurveyView extends MobxLitElement {
       return isSurveyComplete(visibleQuestions, currentSurveyAnswers);
     };
 
+    const startTimestamp =
+      this.participantService.profile?.timestamps.readyStages[this.stage.id];
+    const elapsedMinutes = startTimestamp
+      ? getTimeElapsed(startTimestamp, 'm')
+      : 0;
+
+    const minTimeMet =
+      this.stage.timeMinimumInMinutes == null ||
+      this.stage.timeMinimumInMinutes <= 0 ||
+      (startTimestamp != null &&
+        elapsedMinutes >= this.stage.timeMinimumInMinutes);
+
+    const isNextDisabled = !questionsComplete() || !minTimeMet;
+
     const saveAnswers = async () => {
       if (!this.stage) return;
 
@@ -95,14 +126,24 @@ export class SurveyView extends MobxLitElement {
           return nothing;
         })}
       </div>
-      <stage-footer
-        .disabled=${!questionsComplete()}
-        .onNextClick=${saveAnswers}
-      >
+      <stage-footer .disabled=${isNextDisabled} .onNextClick=${saveAnswers}>
         ${this.stage.progress.showParticipantProgress
           ? html`<progress-stage-completed></progress-stage-completed>`
           : nothing}
+        ${!minTimeMet ? this.renderMinTimeMessage(elapsedMinutes) : nothing}
       </stage-footer>
+    `;
+  }
+
+  private renderMinTimeMessage(elapsedMinutes: number) {
+    const remaining = Math.ceil(
+      (this.stage?.timeMinimumInMinutes ?? 0) - elapsedMinutes,
+    );
+    return html`
+      <div class="description">
+        You must stay on this page for at least ${remaining} more
+        minute${remaining !== 1 ? 's' : ''}.
+      </div>
     `;
   }
 

--- a/frontend/src/components/stages/survey_view.ts
+++ b/frontend/src/components/stages/survey_view.ts
@@ -100,6 +100,11 @@ export class SurveyView extends MobxLitElement {
       ? getTimeElapsed(startTimestamp, 'm')
       : 0;
 
+    // Timing check:
+    // - timeMinimumInMinutes strictly gates the "Next stage" button until met.
+    // - timeLimitInMinutes drives the visual countdown timer in participant-header;
+    //   participants can still complete and edit survey responses after the max time
+    //   is reached (no hard cutoff) to prevent data loss.
     const minTimeMet =
       this.stage.timeMinimumInMinutes == null ||
       this.stage.timeMinimumInMinutes <= 0 ||

--- a/frontend/src/shared/stage.utils.ts
+++ b/frontend/src/shared/stage.utils.ts
@@ -1,3 +1,4 @@
+import {html, nothing} from 'lit';
 import {ChatMessage, UnifiedTimestamp} from '@deliberation-lab/utils';
 import {Timestamp} from 'firebase/firestore';
 
@@ -38,4 +39,115 @@ export function getChatTimeRemainingInSeconds(
   const elapsed = Timestamp.now().seconds - startTimestamp.seconds;
   const remaining = chatStage.timeLimitInMinutes * 60 - elapsed;
   return remaining > 0 ? Math.floor(remaining) : 0;
+}
+
+export interface StageWithTimeLimit {
+  timeLimitInMinutes: number | null;
+  timeMinimumInMinutes: number | null;
+}
+
+export interface RenderTimeLimitOptions<T extends StageWithTimeLimit> {
+  stage: T | undefined;
+  canEdit: boolean;
+  onStageChange: (stage: T) => void;
+  checkboxTitle?: string;
+  maxTimeLabel?: string;
+  minTimeLabel?: string;
+}
+
+/**
+ * Renders the stage time limit editor controls (toggle, max time, min time).
+ */
+export function renderTimeLimit<T extends StageWithTimeLimit>(
+  options: RenderTimeLimitOptions<T>,
+) {
+  const {
+    stage,
+    canEdit,
+    onStageChange,
+    checkboxTitle = 'Disable conversation after a fixed amount of time',
+    maxTimeLabel = 'Maximum time in minutes (starting at first message). Participant will remain in chat until minimum messages requirement is met, even if maximum time has passed.',
+    minTimeLabel = 'Minimum time participants must stay (in minutes). Takes precedence over maximum number of messages.',
+  } = options;
+
+  if (!stage) return nothing;
+
+  const timeLimit = stage.timeLimitInMinutes;
+
+  const updateCheck = () => {
+    const isSet = stage.timeLimitInMinutes != null;
+    onStageChange({
+      ...stage,
+      timeLimitInMinutes: isSet ? null : 20,
+      timeMinimumInMinutes: null,
+    });
+  };
+
+  const updateMaxTime = (e: InputEvent) => {
+    const val = (e.target as HTMLInputElement).valueAsNumber;
+    const timeLimitInMinutes = val > 0 ? Math.floor(val) : null;
+    onStageChange({
+      ...stage,
+      timeLimitInMinutes,
+    });
+  };
+
+  const updateMinTime = (e: InputEvent) => {
+    const val = (e.target as HTMLInputElement).valueAsNumber;
+    const minTime = val > 0 ? Math.floor(val) : null;
+    const max = stage.timeLimitInMinutes;
+    const timeMinimumInMinutes =
+      minTime != null && max != null ? Math.min(minTime, max) : minTime;
+    onStageChange({
+      ...stage,
+      timeMinimumInMinutes,
+    });
+  };
+
+  return html`
+    <div class="config-item">
+      <div class="checkbox-wrapper">
+        <md-checkbox
+          touch-target="wrapper"
+          ?checked=${timeLimit != null}
+          ?disabled=${!canEdit}
+          @click=${updateCheck}
+        >
+        </md-checkbox>
+        <div>${checkboxTitle}</div>
+      </div>
+      ${timeLimit != null
+        ? html`
+            <div class="number-input tab">
+              <label for="timeLimit">${maxTimeLabel}</label>
+              <input
+                type="number"
+                id="timeLimit"
+                name="timeLimit"
+                min="1"
+                step="1"
+                .value=${timeLimit}
+                ?disabled=${!canEdit}
+                @input=${updateMaxTime}
+              />
+            </div>
+            <div class="number-input tab tab-bottom">
+              <label for="timeMinimum">${minTimeLabel}</label>
+              <input
+                type="number"
+                id="timeMinimum"
+                name="timeMinimum"
+                min="1"
+                step="1"
+                .max=${timeLimit ?? ''}
+                .value=${stage.timeMinimumInMinutes ?? ''}
+                placeholder="No minimum"
+                ?disabled=${!canEdit}
+                @input=${updateMinTime}
+              />
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
 }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -1335,6 +1335,8 @@ class SurveyStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     anonymousProfileSetId: str | None = None
+    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
+    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     questions: list[
         TextSurveyQuestion
         | CheckSurveyQuestion

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -1335,14 +1335,14 @@ class SurveyStageConfig(BaseModel):
     descriptions: StageTextConfig
     progress: StageProgressConfig
     anonymousProfileSetId: str | None = None
-    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
-    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
     questions: list[
         TextSurveyQuestion
         | CheckSurveyQuestion
         | MultipleChoiceSurveyQuestion
         | ScaleSurveyQuestion
     ]
+    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
+    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
 
 
 class TransferStageConfig(BaseModel):

--- a/utils/src/stages/survey_stage.ts
+++ b/utils/src/stages/survey_stage.ts
@@ -30,6 +30,8 @@ import {
 export interface SurveyStageConfig extends BaseStageConfig {
   kind: StageKind.SURVEY;
   questions: SurveyQuestion[];
+  timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
+  timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
 }
 
 /** Special "survey per participant" stage
@@ -179,6 +181,8 @@ export function createSurveyStage(
     descriptions: config.descriptions ?? createStageTextConfig(),
     progress: config.progress ?? createStageProgressConfig(),
     questions: config.questions ?? [],
+    timeLimitInMinutes: config.timeLimitInMinutes ?? null,
+    timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
   };
 }
 

--- a/utils/src/stages/survey_stage.validation.test.ts
+++ b/utils/src/stages/survey_stage.validation.test.ts
@@ -1,5 +1,10 @@
-import {validateSurveyQuestions} from './survey_stage.validation';
 import {
+  validateSurveyQuestions,
+  validateSurveyStageConfig,
+} from './survey_stage.validation';
+import {
+  createSurveyStage,
+  createTextSurveyQuestion,
   SurveyQuestionKind,
   MultipleChoiceDisplayType,
   SurveyQuestion,
@@ -217,6 +222,66 @@ describe('validateSurveyQuestions', () => {
     if (!res.valid) {
       expect(res.error).toContain(
         'has a correct answer ID "opt3" that doesn\'t match any option ID',
+      );
+    }
+  });
+});
+
+describe('validateSurveyStageConfig', () => {
+  it('should pass with default configuration (no timer)', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+    });
+    expect(validateSurveyStageConfig(stage)).toEqual({valid: true});
+  });
+
+  it('should pass when timeMinimumInMinutes <= timeLimitInMinutes', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+      timeLimitInMinutes: 10,
+      timeMinimumInMinutes: 5,
+    });
+    expect(validateSurveyStageConfig(stage)).toEqual({valid: true});
+  });
+
+  it('should pass when timeMinimumInMinutes equals timeLimitInMinutes', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+      timeLimitInMinutes: 5,
+      timeMinimumInMinutes: 5,
+    });
+    expect(validateSurveyStageConfig(stage)).toEqual({valid: true});
+  });
+
+  it('should pass when only timeLimitInMinutes is set', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+      timeLimitInMinutes: 5,
+      timeMinimumInMinutes: null,
+    });
+    expect(validateSurveyStageConfig(stage)).toEqual({valid: true});
+  });
+
+  it('should pass when only timeMinimumInMinutes is set', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+      timeLimitInMinutes: null,
+      timeMinimumInMinutes: 5,
+    });
+    expect(validateSurveyStageConfig(stage)).toEqual({valid: true});
+  });
+
+  it('should fail when timeMinimumInMinutes exceeds timeLimitInMinutes', () => {
+    const stage = createSurveyStage({
+      questions: [createTextSurveyQuestion({questionTitle: 'Feedback'})],
+      timeLimitInMinutes: 5,
+      timeMinimumInMinutes: 10,
+    });
+    const res = validateSurveyStageConfig(stage);
+    expect(res.valid).toBe(false);
+    if (!res.valid) {
+      expect(res.error).toContain(
+        'timeMinimumInMinutes (10) cannot exceed timeLimitInMinutes (5)',
       );
     }
   });

--- a/utils/src/stages/survey_stage.validation.ts
+++ b/utils/src/stages/survey_stage.validation.ts
@@ -112,6 +112,12 @@ export const SurveyStageConfigData = Type.Composite(
       {
         kind: Type.Literal(StageKind.SURVEY),
         questions: Type.Array(SurveyQuestionData),
+        timeLimitInMinutes: Type.Optional(
+          Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+        ),
+        timeMinimumInMinutes: Type.Optional(
+          Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+        ),
       },
       strict,
     ),
@@ -309,7 +315,19 @@ export function validateSurveyQuestions(
 export function validateSurveyStageConfig(
   stage: BaseStageConfig,
 ): StageValidationResult {
-  const {questions} = stage as SurveyStageConfig;
+  const {
+    questions,
+    timeMinimumInMinutes: min,
+    timeLimitInMinutes: max,
+  } = stage as SurveyStageConfig;
+
+  if (min != null && max != null && min > max) {
+    return {
+      valid: false,
+      error: `timeMinimumInMinutes (${min}) cannot exceed timeLimitInMinutes (${max})`,
+    };
+  }
+
   return validateSurveyQuestions(questions);
 }
 


### PR DESCRIPTION
## Description
Adds optional minimum and maximum timer functionality to the Survey stage, mirroring the existing timer implementation in privateChat and group chat stages.


- **Data model**: Added optional `timeLimitInMinutes` and `timeMinimumInMinutes` to `SurveyStageConfig` (defaults to `null` for backward compatibility).
- **Validation**: Added TypeBox schema validation and business rule check ensuring `timeMinimumInMinutes <= timeLimitInMinutes`.
- **Experimenter UI**: Added timer configuration controls to `SurveyEditor` (toggle checkbox, max time input, and min time input).
- **Participant UI**:
  - Top header (`participant-header`) displays the countdown timer icon and `MM:SS` countdown when `timeLimitInMinutes` is configured.
  - Survey footer disables progression until both all required questions are answered AND minimum time has elapsed, displaying a helper countdown message.
- **Schemas**: Updated `schemas.json` and Python client types in `scripts/deliberate_lab/types.py`.
- [x] Documentation updated as needed

---

## Verification
- [x] All unit tests pass (`npm test --workspace=utils`, `npm test --workspace=frontend`, `npm test --workspace=functions`).
- [x] Formatting and linter checks pass (`prettier`, `eslint`).
- [x] Verified locally using Firebase emulators and frontend app:
  1. Created a survey stage with max time = 2 min and min time = 1 min.
  2. Verified header live countdown `2:00` -> `0:00`.
  3. Verified "Next stage" button stays disabled until 1 minute elapses with notice message.
  4. Verified "Next stage" button enables and allows stage progression once min time is met.
---

## Related issues

---
