### PR TITLE
agents(bots): Experiment Test Plan Assistant bot with Gemini structured output (#1178)

### DIFF
--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -2,8 +2,6 @@ name: PR Review Bots
 
 # zizmor: ignore[dangerous-triggers] - Runs trusted base scripts; inspects PR diffs strictly as inert text via Octokit
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -1,9 +1,10 @@
 name: PR Review Bots
 
+# zizmor: ignore[dangerous-triggers] - Runs trusted base scripts; inspects PR diffs strictly as inert text via Octokit
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # zizmor: ignore[pull-request-target]
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -3,6 +3,7 @@ name: PR Review Bots
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # zizmor: ignore[pull-request-target]
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
@@ -54,4 +55,3 @@ jobs:
             ARGS="$ARGS --pr $PR_NUMBER_INPUT"
           fi
           npx tsx bots/src/core/runner.ts $ARGS
-

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -1,0 +1,57 @@
+name: PR Review Bots
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to evaluate (optional when triggered from PR)'
+        required: false
+        type: string
+      bot_id:
+        description: 'Bot ID to run (e.g. hello-world, test-plan)'
+        required: false
+        type: string
+        default: 'hello-world'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    name: Run PR Bots
+    runs-on: ubuntu-latest
+    # Skip draft PRs automatically
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run PR Bots
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_ID: ${{ inputs.bot_id || 'hello-world' }}
+          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
+        run: |
+          ARGS="--bot $BOT_ID"
+          if [ -n "$PR_NUMBER_INPUT" ]; then
+            ARGS="$ARGS --pr $PR_NUMBER_INPUT"
+          fi
+          npx tsx bots/src/core/runner.ts $ARGS
+

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -32,10 +32,10 @@ jobs:
       (!github.event.pull_request.draft)
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22.x
           cache: 'npm'

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -17,7 +17,7 @@ on:
         description: 'Bot ID to run (e.g. hello-world, test-plan)'
         required: false
         type: string
-        default: 'hello-world'
+        default: 'all'
 
 permissions:
   contents: read
@@ -48,7 +48,8 @@ jobs:
       - name: Run PR Bots
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BOT_ID: ${{ inputs.bot_id || 'hello-world' }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BOT_ID: ${{ inputs.bot_id || 'all' }}
           PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         run: |
           ARGS="--bot $BOT_ID"

--- a/.github/workflows/pr-bots.yaml
+++ b/.github/workflows/pr-bots.yaml
@@ -13,11 +13,6 @@ on:
         description: 'PR number to evaluate (optional when triggered from PR)'
         required: false
         type: string
-      bot_id:
-        description: 'Bot ID to run (e.g. hello-world, test-plan)'
-        required: false
-        type: string
-        default: 'all'
 
 permissions:
   contents: read
@@ -25,8 +20,8 @@ permissions:
   issues: write
 
 jobs:
-  review:
-    name: Run PR Bots
+  experiment-test-plan:
+    name: Experiment Test Plan Assistant
     runs-on: ubuntu-latest
     # Skip draft PRs automatically
     if: >
@@ -45,15 +40,14 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run PR Bots
+      - name: Run Experiment Test Plan Assistant
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          BOT_ID: ${{ inputs.bot_id || 'all' }}
           PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         run: |
-          ARGS="--bot $BOT_ID"
+          ARGS=""
           if [ -n "$PR_NUMBER_INPUT" ]; then
-            ARGS="$ARGS --pr $PR_NUMBER_INPUT"
+            ARGS="--pr $PR_NUMBER_INPUT"
           fi
-          npx tsx bots/src/core/runner.ts $ARGS
+          npx tsx bots/src/bots/experiment-test-plan/cli.ts $ARGS

--- a/bots/.gitignore
+++ b/bots/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/bots/.gitignore
+++ b/bots/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+

--- a/bots/package.json
+++ b/bots/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.11.1",
-    "@actions/github": "^6.0.0"
+    "@actions/github": "^6.0.0",
+    "@google/genai": "^2.22.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.0",

--- a/bots/package.json
+++ b/bots/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test \"src/**/*.test.ts\"",
-    "start": "tsx src/core/runner.ts"
+    "review:test-plan": "tsx src/bots/experiment-test-plan/cli.ts",
+    "review:hello-world": "tsx src/bots/hello-world/cli.ts"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",

--- a/bots/package.json
+++ b/bots/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@deliberation-lab/bots",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"src/**/*.test.ts\"",
+    "start": "tsx src/core/runner.ts"
+  },
+  "dependencies": {
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/bots/src/bots/experiment-test-plan/bot.test.ts
+++ b/bots/src/bots/experiment-test-plan/bot.test.ts
@@ -122,5 +122,23 @@ describe('ExperimentTestPlanBot', () => {
     assert.match(comment, /Suggested Tentative Test Plan/);
     assert.match(comment, /QuizStage -> SurveyStage/);
     assert.match(comment, /Survey stage unlocks upon submission/);
+    assert.match(comment, /How to Resolve/);
+    assert.match(comment, /issues\/new\?/);
+  });
+
+  it('renders upstream error comment with mitigation steps and bug report link', () => {
+    const errorComment = bot.renderComment(mockContext, {
+      status: 'warn',
+      summary: 'API quota exceeded (503 Service Unavailable)',
+      details: 'Preempted out of decode queue',
+    });
+
+    assert.match(errorComment, /Evaluation Blocked: Upstream Service Error/);
+    assert.match(errorComment, /API quota exceeded/);
+    assert.match(errorComment, /Preempted out of decode queue/);
+    assert.match(errorComment, /How to Re-run/);
+    assert.match(errorComment, /Re-run all jobs/);
+    assert.match(errorComment, /issues\/new\?/);
+    assert.match(errorComment, /area%3Aci-deploy/);
   });
 });

--- a/bots/src/bots/experiment-test-plan/bot.test.ts
+++ b/bots/src/bots/experiment-test-plan/bot.test.ts
@@ -1,0 +1,126 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {ExperimentTestPlanBot} from './bot.js';
+import {renderTestPlanComment} from './renderer.js';
+import type {ExperimentTestPlanEvaluation} from './types.js';
+import type {PRContext} from '../../core/types.js';
+
+const mockContext: PRContext = {
+  owner: 'PAIR-code',
+  repo: 'deliberate-lab',
+  prNumber: 999,
+  title: 'feat(stage): add new QuizStage component',
+  body: 'Implements the QuizStage for participants.',
+  author: 'contributor',
+  baseRef: 'main',
+  headRef: 'feature/quiz-stage',
+  headSha: '1234567890abcdef',
+  isDraft: false,
+  labels: ['feature'],
+  files: [
+    {
+      filename: 'frontend/src/stages/quiz_stage.ts',
+      status: 'added',
+      additions: 120,
+      deletions: 0,
+      changes: 120,
+      patch: '+export class QuizStage extends BaseStage {}',
+    },
+  ],
+};
+
+describe('ExperimentTestPlanBot', () => {
+  const bot = new ExperimentTestPlanBot();
+
+  it('has correct id and name', () => {
+    assert.equal(bot.id, 'experiment-test-plan');
+    assert.match(bot.name, /Experiment Test Plan Assistant/);
+  });
+
+  it('skips draft PRs and runs on ready PRs', () => {
+    assert.equal(bot.shouldRun({...mockContext, isDraft: true}), false);
+    assert.equal(bot.shouldRun({...mockContext, isDraft: false}), true);
+  });
+
+  it('fails closed when GEMINI_API_KEY is not set', async () => {
+    const originalKey = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+
+    try {
+      const evaluation = await bot.evaluate(mockContext);
+      assert.equal(evaluation.status, 'warn');
+      assert.match(evaluation.summary, /GEMINI_API_KEY/);
+      assert.equal(evaluation.metadata?.missingApiKey, true);
+
+      const comment = bot.renderComment(mockContext, evaluation);
+      assert.match(comment, /Missing `GEMINI_API_KEY`/);
+      assert.match(comment, /failed closed cleanly/);
+    } finally {
+      if (originalKey) {
+        process.env.GEMINI_API_KEY = originalKey;
+      }
+    }
+  });
+
+  it('renders non-runtime change comment correctly', () => {
+    const nonRuntimeEval: ExperimentTestPlanEvaluation = {
+      isRuntimeBehaviorChange: false,
+      classificationRationale:
+        'Only documentation and CI workflow changes were detected.',
+      hasManualTestPlan: false,
+      missingElements: [],
+    };
+
+    const comment = renderTestPlanComment(nonRuntimeEval);
+    assert.match(comment, /Non-Runtime Change Detected/);
+    assert.match(comment, /Manual experiment verification is not required/);
+  });
+
+  it('renders verified plan comment correctly', () => {
+    const verifiedEval: ExperimentTestPlanEvaluation = {
+      isRuntimeBehaviorChange: true,
+      classificationRationale: 'Adds new quiz stage.',
+      hasManualTestPlan: true,
+      manualPlanDetails: {
+        experimentTemplate: 'Chat and Quiz Template',
+        stagesSequence: 'Profile -> Quiz -> Chat -> Survey',
+        humanParticipants: '2',
+        agentMediator: 'None',
+        agentParticipants: '1 agent persona',
+        participantActions: 'Complete quiz and observe score persistence',
+        successCriteria: 'Score saves to participant variables cleanly',
+      },
+      missingElements: [],
+    };
+
+    const comment = renderTestPlanComment(verifiedEval);
+    assert.match(comment, /Manual Experiment Test Plan Verified/);
+    assert.match(comment, /Chat and Quiz Template/);
+    assert.match(comment, /Score saves to participant variables/);
+  });
+
+  it('renders suggested tentative plan when manual plan is missing', () => {
+    const missingEval: ExperimentTestPlanEvaluation = {
+      isRuntimeBehaviorChange: true,
+      classificationRationale:
+        'Introduces new QuizStage runtime component without test plan.',
+      hasManualTestPlan: false,
+      missingElements: ['stagesSequence', 'participantActions'],
+      suggestedTentativePlan: {
+        experimentTemplate: 'Default Experiment',
+        stagesSequence: 'QuizStage -> SurveyStage',
+        humanParticipants: '1 Human',
+        agentMediator: 'None',
+        agentParticipants: 'None',
+        participantActions: 'Submit answers in QuizStage',
+        successCriteria: 'Survey stage unlocks upon submission',
+      },
+    };
+
+    const comment = renderTestPlanComment(missingEval);
+    assert.match(comment, /Manual Experiment Test Plan Needed/);
+    assert.match(comment, /Suggested Tentative Test Plan/);
+    assert.match(comment, /QuizStage -> SurveyStage/);
+    assert.match(comment, /Survey stage unlocks upon submission/);
+  });
+});

--- a/bots/src/bots/experiment-test-plan/bot.test.ts
+++ b/bots/src/bots/experiment-test-plan/bot.test.ts
@@ -1,7 +1,7 @@
 import {describe, it} from 'node:test';
 import assert from 'node:assert/strict';
 import {ExperimentTestPlanBot} from './bot.js';
-import {renderTestPlanComment} from './renderer.js';
+import {formatTopologyItem, renderTestPlanComment} from './renderer.js';
 import type {ExperimentTestPlanEvaluation} from './types.js';
 import type {PRContext} from '../../core/types.js';
 
@@ -170,5 +170,50 @@ describe('ExperimentTestPlanBot', () => {
     assert.match(errorComment, /Re-run all jobs/);
     assert.match(errorComment, /issues\/new\?/);
     assert.match(errorComment, /area%3Aci-deploy/);
+  });
+
+  describe('formatTopologyItem', () => {
+    it('formats single-line values correctly', () => {
+      const formatted = formatTopologyItem(
+        1,
+        'Experiment Template',
+        'Default Experiment',
+      );
+      assert.equal(formatted, '1. **Experiment Template**: Default Experiment');
+    });
+
+    it('normalizes literal \\n and indents numbered sub-steps with 3 spaces', () => {
+      const raw = '1. Open editor\\n2. Add stage\\n3. Click save';
+      const formatted = formatTopologyItem(6, 'Tester Actions', raw);
+      assert.equal(
+        formatted,
+        '6. **Tester Actions**:\n   1. Open editor\n   2. Add stage\n   3. Click save',
+      );
+    });
+
+    it('indents bullet points with 3 spaces', () => {
+      const raw = '- First action\n- Second action';
+      const formatted = formatTopologyItem(6, 'Tester Actions', raw);
+      assert.equal(
+        formatted,
+        '6. **Tester Actions**:\n   - First action\n   - Second action',
+      );
+    });
+
+    it('splits inline numbered steps into indented sub-steps', () => {
+      const raw = '1. First step 2. Second step 3. Third step';
+      const formatted = formatTopologyItem(6, 'Tester Actions', raw);
+      assert.equal(
+        formatted,
+        '6. **Tester Actions**:\n   1. First step\n   2. Second step\n   3. Third step',
+      );
+    });
+
+    it('handles undefined or empty values gracefully', () => {
+      assert.equal(
+        formatTopologyItem(4, 'Agent Mediator', undefined),
+        '4. **Agent Mediator**: None / Not specified',
+      );
+    });
   });
 });

--- a/bots/src/bots/experiment-test-plan/bot.test.ts
+++ b/bots/src/bots/experiment-test-plan/bot.test.ts
@@ -62,7 +62,7 @@ describe('ExperimentTestPlanBot', () => {
     }
   });
 
-  it('renders non-runtime change comment correctly', () => {
+  it('renders non-runtime change comment correctly (Tier 2)', () => {
     const nonRuntimeEval: ExperimentTestPlanEvaluation = {
       isRuntimeBehaviorChange: false,
       classificationRationale:
@@ -76,7 +76,7 @@ describe('ExperimentTestPlanBot', () => {
     assert.match(comment, /Manual experiment verification is not required/);
   });
 
-  it('renders verified plan comment correctly', () => {
+  it('renders verified plan comment correctly (Tier 3)', () => {
     const verifiedEval: ExperimentTestPlanEvaluation = {
       isRuntimeBehaviorChange: true,
       classificationRationale: 'Adds new quiz stage.',
@@ -99,13 +99,14 @@ describe('ExperimentTestPlanBot', () => {
     assert.match(comment, /Score saves to participant variables/);
   });
 
-  it('renders suggested tentative plan when manual plan is missing', () => {
-    const missingEval: ExperimentTestPlanEvaluation = {
+  it('renders draft tentative plan for reviewers when deduced (Tier 4, Passes CI)', () => {
+    const deducedEval: ExperimentTestPlanEvaluation = {
       isRuntimeBehaviorChange: true,
       classificationRationale:
         'Introduces new QuizStage runtime component without test plan.',
       hasManualTestPlan: false,
       missingElements: ['stagesSequence', 'participantActions'],
+      canDeducePlan: true,
       suggestedTentativePlan: {
         experimentTemplate: 'Default Experiment',
         stagesSequence: 'QuizStage -> SurveyStage',
@@ -117,16 +118,45 @@ describe('ExperimentTestPlanBot', () => {
       },
     };
 
-    const comment = renderTestPlanComment(missingEval);
-    assert.match(comment, /Manual Experiment Test Plan Needed/);
-    assert.match(comment, /Suggested Tentative Test Plan/);
+    const comment = renderTestPlanComment(deducedEval);
+    assert.match(
+      comment,
+      /Draft Manual Experiment Test Plan \(Ready for Review\)/,
+    );
+    assert.match(comment, /Suggested Test Plan/);
     assert.match(comment, /QuizStage -> SurveyStage/);
     assert.match(comment, /Survey stage unlocks upon submission/);
-    assert.match(comment, /How to Resolve/);
+    assert.match(comment, /CI Status: Passed/);
+  });
+
+  it('renders guidance required comment when code is too ambiguous to deduce (Tier 5, Blocks CI)', () => {
+    const opaqueEval: ExperimentTestPlanEvaluation = {
+      isRuntimeBehaviorChange: true,
+      classificationRationale:
+        'Alters internal participant state machine transition algorithms.',
+      hasManualTestPlan: false,
+      missingElements: [
+        'stagesSequence',
+        'participantActions',
+        'successCriteria',
+      ],
+      canDeducePlan: false,
+      guidanceNeededReason:
+        'State transitions are deeply coupled to custom event bus logic with no UI cues.',
+    };
+
+    const comment = renderTestPlanComment(opaqueEval);
+    assert.match(comment, /Manual Experiment Test Plan Guidance Required/);
+    assert.match(comment, /Why Author Guidance Is Needed/);
+    assert.match(
+      comment,
+      /State transitions are deeply coupled to custom event bus/,
+    );
+    assert.match(comment, /CI Status: Blocked/);
     assert.match(comment, /issues\/new\?/);
   });
 
-  it('renders upstream error comment with mitigation steps and bug report link', () => {
+  it('renders upstream error comment with mitigation steps and bug report link (Tier 1)', () => {
     const errorComment = bot.renderComment(mockContext, {
       status: 'warn',
       summary: 'API quota exceeded (503 Service Unavailable)',

--- a/bots/src/bots/experiment-test-plan/bot.ts
+++ b/bots/src/bots/experiment-test-plan/bot.ts
@@ -9,7 +9,7 @@ import {
   RESPONSE_SCHEMA,
   SYSTEM_INSTRUCTION,
 } from './prompt.js';
-import {renderTestPlanComment} from './renderer.js';
+import {renderErrorComment, renderTestPlanComment} from './renderer.js';
 
 export class ExperimentTestPlanBot implements PRReviewBot {
   readonly id = 'experiment-test-plan';
@@ -73,7 +73,7 @@ export class ExperimentTestPlanBot implements PRReviewBot {
           hasManualTestPlan: false,
           missingElements: [],
         },
-        {missingApiKey: true},
+        {missingApiKey: true, context},
       );
     }
 
@@ -82,14 +82,9 @@ export class ExperimentTestPlanBot implements PRReviewBot {
       | undefined;
 
     if (!planEval) {
-      return (
-        `### 🧪 Deliberate Lab • Experiment Test Plan Assistant\n\n` +
-        `⚠️ **Evaluation Notice**\n\n` +
-        `${evaluation.summary}\n\n` +
-        (evaluation.details ? `\`\`\`\n${evaluation.details}\n\`\`\`\n` : '')
-      );
+      return renderErrorComment(context, evaluation);
     }
 
-    return renderTestPlanComment(planEval);
+    return renderTestPlanComment(planEval, {context});
   }
 }

--- a/bots/src/bots/experiment-test-plan/bot.ts
+++ b/bots/src/bots/experiment-test-plan/bot.ts
@@ -43,23 +43,52 @@ export class ExperimentTestPlanBot implements PRReviewBot {
           responseSchema: RESPONSE_SCHEMA,
         });
 
-      const isCompliant =
-        !evaluation.isRuntimeBehaviorChange || evaluation.hasManualTestPlan;
+      // Tier 2: Non-runtime change (passes cleanly)
+      if (!evaluation.isRuntimeBehaviorChange) {
+        return {
+          status: 'pass',
+          summary: 'Non-runtime change (manual test plan not required).',
+          metadata: {evaluation, tier: 2},
+        };
+      }
 
+      // Tier 3: Runtime change with verified author test plan (passes cleanly)
+      if (evaluation.hasManualTestPlan) {
+        return {
+          status: 'pass',
+          summary: 'Manual experiment test plan verified.',
+          metadata: {evaluation, tier: 3},
+        };
+      }
+
+      // Tier 4: Runtime change with confidently deduced tentative plan (passes cleanly)
+      const hasDeducedPlan =
+        evaluation.canDeducePlan !== false &&
+        Boolean(evaluation.suggestedTentativePlan);
+
+      if (hasDeducedPlan) {
+        return {
+          status: 'pass',
+          summary:
+            'Draft manual experiment test plan synthesized from code changes (ready for review).',
+          metadata: {evaluation, tier: 4},
+        };
+      }
+
+      // Tier 5: Runtime change lacking plan, guidance needed (fails closed)
       return {
-        status: isCompliant ? 'pass' : 'warn',
-        summary: isCompliant
-          ? evaluation.isRuntimeBehaviorChange
-            ? 'Manual experiment test plan verified.'
-            : 'Non-runtime change (manual test plan not required).'
-          : 'Manual experiment test plan needed for behavioral changes.',
-        metadata: {evaluation},
+        status: 'warn',
+        summary:
+          evaluation.guidanceNeededReason ||
+          'Manual experiment test plan required from author (unable to deduce from diffs).',
+        metadata: {evaluation, tier: 5},
       };
     } catch (err) {
       return {
         status: 'warn',
         summary: `Evaluation error encountered: ${(err as Error).message}`,
         details: (err as Error).stack,
+        metadata: {tier: 1},
       };
     }
   }

--- a/bots/src/bots/experiment-test-plan/bot.ts
+++ b/bots/src/bots/experiment-test-plan/bot.ts
@@ -1,0 +1,95 @@
+import type {BotEvaluation, PRContext, PRReviewBot} from '../../core/types.js';
+import {
+  callGeminiStructured,
+  hasGeminiApiKey,
+} from '../../core/gemini-client.js';
+import type {ExperimentTestPlanEvaluation} from './types.js';
+import {
+  buildEvaluationPrompt,
+  RESPONSE_SCHEMA,
+  SYSTEM_INSTRUCTION,
+} from './prompt.js';
+import {renderTestPlanComment} from './renderer.js';
+
+export class ExperimentTestPlanBot implements PRReviewBot {
+  readonly id = 'experiment-test-plan';
+  readonly name = 'Deliberate Lab • Experiment Test Plan Assistant';
+
+  shouldRun(context: PRContext): boolean {
+    // Automatically skip draft PRs until marked ready for review
+    if (context.isDraft) {
+      return false;
+    }
+    return true;
+  }
+
+  async evaluate(context: PRContext): Promise<BotEvaluation> {
+    // Fail-closed validation if GEMINI_API_KEY is not configured
+    if (!hasGeminiApiKey()) {
+      return {
+        status: 'warn',
+        summary: 'GEMINI_API_KEY secret is not configured in this environment.',
+        metadata: {missingApiKey: true},
+      };
+    }
+
+    const prompt = buildEvaluationPrompt(context);
+
+    try {
+      const evaluation =
+        await callGeminiStructured<ExperimentTestPlanEvaluation>({
+          systemInstruction: SYSTEM_INSTRUCTION,
+          prompt,
+          responseSchema: RESPONSE_SCHEMA,
+        });
+
+      const isCompliant =
+        !evaluation.isRuntimeBehaviorChange || evaluation.hasManualTestPlan;
+
+      return {
+        status: isCompliant ? 'pass' : 'warn',
+        summary: isCompliant
+          ? evaluation.isRuntimeBehaviorChange
+            ? 'Manual experiment test plan verified.'
+            : 'Non-runtime change (manual test plan not required).'
+          : 'Manual experiment test plan needed for behavioral changes.',
+        metadata: {evaluation},
+      };
+    } catch (err) {
+      return {
+        status: 'warn',
+        summary: `Evaluation error encountered: ${(err as Error).message}`,
+        details: (err as Error).stack,
+      };
+    }
+  }
+
+  renderComment(context: PRContext, evaluation: BotEvaluation): string {
+    if (evaluation.metadata?.missingApiKey) {
+      return renderTestPlanComment(
+        {
+          isRuntimeBehaviorChange: true,
+          classificationRationale: '',
+          hasManualTestPlan: false,
+          missingElements: [],
+        },
+        {missingApiKey: true},
+      );
+    }
+
+    const planEval = evaluation.metadata?.evaluation as
+      | ExperimentTestPlanEvaluation
+      | undefined;
+
+    if (!planEval) {
+      return (
+        `### 🧪 Deliberate Lab • Experiment Test Plan Assistant\n\n` +
+        `⚠️ **Evaluation Notice**\n\n` +
+        `${evaluation.summary}\n\n` +
+        (evaluation.details ? `\`\`\`\n${evaluation.details}\n\`\`\`\n` : '')
+      );
+    }
+
+    return renderTestPlanComment(planEval);
+  }
+}

--- a/bots/src/bots/experiment-test-plan/cli.ts
+++ b/bots/src/bots/experiment-test-plan/cli.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {runBot} from '../../core/runner.js';
+import {ExperimentTestPlanBot} from './bot.js';
+
+runBot(new ExperimentTestPlanBot()).catch((err) => {
+  console.error('\n❌ Fatal error in Experiment Test Plan Assistant:');
+  console.error(err);
+  process.exit(1);
+});

--- a/bots/src/bots/experiment-test-plan/prompt.ts
+++ b/bots/src/bots/experiment-test-plan/prompt.ts
@@ -1,0 +1,154 @@
+import type {PRContext} from '../../core/types.js';
+
+export const SYSTEM_INSTRUCTION = `You are the Deliberate Lab Experiment Test Plan Assistant, an expert AI reviewer for Deliberate Lab (an open-source behavioral experiment platform developed by Google PAIR).
+
+Deliberate Lab allows researchers to build and run multi-agent and multi-human behavioral experiments. Experiments consist of:
+- Experiment templates / configs
+- Stage sequences (e.g. InfoStage, ProfileStage, ChatStage, SurveyStage, ChipNegotiationStage, etc.)
+- Cohorts of human participants
+- Agent mediators (LLM facilitators)
+- Agent participants (LLM participant personas)
+
+Your job is to act as a helpful co-author reviewing incoming Pull Requests for testing completeness.
+
+You perform two key tasks:
+1. Classification:
+   - Determine whether the PR changes runtime software behavior (e.g. frontend participant/experimenter UX, backend Cloud Functions, Firestore data logic, stage definitions, mediator rules, shared utilities).
+   - Differentiate this from non-runtime changes (documentation, CI/CD GitHub workflows, developer agent skills in .agents/, architecture decision records, linters, build configs, or chores).
+   - If it is non-runtime, mark isRuntimeBehaviorChange = false. No manual experiment test plan is needed.
+
+2. Manual Experiment Test Plan Evaluation:
+   - If the PR changes runtime software behavior, inspect the PR title, description, and comments to determine whether the contributor has provided manual verification steps.
+   - A complete Deliberate Lab manual test plan must address the 7-part experiment topology:
+     (1) experimentTemplate: base template or configuration to use
+     (2) stagesSequence: stage sequence to configure
+     (3) humanParticipants: number of human participants needed in the cohort
+     (4) agentMediator: whether a mediator is needed, and what persona/settings to use
+     (5) agentParticipants: count, personas, or configurations of simulated agent participants
+     (6) participantActions: what participants should do or click
+     (7) successCriteria: expected behavior, state changes, or UI transitions that prove success
+
+3. Proactive Co-Author Synthesis:
+   - If a manual test plan is missing or incomplete, inspect the file changes, additions, and diff patches.
+   - Deduce what experiment setup is needed to test this change and synthesize a ready-to-use Suggested Tentative Manual Test Plan covering all 7 fields.`;
+
+export const RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    isRuntimeBehaviorChange: {
+      type: 'boolean',
+      description:
+        'True if the PR alters runtime application behavior; false if docs, CI, chores, or dev tools.',
+    },
+    classificationRationale: {
+      type: 'string',
+      description:
+        'Brief explanation of why this PR was classified as runtime or non-runtime.',
+    },
+    hasManualTestPlan: {
+      type: 'boolean',
+      description:
+        'True if the author provided adequate manual test steps for the experiment.',
+    },
+    manualPlanDetails: {
+      type: 'object',
+      properties: {
+        experimentTemplate: {type: 'string'},
+        stagesSequence: {type: 'string'},
+        humanParticipants: {type: 'string'},
+        agentMediator: {type: 'string'},
+        agentParticipants: {type: 'string'},
+        participantActions: {type: 'string'},
+        successCriteria: {type: 'string'},
+      },
+    },
+    missingElements: {
+      type: 'array',
+      items: {type: 'string'},
+      description:
+        'List of missing schema elements from the 7-part topology if incomplete.',
+    },
+    suggestedTentativePlan: {
+      type: 'object',
+      properties: {
+        experimentTemplate: {
+          type: 'string',
+          description: 'Suggested base experiment template',
+        },
+        stagesSequence: {
+          type: 'string',
+          description: 'Suggested stage sequence',
+        },
+        humanParticipants: {
+          type: 'string',
+          description: 'Suggested human participant count',
+        },
+        agentMediator: {
+          type: 'string',
+          description: 'Suggested mediator configuration',
+        },
+        agentParticipants: {
+          type: 'string',
+          description: 'Suggested agent participant configuration',
+        },
+        participantActions: {
+          type: 'string',
+          description: 'Specific actions for testers to take',
+        },
+        successCriteria: {
+          type: 'string',
+          description: 'Expected observable outcome',
+        },
+      },
+      required: [
+        'experimentTemplate',
+        'stagesSequence',
+        'humanParticipants',
+        'agentMediator',
+        'agentParticipants',
+        'participantActions',
+        'successCriteria',
+      ],
+      description:
+        'A deduced tentative test plan if the author did not provide one.',
+    },
+  },
+  required: [
+    'isRuntimeBehaviorChange',
+    'classificationRationale',
+    'hasManualTestPlan',
+    'missingElements',
+  ],
+};
+
+export function buildEvaluationPrompt(context: PRContext): string {
+  const filesSummary = context.files
+    .map(
+      (f) => `- ${f.filename} (${f.status}, +${f.additions}/-${f.deletions})`,
+    )
+    .join('\n');
+
+  const patchesSummary = context.files
+    .filter((f) => Boolean(f.patch))
+    .slice(0, 10) // Limit to top 10 patches to manage prompt size
+    .map((f) => `--- File: ${f.filename} ---\n${f.patch}`)
+    .join('\n\n');
+
+  return `Evaluate the following pull request:
+
+Repository: ${context.owner}/${context.repo}
+PR Number: #${context.prNumber}
+Title: ${context.title}
+Author: @${context.author}
+Labels: ${context.labels.join(', ') || 'None'}
+
+PR Description:
+${context.body || '(No description provided)'}
+
+Changed Files (${context.files.length}):
+${filesSummary}
+
+Code Diffs (sample):
+${patchesSummary || '(No patch diffs available)'}
+`;
+}

--- a/bots/src/bots/experiment-test-plan/prompt.ts
+++ b/bots/src/bots/experiment-test-plan/prompt.ts
@@ -105,11 +105,13 @@ export const RESPONSE_SCHEMA = {
         },
         participantActions: {
           type: 'string',
-          description: 'Specific actions for testers to take',
+          description:
+            'Numbered sequential actions for testers to take (e.g. "1. Do foo\n2. Do bar"). Do not escape newlines.',
         },
         successCriteria: {
           type: 'string',
-          description: 'Expected observable outcome',
+          description:
+            'Expected observable outcome or state transitions that prove success.',
         },
       },
       required: [

--- a/bots/src/bots/experiment-test-plan/prompt.ts
+++ b/bots/src/bots/experiment-test-plan/prompt.ts
@@ -28,9 +28,11 @@ You perform two key tasks:
      (6) participantActions: what participants should do or click
      (7) successCriteria: expected behavior, state changes, or UI transitions that prove success
 
-3. Proactive Co-Author Synthesis:
-   - If a manual test plan is missing or incomplete, inspect the file changes, additions, and diff patches.
-   - Deduce what experiment setup is needed to test this change and synthesize a ready-to-use Suggested Tentative Manual Test Plan covering all 7 fields.`;
+3. Proactive Co-Author Synthesis & Confidence Assessment:
+   - If a manual test plan is missing or incomplete:
+     a. Evaluate whether you can confidently deduce a complete, realistic 7-part experiment test plan from the diffs and description.
+     b. If the code changes clearly map to experiment templates, stages, UI actions, or participant flows (e.g. adding min/max timers to InfoStage), synthesize the 7-part plan, set canDeducePlan = true, and populate suggestedTentativePlan.
+     c. If the code changes are too ambiguous, complex, opaque, or internal (e.g. low-level backend refactoring, data migration, subtle algorithm shifts, or lacking context) such that you cannot confidently map them to the 7-part topology without guessing, set canDeducePlan = false, do not guess, and explain in guidanceNeededReason specifically what context or manual steps the author must provide.`;
 
 export const RESPONSE_SCHEMA = {
   type: 'object',
@@ -67,6 +69,16 @@ export const RESPONSE_SCHEMA = {
       items: {type: 'string'},
       description:
         'List of missing schema elements from the 7-part topology if incomplete.',
+    },
+    canDeducePlan: {
+      type: 'boolean',
+      description:
+        'True if a realistic 7-step test plan could be confidently deduced from diffs; false if changes are too ambiguous or opaque and require author guidance.',
+    },
+    guidanceNeededReason: {
+      type: 'string',
+      description:
+        'If canDeducePlan is false, explain why author guidance is required to test this change.',
     },
     suggestedTentativePlan: {
       type: 'object',

--- a/bots/src/bots/experiment-test-plan/renderer.ts
+++ b/bots/src/bots/experiment-test-plan/renderer.ts
@@ -140,42 +140,53 @@ export function renderTestPlanComment(
     );
   }
 
-  // Runtime change missing test plan: Proactive co-author drafting
-  const plan = evaluation.suggestedTentativePlan;
-  let suggestionSection = '';
+  // Tier 4: Runtime change missing test plan, but confidently deduced by Gemini (CI Passes)
+  const hasDeducedPlan =
+    evaluation.canDeducePlan !== false &&
+    Boolean(evaluation.suggestedTentativePlan);
 
-  if (plan) {
-    suggestionSection =
-      `#### 💡 Suggested Tentative Test Plan\n` +
-      `*Deduced from your code changes. Please review, adopt, or refine this in your PR description:*\n\n` +
+  if (hasDeducedPlan && evaluation.suggestedTentativePlan) {
+    const plan = evaluation.suggestedTentativePlan;
+    return (
+      header +
+      `💡 **Draft Manual Experiment Test Plan (Ready for Review)**\n\n` +
+      `This pull request alters runtime application behavior. While manual verification steps were not provided in the PR description, a tentative 7-step test plan was synthesized from the code changes:\n\n` +
+      `**Classification Rationale**: ${evaluation.classificationRationale}\n\n` +
+      `#### 📋 Suggested Test Plan\n` +
       `1. **Experiment Template**: ${plan.experimentTemplate}\n` +
       `2. **Stages Sequence**: ${plan.stagesSequence}\n` +
       `3. **Human Cohort**: ${plan.humanParticipants}\n` +
       `4. **Agent Mediator**: ${plan.agentMediator}\n` +
       `5. **Agent Participants**: ${plan.agentParticipants}\n` +
       `6. **Tester Actions**: ${plan.participantActions}\n` +
-      `7. **Expected Behavior**: ${plan.successCriteria}\n\n`;
+      `7. **Expected Behavior**: ${plan.successCriteria}\n\n` +
+      `---\n\n` +
+      `*✅ **CI Status: Passed** — Reviewers and maintainers can use this draft test plan to verify the PR locally. Authors are encouraged to adopt or refine these steps in their PR description.*`
+    );
   }
 
+  // Tier 5: Runtime change missing test plan, and cannot be deduced (CI Fails Closed)
   const bugUrl = buildBugReportUrl(
     options.context,
     'Potential misclassification or test plan synthesis failure',
-    `Rationale: ${evaluation.classificationRationale}\nMissing: ${evaluation.missingElements.join(', ')}`,
+    `Rationale: ${evaluation.classificationRationale}\nMissing: ${evaluation.missingElements.join(', ')}\nGuidance Needed: ${evaluation.guidanceNeededReason || 'Opaque diff'}`,
   );
 
   return (
     header +
-    `⚠️ **Manual Experiment Test Plan Needed**\n\n` +
-    `This pull request alters runtime application behavior, but complete manual verification steps were not provided.\n\n` +
+    `⚠️ **Manual Experiment Test Plan Guidance Required**\n\n` +
+    `This pull request alters runtime application behavior, but complete manual verification steps were not provided and could not be confidently deduced from the code changes.\n\n` +
     `**Classification Rationale**: ${evaluation.classificationRationale}\n\n` +
+    `**Why Author Guidance Is Needed**:\n` +
+    `${evaluation.guidanceNeededReason || 'The changes to runtime behavior are too complex or opaque to deduce a realistic 7-step test plan automatically.'}\n\n` +
     (evaluation.missingElements.length > 0
-      ? `**Missing Elements**: ${evaluation.missingElements.join(', ')}\n\n`
+      ? `**Missing Topology Elements**: ${evaluation.missingElements.join(', ')}\n\n`
       : '') +
-    suggestionSection +
     `---\n\n` +
     `#### 🔄 How to Resolve\n` +
-    `1. Copy and adopt (or refine) the suggested test plan above into your PR description.\n` +
+    `1. Update your PR description to include step-by-step manual test instructions addressing the 7-part experiment topology (Template, Stages, Human Cohort, Agent Mediator, Agent Participants, Actions, Expected Behavior).\n` +
     `2. Re-run this check by clicking **Re-run all jobs** under the **Checks** tab (or push an update to your PR).\n` +
-    `3. If you believe this PR was misclassified or if this check is failing persistently, please [file a bug report](${bugUrl}).`
+    `3. If you believe this PR was misclassified or if this check is failing persistently, please [file a bug report](${bugUrl}).\n\n` +
+    `*❌ **CI Status: Blocked** — Manual experiment verification instructions are required from the author before this PR can be merged.*`
   );
 }

--- a/bots/src/bots/experiment-test-plan/renderer.ts
+++ b/bots/src/bots/experiment-test-plan/renderer.ts
@@ -1,7 +1,86 @@
 import type {ExperimentTestPlanEvaluation} from './types.js';
+import type {BotEvaluation, PRContext} from '../../core/types.js';
 
 export interface RenderOptions {
   missingApiKey?: boolean;
+  context?: PRContext;
+}
+
+/**
+ * Generate a pre-populated GitHub issue URL for filing bug reports against the bot.
+ */
+export function buildBugReportUrl(
+  context: PRContext | undefined,
+  reason: string,
+  details?: string,
+): string {
+  const owner = context?.owner || 'PAIR-code';
+  const repo = context?.repo || 'deliberate-lab';
+  const prTag = context?.prNumber ? ` on PR #${context.prNumber}` : '';
+  const title = `bug(bots): Experiment Test Plan Assistant failure${prTag}`;
+
+  const bodyLines = [
+    '### Bot Failure Report',
+    `- **PR**: #${context?.prNumber || 'unknown'} (${context?.title || 'unknown'})`,
+    `- **Author**: @${context?.author || 'unknown'}`,
+    `- **Head SHA**: \`${context?.headSha ? context.headSha.slice(0, 8) : 'unknown'}\``,
+    `- **Reason**: ${reason}`,
+    '',
+  ];
+
+  if (details) {
+    bodyLines.push(
+      '### Error Details',
+      '```',
+      details.slice(0, 1500),
+      '```',
+      '',
+    );
+  }
+
+  bodyLines.push(
+    '### Context',
+    'Encountered persistent failure during Experiment Test Plan Assistant evaluation in GitHub Actions.',
+  );
+
+  const params = new URLSearchParams({
+    title,
+    body: bodyLines.join('\n'),
+    labels: 'area:ci-deploy',
+  });
+
+  return `https://github.com/${owner}/${repo}/issues/new?${params.toString()}`;
+}
+
+/**
+ * Render unexpected evaluation errors into a clean, actionable GitHub comment.
+ */
+export function renderErrorComment(
+  context: PRContext,
+  evaluation: BotEvaluation,
+): string {
+  const header = '### 🧪 Deliberate Lab • Experiment Test Plan Assistant\n\n';
+  const bugUrl = buildBugReportUrl(
+    context,
+    evaluation.summary,
+    evaluation.details,
+  );
+
+  return (
+    header +
+    `⚠️ **Evaluation Blocked: Upstream Service Error**\n\n` +
+    `The assistant could not complete its evaluation because an upstream service error occurred:\n` +
+    `> ${evaluation.summary}\n\n` +
+    `*This check failed closed cleanly (blocking merge until resolved).* \n\n` +
+    (evaluation.details
+      ? `<details>\n<summary>Technical Error Details</summary>\n\n\`\`\`\n${evaluation.details.slice(0, 2000)}\n\`\`\`\n</details>\n\n`
+      : '') +
+    `---\n\n` +
+    `#### 🔄 How to Re-run\n` +
+    `- **Re-run Check**: In the PR's **Checks** tab, select **PR Review Bots** and click **Re-run all jobs**.\n` +
+    `- **Trigger via Commit**: Push a new commit or close and reopen this PR to re-trigger once upstream services recover.\n` +
+    `- **Persistent Failure**: If this issue persists across retries, please [file a bug report](${bugUrl}).`
+  );
 }
 
 /**
@@ -14,11 +93,20 @@ export function renderTestPlanComment(
   const header = '### 🧪 Deliberate Lab • Experiment Test Plan Assistant\n\n';
 
   if (options.missingApiKey) {
+    const bugUrl = buildBugReportUrl(
+      options.context,
+      'Missing GEMINI_API_KEY secret in repository Actions secrets',
+    );
     return (
       header +
-      `⚠️ **Evaluation Paused: Missing \`GEMINI_API_KEY\`**\n\n` +
+      `⚠️ **Evaluation Blocked: Missing \`GEMINI_API_KEY\`**\n\n` +
       `The \`GEMINI_API_KEY\` secret is not configured in this environment. To enable automatic experiment test plan evaluation and tentative plan drafting, please configure the \`GEMINI_API_KEY\` secret in repository Actions secrets.\n\n` +
-      `*This check failed closed cleanly without interrupting CI.*`
+      `*This check failed closed cleanly (blocking merge until resolved).*\n\n` +
+      `---\n\n` +
+      `#### 🔄 How to Resolve\n` +
+      `- **Maintainers**: Configure \`GEMINI_API_KEY\` in [Repository Settings > Secrets > Actions](https://github.com/PAIR-code/deliberate-lab/settings/secrets/actions).\n` +
+      `- **Re-run Check**: Once the secret is configured, go to the PR's **Checks** tab and click **Re-run all jobs**.\n` +
+      `- **Persistent Issues**: [File a bug report](${bugUrl})`
     );
   }
 
@@ -69,6 +157,12 @@ export function renderTestPlanComment(
       `7. **Expected Behavior**: ${plan.successCriteria}\n\n`;
   }
 
+  const bugUrl = buildBugReportUrl(
+    options.context,
+    'Potential misclassification or test plan synthesis failure',
+    `Rationale: ${evaluation.classificationRationale}\nMissing: ${evaluation.missingElements.join(', ')}`,
+  );
+
   return (
     header +
     `⚠️ **Manual Experiment Test Plan Needed**\n\n` +
@@ -78,7 +172,10 @@ export function renderTestPlanComment(
       ? `**Missing Elements**: ${evaluation.missingElements.join(', ')}\n\n`
       : '') +
     suggestionSection +
-    `---\n` +
-    `*To resolve this check, please add the manual test steps to your PR description.*`
+    `---\n\n` +
+    `#### 🔄 How to Resolve\n` +
+    `1. Copy and adopt (or refine) the suggested test plan above into your PR description.\n` +
+    `2. Re-run this check by clicking **Re-run all jobs** under the **Checks** tab (or push an update to your PR).\n` +
+    `3. If you believe this PR was misclassified or if this check is failing persistently, please [file a bug report](${bugUrl}).`
   );
 }

--- a/bots/src/bots/experiment-test-plan/renderer.ts
+++ b/bots/src/bots/experiment-test-plan/renderer.ts
@@ -1,0 +1,84 @@
+import type {ExperimentTestPlanEvaluation} from './types.js';
+
+export interface RenderOptions {
+  missingApiKey?: boolean;
+}
+
+/**
+ * Render ExperimentTestPlanEvaluation into GitHub-flavored Markdown.
+ */
+export function renderTestPlanComment(
+  evaluation: ExperimentTestPlanEvaluation,
+  options: RenderOptions = {},
+): string {
+  const header = '### 🧪 Deliberate Lab • Experiment Test Plan Assistant\n\n';
+
+  if (options.missingApiKey) {
+    return (
+      header +
+      `⚠️ **Evaluation Paused: Missing \`GEMINI_API_KEY\`**\n\n` +
+      `The \`GEMINI_API_KEY\` secret is not configured in this environment. To enable automatic experiment test plan evaluation and tentative plan drafting, please configure the \`GEMINI_API_KEY\` secret in repository Actions secrets.\n\n` +
+      `*This check failed closed cleanly without interrupting CI.*`
+    );
+  }
+
+  // Non-runtime change scenario
+  if (!evaluation.isRuntimeBehaviorChange) {
+    return (
+      header +
+      `ℹ️ **Non-Runtime Change Detected**\n\n` +
+      `${evaluation.classificationRationale}\n\n` +
+      `*Manual experiment verification is not required for non-runtime pull requests (documentation, CI/CD workflows, developer tooling, or chores).*`
+    );
+  }
+
+  // Runtime change with complete manual plan
+  if (evaluation.hasManualTestPlan) {
+    const details = evaluation.manualPlanDetails || {};
+    return (
+      header +
+      `✅ **Manual Experiment Test Plan Verified**\n\n` +
+      `This PR modifies runtime behavior and provides manual test verification steps covering Deliberate Lab's experiment topology:\n\n` +
+      `| Topology Component | Verified Details |\n` +
+      `| :--- | :--- |\n` +
+      `| **Experiment Template** | ${details.experimentTemplate || 'Specified'} |\n` +
+      `| **Stage Sequence** | ${details.stagesSequence || 'Specified'} |\n` +
+      `| **Human Cohort** | ${details.humanParticipants || 'Specified'} |\n` +
+      `| **Agent Mediator** | ${details.agentMediator || 'None / Default'} |\n` +
+      `| **Agent Participants** | ${details.agentParticipants || 'None / Default'} |\n` +
+      `| **Participant Actions** | ${details.participantActions || 'Specified'} |\n` +
+      `| **Success Criteria** | ${details.successCriteria || 'Specified'} |\n\n` +
+      `*Test plan verified. Reviewers can use these steps to evaluate the experiment.*`
+    );
+  }
+
+  // Runtime change missing test plan: Proactive co-author drafting
+  const plan = evaluation.suggestedTentativePlan;
+  let suggestionSection = '';
+
+  if (plan) {
+    suggestionSection =
+      `#### 💡 Suggested Tentative Test Plan\n` +
+      `*Deduced from your code changes. Please review, adopt, or refine this in your PR description:*\n\n` +
+      `1. **Experiment Template**: ${plan.experimentTemplate}\n` +
+      `2. **Stages Sequence**: ${plan.stagesSequence}\n` +
+      `3. **Human Cohort**: ${plan.humanParticipants}\n` +
+      `4. **Agent Mediator**: ${plan.agentMediator}\n` +
+      `5. **Agent Participants**: ${plan.agentParticipants}\n` +
+      `6. **Tester Actions**: ${plan.participantActions}\n` +
+      `7. **Expected Behavior**: ${plan.successCriteria}\n\n`;
+  }
+
+  return (
+    header +
+    `⚠️ **Manual Experiment Test Plan Needed**\n\n` +
+    `This pull request alters runtime application behavior, but complete manual verification steps were not provided.\n\n` +
+    `**Classification Rationale**: ${evaluation.classificationRationale}\n\n` +
+    (evaluation.missingElements.length > 0
+      ? `**Missing Elements**: ${evaluation.missingElements.join(', ')}\n\n`
+      : '') +
+    suggestionSection +
+    `---\n` +
+    `*To resolve this check, please add the manual test steps to your PR description.*`
+  );
+}

--- a/bots/src/bots/experiment-test-plan/renderer.ts
+++ b/bots/src/bots/experiment-test-plan/renderer.ts
@@ -84,6 +84,60 @@ export function renderErrorComment(
 }
 
 /**
+ * Format an individual item within the 7-part experiment topology list.
+ * Normalizes literal '\n' sequences into actual newlines and cleanly indents
+ * nested sub-steps or bullet points (3 spaces) so GitHub Flavored Markdown
+ * renders them as a proper nested list without breaking the outer list.
+ */
+export function formatTopologyItem(
+  num: number,
+  label: string,
+  value?: string,
+): string {
+  if (!value) return `${num}. **${label}**: None / Not specified`;
+
+  // Normalize literal '\n' escape sequences into real newlines
+  const normalized = value.replace(/\\n/g, '\n').trim();
+
+  const lines = normalized
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  if (lines.length > 1) {
+    const formattedLines = lines.map((line) => {
+      // If already starts with a number like "1. " or "2) ", indent with 3 spaces
+      if (/^\d+[.)]\s+/.test(line)) {
+        return `   ${line}`;
+      }
+      // If starts with a bullet like "- " or "* ", indent with 3 spaces
+      if (/^[-*]\s+/.test(line)) {
+        return `   ${line}`;
+      }
+      // Otherwise, make it an indented bullet sub-item
+      return `   - ${line}`;
+    });
+
+    return `${num}. **${label}**:\n${formattedLines.join('\n')}`;
+  }
+
+  // Check if a single line contains embedded inline numbered steps e.g. "1. ... 2. ..."
+  const inlineNumbered = normalized.match(/^1[.)]\s+/);
+  if (inlineNumbered && /\s+2[.)]\s+/.test(normalized)) {
+    const subSteps = normalized
+      .split(/(?=\b\d+[.)]\s+)/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (subSteps.length > 1) {
+      const formattedLines = subSteps.map((step) => `   ${step}`);
+      return `${num}. **${label}**:\n${formattedLines.join('\n')}`;
+    }
+  }
+
+  return `${num}. **${label}**: ${normalized}`;
+}
+
+/**
  * Render ExperimentTestPlanEvaluation into GitHub-flavored Markdown.
  */
 export function renderTestPlanComment(
@@ -123,19 +177,22 @@ export function renderTestPlanComment(
   // Runtime change with complete manual plan
   if (evaluation.hasManualTestPlan) {
     const details = evaluation.manualPlanDetails || {};
+    const sanitizeTableCell = (text?: string) =>
+      (text || 'Specified').replace(/\\n|\n/g, '<br>');
+
     return (
       header +
       `✅ **Manual Experiment Test Plan Verified**\n\n` +
       `This PR modifies runtime behavior and provides manual test verification steps covering Deliberate Lab's experiment topology:\n\n` +
       `| Topology Component | Verified Details |\n` +
       `| :--- | :--- |\n` +
-      `| **Experiment Template** | ${details.experimentTemplate || 'Specified'} |\n` +
-      `| **Stage Sequence** | ${details.stagesSequence || 'Specified'} |\n` +
-      `| **Human Cohort** | ${details.humanParticipants || 'Specified'} |\n` +
-      `| **Agent Mediator** | ${details.agentMediator || 'None / Default'} |\n` +
-      `| **Agent Participants** | ${details.agentParticipants || 'None / Default'} |\n` +
-      `| **Participant Actions** | ${details.participantActions || 'Specified'} |\n` +
-      `| **Success Criteria** | ${details.successCriteria || 'Specified'} |\n\n` +
+      `| **Experiment Template** | ${sanitizeTableCell(details.experimentTemplate)} |\n` +
+      `| **Stage Sequence** | ${sanitizeTableCell(details.stagesSequence)} |\n` +
+      `| **Human Cohort** | ${sanitizeTableCell(details.humanParticipants)} |\n` +
+      `| **Agent Mediator** | ${sanitizeTableCell(details.agentMediator)} |\n` +
+      `| **Agent Participants** | ${sanitizeTableCell(details.agentParticipants)} |\n` +
+      `| **Participant Actions** | ${sanitizeTableCell(details.participantActions)} |\n` +
+      `| **Success Criteria** | ${sanitizeTableCell(details.successCriteria)} |\n\n` +
       `*Test plan verified. Reviewers can use these steps to evaluate the experiment.*`
     );
   }
@@ -147,19 +204,23 @@ export function renderTestPlanComment(
 
   if (hasDeducedPlan && evaluation.suggestedTentativePlan) {
     const plan = evaluation.suggestedTentativePlan;
+    const planItems = [
+      formatTopologyItem(1, 'Experiment Template', plan.experimentTemplate),
+      formatTopologyItem(2, 'Stages Sequence', plan.stagesSequence),
+      formatTopologyItem(3, 'Human Cohort', plan.humanParticipants),
+      formatTopologyItem(4, 'Agent Mediator', plan.agentMediator),
+      formatTopologyItem(5, 'Agent Participants', plan.agentParticipants),
+      formatTopologyItem(6, 'Tester Actions', plan.participantActions),
+      formatTopologyItem(7, 'Expected Behavior', plan.successCriteria),
+    ].join('\n');
+
     return (
       header +
       `💡 **Draft Manual Experiment Test Plan (Ready for Review)**\n\n` +
       `This pull request alters runtime application behavior. While manual verification steps were not provided in the PR description, a tentative 7-step test plan was synthesized from the code changes:\n\n` +
       `**Classification Rationale**: ${evaluation.classificationRationale}\n\n` +
       `#### 📋 Suggested Test Plan\n` +
-      `1. **Experiment Template**: ${plan.experimentTemplate}\n` +
-      `2. **Stages Sequence**: ${plan.stagesSequence}\n` +
-      `3. **Human Cohort**: ${plan.humanParticipants}\n` +
-      `4. **Agent Mediator**: ${plan.agentMediator}\n` +
-      `5. **Agent Participants**: ${plan.agentParticipants}\n` +
-      `6. **Tester Actions**: ${plan.participantActions}\n` +
-      `7. **Expected Behavior**: ${plan.successCriteria}\n\n` +
+      `${planItems}\n\n` +
       `---\n\n` +
       `*✅ **CI Status: Passed** — Reviewers and maintainers can use this draft test plan to verify the PR locally. Authors are encouraged to adopt or refine these steps in their PR description.*`
     );

--- a/bots/src/bots/experiment-test-plan/types.ts
+++ b/bots/src/bots/experiment-test-plan/types.ts
@@ -28,5 +28,7 @@ export interface ExperimentTestPlanEvaluation {
   hasManualTestPlan: boolean;
   manualPlanDetails?: ExperimentTestPlanDetails;
   missingElements: string[];
+  canDeducePlan?: boolean;
+  guidanceNeededReason?: string;
   suggestedTentativePlan?: SuggestedTentativePlan;
 }

--- a/bots/src/bots/experiment-test-plan/types.ts
+++ b/bots/src/bots/experiment-test-plan/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Types and schema for the Experiment Test Plan Assistant.
+ */
+
+export interface ExperimentTestPlanDetails {
+  experimentTemplate?: string;
+  stagesSequence?: string;
+  humanParticipants?: string;
+  agentMediator?: string;
+  agentParticipants?: string;
+  participantActions?: string;
+  successCriteria?: string;
+}
+
+export interface SuggestedTentativePlan {
+  experimentTemplate: string;
+  stagesSequence: string;
+  humanParticipants: string;
+  agentMediator: string;
+  agentParticipants: string;
+  participantActions: string;
+  successCriteria: string;
+}
+
+export interface ExperimentTestPlanEvaluation {
+  isRuntimeBehaviorChange: boolean;
+  classificationRationale: string;
+  hasManualTestPlan: boolean;
+  manualPlanDetails?: ExperimentTestPlanDetails;
+  missingElements: string[];
+  suggestedTentativePlan?: SuggestedTentativePlan;
+}

--- a/bots/src/bots/hello-world/bot.test.ts
+++ b/bots/src/bots/hello-world/bot.test.ts
@@ -1,0 +1,57 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {HelloWorldBot} from './bot.js';
+import type {PRContext} from '../../core/types.js';
+
+const mockContext: PRContext = {
+  owner: 'PAIR-code',
+  repo: 'deliberate-lab',
+  prNumber: 42,
+  title: 'feat: add awesome feature',
+  body: 'This PR adds something great.',
+  author: 'test-author',
+  baseRef: 'main',
+  headRef: 'feat-branch',
+  headSha: 'abc1234567890',
+  isDraft: false,
+  labels: ['feature'],
+  files: [
+    {
+      filename: 'utils/src/test.ts',
+      status: 'modified',
+      additions: 10,
+      deletions: 2,
+      changes: 12,
+    },
+  ],
+};
+
+describe('HelloWorldBot', () => {
+  const bot = new HelloWorldBot();
+
+  it('should have correct id and name', () => {
+    assert.equal(bot.id, 'hello-world');
+    assert.match(bot.name, /Status Check/);
+  });
+
+  it('shouldRun always returns true for hello-world', () => {
+    assert.equal(bot.shouldRun(mockContext), true);
+  });
+
+  it('evaluates context and returns pass status', async () => {
+    const evaluation = await bot.evaluate(mockContext);
+    assert.equal(evaluation.status, 'pass');
+    assert.match(evaluation.summary, /verified/i);
+    assert.equal(evaluation.metadata?.fileCount, 1);
+  });
+
+  it('renders markdown comment with PR details and table', async () => {
+    const evaluation = await bot.evaluate(mockContext);
+    const comment = bot.renderComment(mockContext, evaluation);
+
+    assert.match(comment, /#42/);
+    assert.match(comment, /test-author/);
+    assert.match(comment, /abc12345/);
+    assert.match(comment, /Operational/);
+  });
+});

--- a/bots/src/bots/hello-world/bot.ts
+++ b/bots/src/bots/hello-world/bot.ts
@@ -1,0 +1,49 @@
+import type {BotEvaluation, PRContext, PRReviewBot} from '../../core/types.js';
+
+export class HelloWorldBot implements PRReviewBot {
+  readonly id = 'hello-world';
+  readonly name = 'Deliberate Lab Bot • Status Check';
+
+  shouldRun(_context: PRContext): boolean {
+    return true;
+  }
+
+  async evaluate(context: PRContext): Promise<BotEvaluation> {
+    return {
+      status: 'pass',
+      summary: 'Hello World! PR review bot pipeline verified.',
+      details: `Inspected ${context.files.length} files on branch ${context.headRef} at commit ${context.headSha.slice(0, 8)}.`,
+      metadata: {
+        fileCount: context.files.length,
+        headSha: context.headSha,
+      },
+    };
+  }
+
+  renderComment(context: PRContext, evaluation: BotEvaluation): string {
+    const totalAdditions = context.files.reduce(
+      (sum, f) => sum + f.additions,
+      0,
+    );
+    const totalDeletions = context.files.reduce(
+      (sum, f) => sum + f.deletions,
+      0,
+    );
+    const timestamp = new Date().toISOString();
+
+    return `### 🤖 Deliberate Lab Bot • Pipeline Verified
+
+${evaluation.summary}
+
+| Metric | Details |
+| :--- | :--- |
+| **Pull Request** | #${context.prNumber} (${context.title}) |
+| **Author** | @${context.author} |
+| **Head Commit** | \`${context.headSha.slice(0, 8)}\` |
+| **Changes** | ${context.files.length} file(s) (+\`${totalAdditions}\` / -\`${totalDeletions}\`) |
+| **Status** | ✅ Operational |
+| **Last Evaluated** | \`${timestamp}\` |
+
+*This is a deterministic Phase 1 health check verifying GitHub Actions triggers, Octokit API authentication, and idempotent comment updates.*`;
+  }
+}

--- a/bots/src/bots/hello-world/bot.ts
+++ b/bots/src/bots/hello-world/bot.ts
@@ -2,7 +2,7 @@ import type {BotEvaluation, PRContext, PRReviewBot} from '../../core/types.js';
 
 export class HelloWorldBot implements PRReviewBot {
   readonly id = 'hello-world';
-  readonly name = 'Deliberate Lab Bot • Status Check';
+  readonly name = 'Deliberate Lab Diagnostics • Pipeline Status Check';
 
   shouldRun(_context: PRContext): boolean {
     return true;
@@ -31,7 +31,7 @@ export class HelloWorldBot implements PRReviewBot {
     );
     const timestamp = new Date().toISOString();
 
-    return `### 🤖 Deliberate Lab Bot • Pipeline Verified
+    return `### 🤖 Deliberate Lab Diagnostics • Pipeline Verified
 
 ${evaluation.summary}
 

--- a/bots/src/bots/hello-world/cli.ts
+++ b/bots/src/bots/hello-world/cli.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {runBot} from '../../core/runner.js';
+import {HelloWorldBot} from './bot.js';
+
+runBot(new HelloWorldBot()).catch((err) => {
+  console.error('\n❌ Fatal error in Hello World Diagnostic Bot:');
+  console.error(err);
+  process.exit(1);
+});

--- a/bots/src/core/comment-manager.test.ts
+++ b/bots/src/core/comment-manager.test.ts
@@ -1,0 +1,17 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {getBotMarker} from './comment-manager.js';
+
+describe('comment-manager', () => {
+  it('generates expected HTML marker tag for a bot ID', () => {
+    const marker = getBotMarker('hello-world');
+    assert.equal(marker, '<!-- deliberate-lab-bot: hello-world -->');
+  });
+
+  it('generates unique marker for different bot IDs', () => {
+    const markerA = getBotMarker('bot-a');
+    const markerB = getBotMarker('bot-b');
+    assert.notEqual(markerA, markerB);
+    assert.equal(markerA, '<!-- deliberate-lab-bot: bot-a -->');
+  });
+});

--- a/bots/src/core/comment-manager.test.ts
+++ b/bots/src/core/comment-manager.test.ts
@@ -4,8 +4,8 @@ import {getBotMarker} from './comment-manager.js';
 
 describe('comment-manager', () => {
   it('generates expected HTML marker tag for a bot ID', () => {
-    const marker = getBotMarker('hello-world');
-    assert.equal(marker, '<!-- deliberate-lab-bot: hello-world -->');
+    const marker = getBotMarker('experiment-test-plan');
+    assert.equal(marker, '<!-- deliberate-lab-bot: experiment-test-plan -->');
   });
 
   it('generates unique marker for different bot IDs', () => {

--- a/bots/src/core/comment-manager.ts
+++ b/bots/src/core/comment-manager.ts
@@ -1,0 +1,84 @@
+import * as github from '@actions/github';
+import type {PRContext} from './types.js';
+import {resolveGitHubToken} from './pr-context.js';
+
+export interface CommentOptions {
+  botId: string;
+  markdownBody: string;
+  dryRun?: boolean;
+  token?: string;
+}
+
+export interface CommentResult {
+  action: 'created' | 'updated' | 'skipped_dry_run';
+  commentId?: number;
+  url?: string;
+}
+
+/**
+ * Generate standard HTML signature marker for a bot.
+ */
+export function getBotMarker(botId: string): string {
+  return `<!-- deliberate-lab-bot: ${botId} -->`;
+}
+
+/**
+ * Idempotently post or update a PR comment for a given bot.
+ */
+export async function postOrUpdateComment(
+  context: PRContext,
+  options: CommentOptions,
+): Promise<CommentResult> {
+  const marker = getBotMarker(options.botId);
+  const fullBody = `${options.markdownBody.trim()}\n\n${marker}`;
+
+  if (options.dryRun) {
+    console.log(
+      `[DRY RUN] Would post or update comment for bot "${options.botId}":\n`,
+    );
+    console.log(fullBody);
+    return {action: 'skipped_dry_run'};
+  }
+
+  const token = resolveGitHubToken(options.token);
+  const octokit = github.getOctokit(token);
+
+  // List existing comments to find an existing one with this bot's marker
+  const {data: comments} = await octokit.rest.issues.listComments({
+    owner: context.owner,
+    repo: context.repo,
+    issue_number: context.prNumber,
+    per_page: 100,
+  });
+
+  const existingComment = comments.find((comment) =>
+    comment.body?.includes(marker),
+  );
+
+  if (existingComment) {
+    const {data: updated} = await octokit.rest.issues.updateComment({
+      owner: context.owner,
+      repo: context.repo,
+      comment_id: existingComment.id,
+      body: fullBody,
+    });
+    return {
+      action: 'updated',
+      commentId: updated.id,
+      url: updated.html_url,
+    };
+  }
+
+  const {data: created} = await octokit.rest.issues.createComment({
+    owner: context.owner,
+    repo: context.repo,
+    issue_number: context.prNumber,
+    body: fullBody,
+  });
+
+  return {
+    action: 'created',
+    commentId: created.id,
+    url: created.html_url,
+  };
+}

--- a/bots/src/core/comment-manager.ts
+++ b/bots/src/core/comment-manager.ts
@@ -16,7 +16,8 @@ export interface CommentResult {
 }
 
 /**
- * Generate standard HTML signature marker for a bot.
+ * Generate standard HTML signature marker for a specialist bot.
+ * Follows the convention: `<!-- deliberate-lab-bot: <bot-id> -->` (e.g. `experiment-test-plan`).
  */
 export function getBotMarker(botId: string): string {
   return `<!-- deliberate-lab-bot: ${botId} -->`;

--- a/bots/src/core/comment-manager.ts
+++ b/bots/src/core/comment-manager.ts
@@ -43,42 +43,61 @@ export async function postOrUpdateComment(
   const token = resolveGitHubToken(options.token);
   const octokit = github.getOctokit(token);
 
-  // List existing comments to find an existing one with this bot's marker
-  const {data: comments} = await octokit.rest.issues.listComments({
-    owner: context.owner,
-    repo: context.repo,
-    issue_number: context.prNumber,
-    per_page: 100,
-  });
-
-  const existingComment = comments.find((comment) =>
-    comment.body?.includes(marker),
-  );
-
-  if (existingComment) {
-    const {data: updated} = await octokit.rest.issues.updateComment({
+  try {
+    // List existing comments to find an existing one with this bot's marker
+    const {data: comments} = await octokit.rest.issues.listComments({
       owner: context.owner,
       repo: context.repo,
-      comment_id: existingComment.id,
+      issue_number: context.prNumber,
+      per_page: 100,
+    });
+
+    const existingComment = comments.find((comment) =>
+      comment.body?.includes(marker),
+    );
+
+    if (existingComment) {
+      const {data: updated} = await octokit.rest.issues.updateComment({
+        owner: context.owner,
+        repo: context.repo,
+        comment_id: existingComment.id,
+        body: fullBody,
+      });
+      return {
+        action: 'updated',
+        commentId: updated.id,
+        url: updated.html_url,
+      };
+    }
+
+    const {data: created} = await octokit.rest.issues.createComment({
+      owner: context.owner,
+      repo: context.repo,
+      issue_number: context.prNumber,
       body: fullBody,
     });
+
     return {
-      action: 'updated',
-      commentId: updated.id,
-      url: updated.html_url,
+      action: 'created',
+      commentId: created.id,
+      url: created.html_url,
     };
+  } catch (error: unknown) {
+    const err = error as {status?: number; message?: string};
+    if (err.status === 403) {
+      console.warn(
+        `\n[WARN] GITHUB_TOKEN has read-only access (status 403 Forbidden).`,
+      );
+      console.warn(
+        `       This occurs when running under 'pull_request' on an unmerged fork PR.`,
+      );
+      console.warn(
+        `       Once merged to main, 'pull_request_target' will have full write permissions.\n`,
+      );
+      console.log(`[PREVIEW] Comment that would have been posted:\n`);
+      console.log(fullBody);
+      return {action: 'skipped_dry_run'};
+    }
+    throw error;
   }
-
-  const {data: created} = await octokit.rest.issues.createComment({
-    owner: context.owner,
-    repo: context.repo,
-    issue_number: context.prNumber,
-    body: fullBody,
-  });
-
-  return {
-    action: 'created',
-    commentId: created.id,
-    url: created.html_url,
-  };
 }

--- a/bots/src/core/gemini-client.ts
+++ b/bots/src/core/gemini-client.ts
@@ -1,0 +1,61 @@
+import {GoogleGenAI} from '@google/genai';
+
+/**
+ * Check whether a Gemini API key is available in the environment.
+ */
+export function hasGeminiApiKey(): boolean {
+  return Boolean(process.env.GEMINI_API_KEY?.trim());
+}
+
+export interface GeminiStructuredOptions {
+  prompt: string;
+  systemInstruction?: string;
+  model?: string;
+  responseSchema?: Record<string, unknown>;
+}
+
+/**
+ * Make a structured JSON call to the Gemini API using @google/genai.
+ */
+export async function callGeminiStructured<T>(
+  options: GeminiStructuredOptions,
+): Promise<T> {
+  const apiKey = process.env.GEMINI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('Missing GEMINI_API_KEY environment variable.');
+  }
+
+  const ai = new GoogleGenAI({apiKey});
+  const model = options.model || process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+
+  const config: Record<string, unknown> = {
+    responseMimeType: 'application/json',
+  };
+
+  if (options.systemInstruction) {
+    config.systemInstruction = options.systemInstruction;
+  }
+
+  if (options.responseSchema) {
+    config.responseSchema = options.responseSchema;
+  }
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: options.prompt,
+    config,
+  });
+
+  const text = response.text;
+  if (!text) {
+    throw new Error('Gemini API returned an empty response.');
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse Gemini structured JSON response: ${(err as Error).message}\nRaw text: ${text}`,
+    );
+  }
+}

--- a/bots/src/core/gemini-client.ts
+++ b/bots/src/core/gemini-client.ts
@@ -26,7 +26,7 @@ export async function callGeminiStructured<T>(
   }
 
   const ai = new GoogleGenAI({apiKey});
-  const model = options.model || process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+  const model = options.model || process.env.GEMINI_MODEL || 'gemini-3.7-flash';
 
   const config: Record<string, unknown> = {
     responseMimeType: 'application/json',
@@ -40,22 +40,49 @@ export async function callGeminiStructured<T>(
     config.responseSchema = options.responseSchema;
   }
 
-  const response = await ai.models.generateContent({
-    model,
-    contents: options.prompt,
-    config,
-  });
+  const maxRetries = 3;
+  let lastError: unknown;
 
-  const text = response.text;
-  if (!text) {
-    throw new Error('Gemini API returned an empty response.');
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await ai.models.generateContent({
+        model,
+        contents: options.prompt,
+        config,
+      });
+
+      const text = response.text;
+      if (!text) {
+        throw new Error('Gemini API returned an empty response.');
+      }
+
+      try {
+        return JSON.parse(text) as T;
+      } catch (err) {
+        throw new Error(
+          `Failed to parse Gemini structured JSON response: ${(err as Error).message}\nRaw text: ${text}`,
+        );
+      }
+    } catch (err: unknown) {
+      lastError = err;
+      const errMsg = (err as Error)?.message || '';
+      const isTransient =
+        errMsg.includes('503') ||
+        errMsg.includes('429') ||
+        errMsg.includes('high demand') ||
+        errMsg.includes('UNAVAILABLE');
+
+      if (isTransient && attempt < maxRetries) {
+        const delayMs = attempt * 2000;
+        console.warn(
+          `[WARN] Gemini call encountered transient error (${errMsg.slice(0, 100)}...). Retrying in ${delayMs}ms (attempt ${attempt}/${maxRetries})...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      break;
+    }
   }
 
-  try {
-    return JSON.parse(text) as T;
-  } catch (err) {
-    throw new Error(
-      `Failed to parse Gemini structured JSON response: ${(err as Error).message}\nRaw text: ${text}`,
-    );
-  }
+  throw lastError;
 }

--- a/bots/src/core/pr-context.ts
+++ b/bots/src/core/pr-context.ts
@@ -52,10 +52,18 @@ export async function loadPRContext(
       const [envOwner, envRepo] = process.env.GITHUB_REPOSITORY.split('/');
       owner = owner || envOwner;
       repo = repo || envRepo;
-    } else if (github.context.repo.owner && github.context.repo.repo) {
-      owner = owner || github.context.repo.owner;
-      repo = repo || github.context.repo.repo;
+    } else {
+      try {
+        if (github.context.repo.owner && github.context.repo.repo) {
+          owner = owner || github.context.repo.owner;
+          repo = repo || github.context.repo.repo;
+        }
+      } catch {
+        // Not running in an Actions environment with GITHUB_REPOSITORY set
+      }
     }
+    owner = owner || 'PAIR-code';
+    repo = repo || 'deliberate-lab';
   }
 
   if (!prNumber) {

--- a/bots/src/core/pr-context.ts
+++ b/bots/src/core/pr-context.ts
@@ -1,0 +1,130 @@
+import {execSync} from 'node:child_process';
+import * as github from '@actions/github';
+import type {PRContext, PRFile} from './types.js';
+
+export interface ContextOptions {
+  owner?: string;
+  repo?: string;
+  prNumber?: number;
+  token?: string;
+}
+
+/**
+ * Resolve a GitHub token from environment variables or local `gh auth token`.
+ */
+export function resolveGitHubToken(explicitToken?: string): string {
+  if (explicitToken) return explicitToken;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+
+  // Attempt to read from gh CLI for local development
+  try {
+    const token = execSync('gh auth token', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (token) return token;
+  } catch {
+    // gh CLI not available or not logged in
+  }
+
+  throw new Error(
+    'GitHub token not found. Please provide GITHUB_TOKEN or ensure `gh auth login` is configured.',
+  );
+}
+
+/**
+ * Fetch and construct the PRContext for a given pull request.
+ */
+export async function loadPRContext(
+  options: ContextOptions = {},
+): Promise<PRContext> {
+  const token = resolveGitHubToken(options.token);
+  const octokit = github.getOctokit(token);
+
+  let owner = options.owner;
+  let repo = options.repo;
+  let prNumber = options.prNumber;
+
+  // If in GitHub Actions, infer from action context
+  if (!owner || !repo) {
+    if (process.env.GITHUB_REPOSITORY) {
+      const [envOwner, envRepo] = process.env.GITHUB_REPOSITORY.split('/');
+      owner = owner || envOwner;
+      repo = repo || envRepo;
+    } else if (github.context.repo.owner && github.context.repo.repo) {
+      owner = owner || github.context.repo.owner;
+      repo = repo || github.context.repo.repo;
+    }
+  }
+
+  if (!prNumber) {
+    if (github.context.payload.pull_request?.number) {
+      prNumber = github.context.payload.pull_request.number;
+    } else if (github.context.issue?.number) {
+      prNumber = github.context.issue.number;
+    }
+  }
+
+  if (!owner || !repo || !prNumber) {
+    throw new Error(
+      `Unable to resolve PR context (owner: ${owner}, repo: ${repo}, prNumber: ${prNumber}). ` +
+        'Specify --owner, --repo, and --pr when running locally.',
+    );
+  }
+
+  // Fetch PR metadata
+  const {data: pr} = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  // Fetch PR changed files (pages up to 300 files)
+  const files: PRFile[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (page <= 3) {
+    const {data: pageFiles} = await octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: perPage,
+      page,
+    });
+
+    for (const f of pageFiles) {
+      files.push({
+        filename: f.filename,
+        status: f.status,
+        additions: f.additions,
+        deletions: f.deletions,
+        changes: f.changes,
+        patch: f.patch,
+      });
+    }
+
+    if (pageFiles.length < perPage) break;
+    page++;
+  }
+
+  const labels = (pr.labels || [])
+    .map((label) => (typeof label === 'string' ? label : label.name))
+    .filter((name): name is string => Boolean(name));
+
+  return {
+    owner,
+    repo,
+    prNumber,
+    title: pr.title,
+    body: pr.body || '',
+    author: pr.user?.login || 'unknown',
+    baseRef: pr.base.ref,
+    headRef: pr.head.ref,
+    headSha: pr.head.sha,
+    isDraft: Boolean(pr.draft),
+    labels,
+    files,
+  };
+}

--- a/bots/src/core/runner.ts
+++ b/bots/src/core/runner.ts
@@ -1,0 +1,113 @@
+import process from 'node:process';
+import type {PRReviewBot} from './types.js';
+import {loadPRContext} from './pr-context.js';
+import {postOrUpdateComment} from './comment-manager.js';
+import {HelloWorldBot} from '../bots/hello-world/bot.js';
+
+// Registry of available review bots
+const AVAILABLE_BOTS: PRReviewBot[] = [new HelloWorldBot()];
+
+interface CliArgs {
+  botId?: string;
+  prNumber?: number;
+  owner?: string;
+  repo?: string;
+  dryRun: boolean;
+}
+
+function parseArgs(args: string[]): CliArgs {
+  const parsed: CliArgs = {dryRun: false};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--bot' && args[i + 1]) {
+      parsed.botId = args[++i];
+    } else if (arg === '--pr' && args[i + 1]) {
+      parsed.prNumber = parseInt(args[++i], 10);
+    } else if (arg === '--owner' && args[i + 1]) {
+      parsed.owner = args[++i];
+    } else if (arg === '--repo' && args[i + 1]) {
+      parsed.repo = args[++i];
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    }
+  }
+
+  return parsed;
+}
+
+export async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  console.log('🤖 Deliberate Lab PR Review Bot Runner');
+  console.log('----------------------------------------');
+
+  const context = await loadPRContext({
+    owner: args.owner,
+    repo: args.repo,
+    prNumber: args.prNumber,
+  });
+
+  console.log(`Repository: ${context.owner}/${context.repo}`);
+  console.log(`Pull Request: #${context.prNumber} ("${context.title}")`);
+  console.log(`Author: @${context.author}`);
+  console.log(`Head SHA: ${context.headSha}`);
+  console.log(`Files Changed: ${context.files.length}`);
+  console.log('----------------------------------------');
+
+  const botsToRun = args.botId
+    ? AVAILABLE_BOTS.filter((b) => b.id === args.botId)
+    : AVAILABLE_BOTS;
+
+  if (botsToRun.length === 0) {
+    console.error(`[ERROR] No bot found matching ID "${args.botId}".`);
+    console.error(
+      `Available bots: ${AVAILABLE_BOTS.map((b) => b.id).join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  for (const bot of botsToRun) {
+    console.log(`\n▶ Running Bot: ${bot.name} (id: ${bot.id})`);
+
+    if (!bot.shouldRun(context)) {
+      console.log(`  [SKIP] Bot indicated shouldRun = false.`);
+      continue;
+    }
+
+    console.log('  Evaluating PR...');
+    const evaluation = await bot.evaluate(context);
+    console.log(
+      `  Evaluation result: [${evaluation.status.toUpperCase()}] ${evaluation.summary}`,
+    );
+
+    const commentBody = bot.renderComment(context, evaluation);
+    const result = await postOrUpdateComment(context, {
+      botId: bot.id,
+      markdownBody: commentBody,
+      dryRun: args.dryRun,
+    });
+
+    if (result.action === 'skipped_dry_run') {
+      console.log('  [DRY RUN] Completed without updating GitHub.');
+    } else {
+      console.log(
+        `  [OK] Comment ${result.action}: ${result.url || result.commentId}`,
+      );
+    }
+  }
+
+  console.log('\n✅ All bot evaluations finished successfully.');
+}
+
+// Execute if run directly
+if (
+  import.meta.url.endsWith(process.argv[1]) ||
+  process.argv[1]?.includes('runner')
+) {
+  main().catch((err) => {
+    console.error('\n❌ Fatal error in bot runner:');
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/bots/src/core/runner.ts
+++ b/bots/src/core/runner.ts
@@ -5,11 +5,13 @@ import {postOrUpdateComment} from './comment-manager.js';
 import {HelloWorldBot} from '../bots/hello-world/bot.js';
 import {ExperimentTestPlanBot} from '../bots/experiment-test-plan/bot.js';
 
-// Registry of available review bots
-const AVAILABLE_BOTS: PRReviewBot[] = [
-  new HelloWorldBot(),
-  new ExperimentTestPlanBot(),
-];
+// Production review bots run on standard PR reviews
+const PRODUCTION_BOTS: PRReviewBot[] = [new ExperimentTestPlanBot()];
+
+// Diagnostic bots available for pipeline and health checks via --bot <id>
+const DIAGNOSTIC_BOTS: PRReviewBot[] = [new HelloWorldBot()];
+
+const ALL_BOTS: PRReviewBot[] = [...PRODUCTION_BOTS, ...DIAGNOSTIC_BOTS];
 
 interface CliArgs {
   botId?: string;
@@ -61,14 +63,12 @@ export async function main(): Promise<void> {
 
   const botsToRun =
     args.botId && args.botId !== 'all'
-      ? AVAILABLE_BOTS.filter((b) => b.id === args.botId)
-      : AVAILABLE_BOTS;
+      ? ALL_BOTS.filter((b) => b.id === args.botId)
+      : PRODUCTION_BOTS;
 
   if (botsToRun.length === 0) {
     console.error(`[ERROR] No bot found matching ID "${args.botId}".`);
-    console.error(
-      `Available bots: ${AVAILABLE_BOTS.map((b) => b.id).join(', ')}`,
-    );
+    console.error(`Available bots: ${ALL_BOTS.map((b) => b.id).join(', ')}`);
     process.exit(1);
   }
 

--- a/bots/src/core/runner.ts
+++ b/bots/src/core/runner.ts
@@ -72,6 +72,8 @@ export async function main(): Promise<void> {
     process.exit(1);
   }
 
+  let hasBlockingFailure = false;
+
   for (const bot of botsToRun) {
     console.log(`\n▶ Running Bot: ${bot.name} (id: ${bot.id})`);
 
@@ -100,6 +102,17 @@ export async function main(): Promise<void> {
         `  [OK] Comment ${result.action}: ${result.url || result.commentId}`,
       );
     }
+
+    if (evaluation.status === 'warn' || evaluation.status === 'fail') {
+      hasBlockingFailure = true;
+    }
+  }
+
+  if (hasBlockingFailure) {
+    console.error(
+      '\n❌ Blocking check failure: One or more PR review bots reported requirements not met (see comments above).',
+    );
+    process.exit(1);
   }
 
   console.log('\n✅ All bot evaluations finished successfully.');

--- a/bots/src/core/runner.ts
+++ b/bots/src/core/runner.ts
@@ -3,9 +3,13 @@ import type {PRReviewBot} from './types.js';
 import {loadPRContext} from './pr-context.js';
 import {postOrUpdateComment} from './comment-manager.js';
 import {HelloWorldBot} from '../bots/hello-world/bot.js';
+import {ExperimentTestPlanBot} from '../bots/experiment-test-plan/bot.js';
 
 // Registry of available review bots
-const AVAILABLE_BOTS: PRReviewBot[] = [new HelloWorldBot()];
+const AVAILABLE_BOTS: PRReviewBot[] = [
+  new HelloWorldBot(),
+  new ExperimentTestPlanBot(),
+];
 
 interface CliArgs {
   botId?: string;
@@ -55,9 +59,10 @@ export async function main(): Promise<void> {
   console.log(`Files Changed: ${context.files.length}`);
   console.log('----------------------------------------');
 
-  const botsToRun = args.botId
-    ? AVAILABLE_BOTS.filter((b) => b.id === args.botId)
-    : AVAILABLE_BOTS;
+  const botsToRun =
+    args.botId && args.botId !== 'all'
+      ? AVAILABLE_BOTS.filter((b) => b.id === args.botId)
+      : AVAILABLE_BOTS;
 
   if (botsToRun.length === 0) {
     console.error(`[ERROR] No bot found matching ID "${args.botId}".`);

--- a/bots/src/core/runner.ts
+++ b/bots/src/core/runner.ts
@@ -2,33 +2,20 @@ import process from 'node:process';
 import type {PRReviewBot} from './types.js';
 import {loadPRContext} from './pr-context.js';
 import {postOrUpdateComment} from './comment-manager.js';
-import {HelloWorldBot} from '../bots/hello-world/bot.js';
-import {ExperimentTestPlanBot} from '../bots/experiment-test-plan/bot.js';
 
-// Production review bots run on standard PR reviews
-const PRODUCTION_BOTS: PRReviewBot[] = [new ExperimentTestPlanBot()];
-
-// Diagnostic bots available for pipeline and health checks via --bot <id>
-const DIAGNOSTIC_BOTS: PRReviewBot[] = [new HelloWorldBot()];
-
-const ALL_BOTS: PRReviewBot[] = [...PRODUCTION_BOTS, ...DIAGNOSTIC_BOTS];
-
-interface CliArgs {
-  botId?: string;
+export interface CliArgs {
   prNumber?: number;
   owner?: string;
   repo?: string;
   dryRun: boolean;
 }
 
-function parseArgs(args: string[]): CliArgs {
+export function parseArgs(args: string[]): CliArgs {
   const parsed: CliArgs = {dryRun: false};
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === '--bot' && args[i + 1]) {
-      parsed.botId = args[++i];
-    } else if (arg === '--pr' && args[i + 1]) {
+    if (arg === '--pr' && args[i + 1]) {
       parsed.prNumber = parseInt(args[++i], 10);
     } else if (arg === '--owner' && args[i + 1]) {
       parsed.owner = args[++i];
@@ -42,10 +29,16 @@ function parseArgs(args: string[]): CliArgs {
   return parsed;
 }
 
-export async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
+/**
+ * Execute a single review bot against a pull request.
+ */
+export async function runBot(
+  bot: PRReviewBot,
+  argv: string[] = process.argv.slice(2),
+): Promise<void> {
+  const args = parseArgs(argv);
 
-  console.log('🤖 Deliberate Lab PR Review Bot Runner');
+  console.log(`🤖 Deliberate Lab PR Review Bot: ${bot.name} (id: ${bot.id})`);
   console.log('----------------------------------------');
 
   const context = await loadPRContext({
@@ -61,71 +54,38 @@ export async function main(): Promise<void> {
   console.log(`Files Changed: ${context.files.length}`);
   console.log('----------------------------------------');
 
-  const botsToRun =
-    args.botId && args.botId !== 'all'
-      ? ALL_BOTS.filter((b) => b.id === args.botId)
-      : PRODUCTION_BOTS;
-
-  if (botsToRun.length === 0) {
-    console.error(`[ERROR] No bot found matching ID "${args.botId}".`);
-    console.error(`Available bots: ${ALL_BOTS.map((b) => b.id).join(', ')}`);
-    process.exit(1);
+  if (!bot.shouldRun(context)) {
+    console.log(`  [SKIP] Bot indicated shouldRun = false (e.g. draft PR).`);
+    return;
   }
 
-  let hasBlockingFailure = false;
+  console.log('  Evaluating PR...');
+  const evaluation = await bot.evaluate(context);
+  console.log(
+    `  Evaluation result: [${evaluation.status.toUpperCase()}] ${evaluation.summary}`,
+  );
 
-  for (const bot of botsToRun) {
-    console.log(`\n▶ Running Bot: ${bot.name} (id: ${bot.id})`);
-
-    if (!bot.shouldRun(context)) {
-      console.log(`  [SKIP] Bot indicated shouldRun = false.`);
-      continue;
-    }
-
-    console.log('  Evaluating PR...');
-    const evaluation = await bot.evaluate(context);
-    console.log(
-      `  Evaluation result: [${evaluation.status.toUpperCase()}] ${evaluation.summary}`,
-    );
-
-    const commentBody = bot.renderComment(context, evaluation);
-    const result = await postOrUpdateComment(context, {
-      botId: bot.id,
-      markdownBody: commentBody,
-      dryRun: args.dryRun,
-    });
-
-    if (result.action === 'skipped_dry_run') {
-      console.log('  [DRY RUN] Completed without updating GitHub.');
-    } else {
-      console.log(
-        `  [OK] Comment ${result.action}: ${result.url || result.commentId}`,
-      );
-    }
-
-    if (evaluation.status === 'warn' || evaluation.status === 'fail') {
-      hasBlockingFailure = true;
-    }
-  }
-
-  if (hasBlockingFailure) {
-    console.error(
-      '\n❌ Blocking check failure: One or more PR review bots reported requirements not met (see comments above).',
-    );
-    process.exit(1);
-  }
-
-  console.log('\n✅ All bot evaluations finished successfully.');
-}
-
-// Execute if run directly
-if (
-  import.meta.url.endsWith(process.argv[1]) ||
-  process.argv[1]?.includes('runner')
-) {
-  main().catch((err) => {
-    console.error('\n❌ Fatal error in bot runner:');
-    console.error(err);
-    process.exit(1);
+  const commentBody = bot.renderComment(context, evaluation);
+  const result = await postOrUpdateComment(context, {
+    botId: bot.id,
+    markdownBody: commentBody,
+    dryRun: args.dryRun,
   });
+
+  if (result.action === 'skipped_dry_run') {
+    console.log('  [DRY RUN] Completed without updating GitHub.');
+  } else {
+    console.log(
+      `  [OK] Comment ${result.action}: ${result.url || result.commentId}`,
+    );
+  }
+
+  if (evaluation.status === 'warn' || evaluation.status === 'fail') {
+    console.error(
+      `\n❌ Blocking check failure: ${bot.name} reported requirements not met (see comment above).`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n✅ ${bot.name} evaluation passed.`);
 }

--- a/bots/src/core/types.ts
+++ b/bots/src/core/types.ts
@@ -35,8 +35,8 @@ export interface BotEvaluation {
 
 export interface PRReviewBot {
   /**
-   * Unique identifier used in HTML comment signatures:
-   * `<!-- deliberate-lab-bot: <id> -->`
+   * Unique identifier for the specialist bot, used in HTML comment signatures:
+   * `<!-- deliberate-lab-bot: <id> -->` (e.g. `experiment-test-plan`).
    */
   readonly id: string;
 

--- a/bots/src/core/types.ts
+++ b/bots/src/core/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Core types and interfaces for Deliberate Lab PR review bots.
+ */
+
+export interface PRFile {
+  filename: string;
+  status: 'added' | 'modified' | 'removed' | 'renamed' | string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+}
+
+export interface PRContext {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  title: string;
+  body: string;
+  author: string;
+  baseRef: string;
+  headRef: string;
+  headSha: string;
+  isDraft: boolean;
+  labels: string[];
+  files: PRFile[];
+}
+
+export interface BotEvaluation {
+  status: 'pass' | 'warn' | 'fail' | 'info';
+  summary: string;
+  details?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PRReviewBot {
+  /**
+   * Unique identifier used in HTML comment signatures:
+   * `<!-- deliberate-lab-bot: <id> -->`
+   */
+  readonly id: string;
+
+  /**
+   * Human-readable display name used in titles/logs.
+   */
+  readonly name: string;
+
+  /**
+   * Pre-filter check to decide if this bot should run on the given PR.
+   */
+  shouldRun(context: PRContext): boolean;
+
+  /**
+   * Perform evaluation and return structured results.
+   */
+  evaluate(context: PRContext): Promise<BotEvaluation>;
+
+  /**
+   * Render the evaluation into a GitHub Markdown comment body.
+   */
+  renderComment(context: PRContext, evaluation: BotEvaluation): string;
+}

--- a/bots/tsconfig.json
+++ b/bots/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@deliberation-lab/utils": ["../utils/dist"]
+    },
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "frontend",
         "utils",
-        "functions"
+        "functions",
+        "bots"
       ],
       "dependencies": {
         "crypto-browserify": "^3.12.1"
@@ -29,6 +30,36 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "bots": {
+      "name": "@deliberation-lab/bots",
+      "version": "1.0.0",
+      "dependencies": {
+        "@actions/core": "^1.11.1",
+        "@actions/github": "^6.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3"
+      }
+    },
+    "bots/node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "bots/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "frontend": {
       "name": "deliberate-lab",
@@ -1010,6 +1041,98 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@actions/github/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
     },
     "node_modules/@adobe/lit-mobx": {
       "version": "2.2.2",
@@ -3057,6 +3180,10 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@deliberation-lab/bots": {
+      "resolved": "bots",
+      "link": true
     },
     "node_modules/@deliberation-lab/utils": {
       "resolved": "utils",
@@ -6509,6 +6636,164 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@open-draft/deferred-promise": {
@@ -10053,6 +10338,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -12356,6 +12647,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -24786,6 +25083,15 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -25096,6 +25402,12 @@
       "engines": {
         "node": ">=12.18.2"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@actions/core": "^1.11.1",
-        "@actions/github": "^6.0.0"
+        "@actions/github": "^6.0.0",
+        "@google/genai": "^2.22.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",
@@ -4851,6 +4852,49 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.22.0.tgz",
+      "integrity": "sha512-NE90Nl0AP75YZ2tGxXjQQs6Gkunma7a1JmPCx5g5CxvjHXshmuI2aNoPJ1xLrRixjkNxog898oylM+MyNudUQw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@google/genai/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -26511,7 +26555,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "build:utils": "npm run build -w utils",
     "build:functions": "npm run build -w functions",
     "build:frontend": "node scripts/ensure-frontend-dev-config.js && npm run build -w frontend",
-    "build": "npm run build:utils && npm run build:functions && npm run build:frontend",
-    "lint": "prettier --check \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\" && eslint --quiet \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\"",
-    "test": "npm test -w utils && npm test -w functions && npm test -w frontend",
+    "build:bots": "npm run build -w bots",
+    "build": "npm run build:utils && npm run build:functions && npm run build:frontend && npm run build:bots",
+    "lint": "prettier --check \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\" \"bots/**/*.ts\" && eslint --quiet \"utils/**/*.ts\" \"functions/**/*.ts\" \"frontend/**/*.ts\" \"bots/**/*.ts\"",
+    "test": "npm test -w utils && npm test -w functions && npm test -w frontend && npm test -w bots",
     "deploy:rules:firestore": "node scripts/deploy-firestore-rules.js",
     "deploy:rules:storage": "node scripts/deploy-storage-rules.js",
     "deploy:rules:database": "node scripts/deploy-database-rules.js",
@@ -49,7 +50,8 @@
   "workspaces": [
     "frontend",
     "utils",
-    "functions"
+    "functions",
+    "bots"
   ],
   "dependencies": {
     "crypto-browserify": "^3.12.1"


### PR DESCRIPTION
## Description
Implements Phases 1 & 2 of #1178:
- Establishes `@deliberation-lab/bots` as a top-level npm workspace package for specialized PR review bots.
- Implements core multi-bot infrastructure:
  - `pr-context`: Extracts PR metadata, diffs, and file changes via Octokit.
  - `comment-manager`: Idempotently creates or updates bot comments tagged with `<!-- deliberate-lab-bot: <id> -->`.
  - `gemini-client`: Invokes Gemini API via `@google/genai` with structured JSON schema responses.
  - `runner`: Modular CLI runner executing production review bots by default and diagnostic bots on demand.
- Implements **`ExperimentTestPlanBot`** (`experiment-test-plan`):
  - Classifies runtime behavioral changes vs. non-runtime modifications (docs, CI, developer agent skills).
  - Evaluates PRs against Deliberate Lab's 7-part manual experiment topology (templates, stages, cohorts, personas, actions, success criteria).
  - Proactively synthesizes suggested tentative test plans from code diffs when manual steps are missing.
  - Fail-closed validation: Cleanly pauses and emits an actionable setup notice when `GEMINI_API_KEY` is not configured, without failing CI.
- Adds `hello-world` deterministic diagnostic bot for pipeline health checks.
- Adds `.github/workflows/pr-bots.yaml` triggered on `pull_request`, `pull_request_target`, and `workflow_dispatch` (pinned to commit SHAs per Zizmor security policies).

---

## Verification
- [x] Unit tests pass (`npm test -w bots`): 12 tests across 3 test suites.
- [x] Prettier and ESLint pass cleanly (`npm run lint`).
- [x] Local dry-run tested against live PR (`runner.ts --pr 1251 --dry-run`).
- [x] Fail-closed behavior validated in both unit tests and GitHub Actions CI.

---

## Related issues
Fixes: #1178
Companion: #1252
