### PR TITLE
feat: add optional min and max timer to info stage

### DIFF
--- a/docs/assets/api/schemas.json
+++ b/docs/assets/api/schemas.json
@@ -1144,6 +1144,14 @@
         },
         "youtubeVideoId": {
           "type": ["null", "string"]
+        },
+        "timeLimitInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "timeMinimumInMinutes": {
+          "minimum": 1,
+          "type": ["integer", "null"]
         }
       }
     },

--- a/frontend/src/components/participant_view/participant_header.ts
+++ b/frontend/src/components/participant_view/participant_header.ts
@@ -53,11 +53,12 @@ export class Header extends MobxLitElement {
   private updateTimer() {
     if (!this.stage) return;
 
-    // Check if stage is chat or survey (or other stage with time limit)
+    // Check if stage is chat, survey, or info (or other stage with time limit)
     if (
       this.stage.kind === StageKind.CHAT ||
       this.stage.kind === StageKind.PRIVATE_CHAT ||
-      this.stage.kind === StageKind.SURVEY
+      this.stage.kind === StageKind.SURVEY ||
+      this.stage.kind === StageKind.INFO
     ) {
       if (this.stage.timeLimitInMinutes) {
         const publicStageData = this.cohortService.stagePublicDataMap[

--- a/frontend/src/components/stages/info_editor.scss
+++ b/frontend/src/components/stages/info_editor.scss
@@ -15,3 +15,23 @@ pr-textarea-template {
 md-outlined-text-field {
   width: 100%;
 }
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+.number-input {
+  @include common.number-input;
+  width: max-content;
+}
+
+.tab {
+  margin-top: 0px;
+  margin-left: calc(48px + common.$spacing-medium);
+}

--- a/frontend/src/components/stages/info_editor.ts
+++ b/frontend/src/components/stages/info_editor.ts
@@ -1,11 +1,13 @@
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
+import '@material/web/checkbox/checkbox.js';
 import '@material/web/textfield/outlined-text-field.js';
 import '../../pair-components/textarea_template';
 
 import {core} from '../../core/core';
 import {ExperimentEditor} from '../../services/experiment.editor';
+import {renderTimeLimit} from '../../shared/stage.utils';
 
 import {InfoStageConfig} from '@deliberation-lab/utils';
 
@@ -25,7 +27,18 @@ export class InfoEditorComponent extends MobxLitElement {
       return nothing;
     }
 
-    return html` ${this.renderInfoLines()} ${this.renderYouTubeInput()} `;
+    return html`
+      ${renderTimeLimit({
+        stage: this.stage,
+        canEdit: this.experimentEditor.canEditStages,
+        onStageChange: (stage) => this.experimentEditor.updateStage(stage),
+        checkboxTitle: 'Set time limit for info stage',
+        maxTimeLabel:
+          'Maximum time in minutes (starting when participant enters stage).',
+        minTimeLabel: 'Minimum time participants must stay (in minutes).',
+      })}
+      ${this.renderInfoLines()} ${this.renderYouTubeInput()}
+    `;
   }
 
   private renderYouTubeInput() {

--- a/frontend/src/components/stages/info_view.scss
+++ b/frontend/src/components/stages/info_view.scss
@@ -1,5 +1,5 @@
-@use "../../sass/common";
-@use "../../sass/typescale";
+@use '../../sass/common';
+@use '../../sass/typescale';
 
 :host {
   @include common.flex-column;
@@ -30,4 +30,9 @@
   max-width: 100%;
   display: block;
   margin: auto;
+}
+
+.description {
+  @include typescale.body-medium;
+  color: var(--md-sys-color-on-surface-variant);
 }

--- a/frontend/src/components/stages/info_view.ts
+++ b/frontend/src/components/stages/info_view.ts
@@ -7,7 +7,9 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
-import {InfoStageConfig} from '@deliberation-lab/utils';
+import {InfoStageConfig, getTimeElapsed} from '@deliberation-lab/utils';
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant.service';
 
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {convertMarkdownToHTML} from '../../shared/utils';
@@ -18,12 +20,46 @@ import {styles} from './info_view.scss';
 export class InfoView extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
+  private readonly participantService = core.getService(ParticipantService);
+
   @property() stage: InfoStageConfig | null = null;
+
+  private timerInterval: number | undefined;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.timerInterval = window.setInterval(() => {
+      if (this.stage?.timeMinimumInMinutes || this.stage?.timeLimitInMinutes) {
+        this.requestUpdate();
+      }
+    }, 1000);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.clearInterval(this.timerInterval);
+  }
 
   override render() {
     if (!this.stage) {
       return nothing;
     }
+
+    const startTimestamp =
+      this.participantService.profile?.timestamps.readyStages[this.stage.id];
+    const elapsedMinutes = startTimestamp
+      ? getTimeElapsed(startTimestamp, 'm')
+      : 0;
+
+    // Timing check:
+    // - timeMinimumInMinutes strictly gates the "Next stage" button until met.
+    // - timeLimitInMinutes drives the visual countdown timer in participant-header;
+    //   participants can still view info after the max time is reached (no hard cutoff).
+    const minTimeMet =
+      this.stage.timeMinimumInMinutes == null ||
+      this.stage.timeMinimumInMinutes <= 0 ||
+      (startTimestamp != null &&
+        elapsedMinutes >= this.stage.timeMinimumInMinutes);
 
     const infoLinesJoined = this.stage?.infoLines.join('\n\n');
     return html`
@@ -48,11 +84,24 @@ export class InfoView extends MobxLitElement {
             `
           : nothing}
       </div>
-      <stage-footer>
+      <stage-footer .disabled=${!minTimeMet}>
         ${this.stage.progress.showParticipantProgress
           ? html`<progress-stage-completed></progress-stage-completed>`
           : nothing}
+        ${!minTimeMet ? this.renderMinTimeMessage(elapsedMinutes) : nothing}
       </stage-footer>
+    `;
+  }
+
+  private renderMinTimeMessage(elapsedMinutes: number) {
+    const remaining = Math.ceil(
+      (this.stage?.timeMinimumInMinutes ?? 0) - elapsedMinutes,
+    );
+    return html`
+      <div class="description">
+        You must stay on this page for at least ${remaining} more
+        minute${remaining !== 1 ? 's' : ''}.
+      </div>
     `;
   }
 }

--- a/scripts/deliberate_lab/types.py
+++ b/scripts/deliberate_lab/types.py
@@ -290,6 +290,8 @@ class InfoStageConfig(BaseModel):
     anonymousProfileSetId: str | None = None
     infoLines: list[str]
     youtubeVideoId: str | None = None
+    timeLimitInMinutes: Annotated[int | None, Field(ge=1)] = None
+    timeMinimumInMinutes: Annotated[int | None, Field(ge=1)] = None
 
 
 class Currency(StrEnum):

--- a/utils/src/stages/info_stage.ts
+++ b/utils/src/stages/info_stage.ts
@@ -16,6 +16,8 @@ export interface InfoStageConfig extends BaseStageConfig {
   kind: StageKind.INFO;
   infoLines: string[];
   youtubeVideoId?: string;
+  timeLimitInMinutes: number | null; // Maximum duration in minutes (integer), or null if no limit.
+  timeMinimumInMinutes: number | null; // Minimum time participants must stay in minutes (integer), or null if no minimum.
 }
 
 // ************************************************************************* //
@@ -48,6 +50,8 @@ export function createInfoStage(
     progress: config.progress ?? createStageProgressConfig(),
     infoLines: config.infoLines ?? [],
     youtubeVideoId: config.youtubeVideoId,
+    timeLimitInMinutes: config.timeLimitInMinutes ?? null,
+    timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
   };
 }
 
@@ -63,5 +67,7 @@ export function createTutorialInfoStage(
     progress: config.progress ?? createStageProgressConfig(),
     infoLines: config.infoLines ?? TUTORIAL_INFO_LINES,
     youtubeVideoId: config.youtubeVideoId,
+    timeLimitInMinutes: config.timeLimitInMinutes ?? null,
+    timeMinimumInMinutes: config.timeMinimumInMinutes ?? null,
   };
 }

--- a/utils/src/stages/info_stage.validation.ts
+++ b/utils/src/stages/info_stage.validation.ts
@@ -1,6 +1,10 @@
 import {Type, type Static} from '@sinclair/typebox';
-import {StageKind} from './stage';
-import {BaseStageConfigSchema} from './stage.schemas';
+import {BaseStageConfig, StageKind} from './stage';
+import {
+  BaseStageConfigSchema,
+  type StageValidationResult,
+} from './stage.schemas';
+import {InfoStageConfig} from './info_stage';
 
 /** Shorthand for strict TypeBox object validation */
 const strict = {additionalProperties: false} as const;
@@ -19,9 +23,35 @@ export const InfoStageConfigData = Type.Composite(
         infoLines: Type.Array(Type.String()),
         // Optional YouTube video ID to display
         youtubeVideoId: Type.Optional(Type.Union([Type.Null(), Type.String()])),
+        timeLimitInMinutes: Type.Optional(
+          Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+        ),
+        timeMinimumInMinutes: Type.Optional(
+          Type.Union([Type.Integer({minimum: 1}), Type.Null()]),
+        ),
       },
       strict,
     ),
   ],
   {$id: 'InfoStageConfig', ...strict},
 );
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+
+export function validateInfoStageConfig(
+  stage: BaseStageConfig,
+): StageValidationResult {
+  const {timeMinimumInMinutes: min, timeLimitInMinutes: max} =
+    stage as InfoStageConfig;
+
+  if (min != null && max != null && min > max) {
+    return {
+      valid: false,
+      error: `timeMinimumInMinutes (${min}) cannot exceed timeLimitInMinutes (${max})`,
+    };
+  }
+
+  return {valid: true};
+}

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -13,7 +13,10 @@ import {ChipStageConfigData} from './chip_stage.validation';
 import {ComprehensionStageConfigData} from './comprehension_stage.validation';
 import {FlipCardStageConfigData} from './flipcard_stage.validation';
 import {RankingStageConfigData} from './ranking_stage.validation';
-import {InfoStageConfigData} from './info_stage.validation';
+import {
+  InfoStageConfigData,
+  validateInfoStageConfig,
+} from './info_stage.validation';
 import {PayoutStageConfigData} from './payout_stage.validation';
 import {
   PrivateChatStageConfigData,
@@ -60,7 +63,7 @@ export const CONFIG_DATA: Record<string, StageConfigEntry> = {
   chip: {schema: ChipStageConfigData},
   comprehension: {schema: ComprehensionStageConfigData},
   flipcard: {schema: FlipCardStageConfigData},
-  info: {schema: InfoStageConfigData},
+  info: {schema: InfoStageConfigData, validate: validateInfoStageConfig},
   payout: {schema: PayoutStageConfigData},
   privateChat: {
     schema: PrivateChatStageConfigData,


### PR DESCRIPTION
### Summary
Adds optional minimum duration (`timeMinimumInMinutes`) and maximum duration (`timeLimitInMinutes`) support to the **Info stage**, mirroring the behavior implemented for the Survey stage in #1221.

### Features
1. **Stage Editor UI**: Added "Set time limit for info stage" checkbox with maximum and minimum time inputs in `info_editor.ts` using `renderTimeLimit`.
2. **Participant Header Countdown**: Added `StageKind.INFO` to header timer evaluation so the countdown displays when `timeLimitInMinutes` is configured.
3. **Stage Gating**: Disabled the "Next stage" button in `info_view.ts` until `timeMinimumInMinutes` has elapsed, displaying a remaining-time notice. The button is automatically enabled once the minimum duration passes.
4. **Validation**: Added TypeBox schema validation and `validateInfoStageConfig()` ensuring `timeMinimumInMinutes <= timeLimitInMinutes`.
5. **API & Python Types**: Updated `schemas.json` and regenerated Pydantic models in `deliberate_lab/types.py`.

### Testing
- `npm test -w utils` passed.
- `npm test -w frontend` passed.
- `npm run lint` passed.
- `npm run build:utils` and `npm run build:frontend` passed.
- `pyright deliberate_lab/` passed.
- Verified in local dev environment using `./run_locally.sh`.

### Manual Testing (local)
- Build experiment from scratch
- Add stage `Info`, under Info settings, set time limit for info stage
- Set max time to 2 min and min time to 1 min
- save the experiment, create a cohort, and join as a human participant
- Verify that at the Info stage, there's a count down timer starting from 2 min, and the `Next Stage` button is disabled (and automatically enabled) till the timer reaches 1 min.
- Verify that the participant can still stay on the Info stage when the timer ends.
- 

1. **Experiment Template**: Default / blank template
2. **Stages Sequence**: InfoStage (`timeMinimumInMinutes=1`, `timeLimitInMinutes=2`) -> SurveyStage
3. **Human Cohort**: 1 human participant
4. **Agent Mediator**: None
5. **Agent Participants**: None
6. **Tester Actions**:
   1. In the Experiment Editor, create an Info stage, check "Set time limit for info stage", set maximum time to `2` minutes and minimum time to `1` minute.
   2. Verify that the min time cannot be set to be greater than the max time
   3. Create and launch a cohort with 1 human participant.
   4. Join as the participant and land on the Info stage.
   5. Confirm the participant header shows a countdown timer, and the "Next stage" button is disabled with the notice "You must stay on this page for at least 1 more minute."
   6. Wait without interacting with the page. After 1 minute, confirm the button enables **on its own** (no click or refresh needed) and clicking "Next stage" advances to the Survey stage.
   7. On a fresh run, confirm that participant can still stay after the timer ends — the maximum time only drives the header countdown.